### PR TITLE
Bean proxying only when needed via `BeanProxyDecider`

### DIFF
--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/component/proxy/decider/BeanProxyDecider.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/component/proxy/decider/BeanProxyDecider.java
@@ -20,37 +20,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler;
+package tech.guilhermekaua.spigotboot.core.context.component.proxy.decider;
 
 import org.jetbrains.annotations.NotNull;
-import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.context.MethodHandlerContext;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.stream.Collectors;
-
-public final class MethodHandlerRegistry {
-    private static final List<RegisteredMethodHandler> handlers = new ArrayList<>();
-
-    private MethodHandlerRegistry() {
-    }
-
-    public static void registerAll(List<RegisteredMethodHandler> handlers) {
-        MethodHandlerRegistry.handlers.addAll(handlers);
-    }
-
-    public static @NotNull List<RegisteredMethodHandler> getAllHandlers() {
-        return Collections.unmodifiableList(handlers);
-    }
-
-    public static List<RegisteredMethodHandler> getHandlersFor(@NotNull MethodHandlerContext context) {
-        return handlers.stream()
-                .filter(handler -> handler.canHandle(context))
-                .collect(Collectors.toList());
-    }
-
-    public static void clear() {
-        handlers.clear();
-    }
+@FunctionalInterface
+public interface BeanProxyDecider {
+    /**
+     * Decide whether the given bean should be instantiated as a proxy.
+     *
+     * <p>Implementations should be lightweight and side-effect free.</p>
+     */
+    boolean shouldProxy(@NotNull BeanDefinition definition, @NotNull DependencyManager dependencyManager);
 }
+
+

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/component/proxy/decider/impl/MethodHandlerDrivenProxyDecider.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/component/proxy/decider/impl/MethodHandlerDrivenProxyDecider.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.impl;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.BeanProxyDecider;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.MethodHandlerRegistry;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.RegisteredMethodHandler;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+/**
+ * Default proxy decider: proxies a bean if at least one registered {@link RegisteredMethodHandler}
+ * could ever match it (based on the handler's metadata).
+ */
+@Component
+public class MethodHandlerDrivenProxyDecider implements BeanProxyDecider {
+    @Override
+    public boolean shouldProxy(@NotNull BeanDefinition definition, @NotNull DependencyManager dependencyManager) {
+        Class<?> beanClass = definition.getType();
+        if (beanClass == null) {
+            return false;
+        }
+
+        for (RegisteredMethodHandler handler : MethodHandlerRegistry.getAllHandlers()) {
+            if (handlerCouldApply(handler, beanClass)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean handlerCouldApply(RegisteredMethodHandler handler, Class<?> beanClass) {
+        Class<?> targetClass = handler.getTargetClass();
+        if (targetClass != null && !targetClass.isAssignableFrom(beanClass)) {
+            return false;
+        }
+
+        Class<? extends Annotation> classAnn = handler.getClassTargetAnnotation();
+        if (classAnn != null && !beanClass.isAnnotationPresent(classAnn)) {
+            return false;
+        }
+
+        Class<? extends Annotation> methodAnn = handler.getMethodTargetAnnotation();
+        if (methodAnn != null && !hasAnyMethodAnnotated(beanClass, methodAnn)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private boolean hasAnyMethodAnnotated(Class<?> beanClass, Class<? extends Annotation> annotation) {
+        for (Method method : beanClass.getMethods()) {
+            if (method.isAnnotationPresent(annotation)) {
+                return true;
+            }
+        }
+
+        for (Method method : beanClass.getDeclaredMethods()) {
+            if (method.isAnnotationPresent(annotation)) {
+                return true;
+            }
+        }
+
+        for (Class<?> iface : beanClass.getInterfaces()) {
+            for (Method method : iface.getMethods()) {
+                if (method.isAnnotationPresent(annotation)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+}
+
+

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/component/proxy/decider/strategy/BeanProxyDeciderResolver.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/component/proxy/decider/strategy/BeanProxyDeciderResolver.java
@@ -1,0 +1,59 @@
+package tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.strategy;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.BeanProxyDecider;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.util.Objects;
+
+public class BeanProxyDeciderResolver {
+    private volatile boolean proxyDecidersBootstrapped = false;
+    private final ThreadLocal<Boolean> bootstrappingProxyDeciders = ThreadLocal.withInitial(() -> false);
+
+    public boolean shouldProxy(@NotNull BeanDefinition definition, @NotNull DependencyManager dependencyManager) throws Exception {
+        Objects.requireNonNull(definition, "definition cannot be null.");
+        Objects.requireNonNull(dependencyManager, "dependencyManager cannot be null.");
+
+        Class<?> type = definition.getType();
+        if (type == null) {
+            return false;
+        }
+
+        // never proxy deciders themselves (avoids recursion and weird double-proxying)
+        if (BeanProxyDecider.class.isAssignableFrom(type)) {
+            return false;
+        }
+
+        ensureProxyDecidersBootstrapped(dependencyManager);
+
+        for (BeanProxyDecider decider : dependencyManager.getInstancesByType(BeanProxyDecider.class)) {
+            if (decider.shouldProxy(definition, dependencyManager)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void ensureProxyDecidersBootstrapped(@NotNull DependencyManager dependencyManager) throws Exception {
+        if (proxyDecidersBootstrapped) {
+            return;
+        }
+
+        if (Boolean.TRUE.equals(bootstrappingProxyDeciders.get())) {
+            return;
+        }
+
+        bootstrappingProxyDeciders.set(true);
+        try {
+            for (BeanDefinition definition : dependencyManager.getBeanDefinitionRegistry().getDefinitions(BeanProxyDecider.class)) {
+                // resolve each definition directly to avoid qualifier/primary ambiguity
+                dependencyManager.resolveFromDefinition(BeanProxyDecider.class, definition);
+            }
+            proxyDecidersBootstrapped = true;
+        } finally {
+            bootstrappingProxyDeciders.set(false);
+        }
+    }
+}

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/component/proxy/SelectiveProxyingTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/component/proxy/SelectiveProxyingTest.java
@@ -1,0 +1,91 @@
+package tech.guilhermekaua.spigotboot.core.test.context.component.proxy;
+
+import javassist.util.proxy.ProxyObject;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.impl.MethodHandlerDrivenProxyDecider;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.MethodHandlerRegistry;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.RegisteredMethodHandler;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.lang.annotation.*;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SelectiveProxyingTest {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface Intercept {
+    }
+
+    static class NeedsProxy {
+        @Intercept
+        public String hello() {
+            return "original";
+        }
+
+        public String other() {
+            return "other";
+        }
+    }
+
+    static class NoProxy {
+        public String hello() {
+            return "original";
+        }
+    }
+
+    private DependencyManager dependencyManager;
+
+    @BeforeEach
+    void setUp() {
+        MethodHandlerRegistry.clear();
+
+        dependencyManager = new DependencyManager();
+
+        // register the default decider (in production this is discovered via @Component scan)
+        dependencyManager.registerDependency(new MethodHandlerDrivenProxyDecider(), null, true);
+
+        RegisteredMethodHandler handler = new RegisteredMethodHandler(
+                context -> "intercepted",
+                void.class,
+                Annotation.class,
+                Intercept.class
+        );
+
+        MethodHandlerRegistry.registerAll(Collections.singletonList(handler));
+    }
+
+    @AfterEach
+    void tearDown() {
+        MethodHandlerRegistry.clear();
+    }
+
+    @Test
+    void beanWithAnnotatedMethodShouldBeProxiedAndIntercepted() {
+        dependencyManager.registerDependency(NeedsProxy.class, (String) null, false, null, null);
+
+        NeedsProxy bean = dependencyManager.resolveDependency(NeedsProxy.class, null);
+        assertNotNull(bean);
+
+        assertInstanceOf(ProxyObject.class, bean, "Bean should be proxied due to matching MethodHandler metadata");
+        assertEquals("intercepted", bean.hello(), "Annotated method should be intercepted by handler");
+        assertEquals("other", bean.other(), "Non-annotated method should proceed normally");
+    }
+
+    @Test
+    void beanWithoutAnnotatedMethodShouldNotBeProxied() {
+        dependencyManager.registerDependency(NoProxy.class, (String) null, false, null, null);
+
+        NoProxy bean = dependencyManager.resolveDependency(NoProxy.class, null);
+        assertNotNull(bean);
+
+        assertFalse(bean instanceof ProxyObject, "Bean should not be proxied when no handlers could apply");
+        assertEquals("original", bean.hello());
+    }
+}
+
+

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/component/proxy/decider/MethodHandlerDrivenProxyDeciderTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/component/proxy/decider/MethodHandlerDrivenProxyDeciderTest.java
@@ -1,0 +1,99 @@
+package tech.guilhermekaua.spigotboot.core.test.context.component.proxy.decider;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.impl.MethodHandlerDrivenProxyDecider;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.MethodHandlerRegistry;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.RegisteredMethodHandler;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.lang.annotation.*;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MethodHandlerDrivenProxyDeciderTest {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.METHOD)
+    @interface Intercept {
+    }
+
+    static class BeanWithAnnotatedMethod {
+        @Intercept
+        public void run() {
+        }
+    }
+
+    static class BeanWithoutAnnotatedMethod {
+        public void run() {
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        MethodHandlerRegistry.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MethodHandlerRegistry.clear();
+    }
+
+    @Test
+    void shouldReturnTrueWhenAtLeastOneRegisteredMethodHandlerCouldApply() {
+        RegisteredMethodHandler handler = new RegisteredMethodHandler(
+                context -> null,
+                void.class,
+                Annotation.class,
+                Intercept.class
+        );
+
+        MethodHandlerRegistry.registerAll(Collections.singletonList(handler));
+
+        MethodHandlerDrivenProxyDecider decider = new MethodHandlerDrivenProxyDecider();
+        DependencyManager dependencyManager = new DependencyManager();
+
+        BeanDefinition beanDefinition = new BeanDefinition(
+                BeanWithAnnotatedMethod.class,
+                BeanWithAnnotatedMethod.class,
+                null,
+                false,
+                null,
+                null
+        );
+
+        assertTrue(decider.shouldProxy(beanDefinition, dependencyManager));
+    }
+
+    @Test
+    void shouldReturnFalseWhenNoRegisteredMethodHandlerCouldApply() {
+        RegisteredMethodHandler handler = new RegisteredMethodHandler(
+                context -> null,
+                void.class,
+                Annotation.class,
+                Intercept.class
+        );
+
+        MethodHandlerRegistry.registerAll(Collections.singletonList(handler));
+
+        MethodHandlerDrivenProxyDecider decider = new MethodHandlerDrivenProxyDecider();
+        DependencyManager dependencyManager = new DependencyManager();
+
+        BeanDefinition beanDefinition = new BeanDefinition(
+                BeanWithoutAnnotatedMethod.class,
+                BeanWithoutAnnotatedMethod.class,
+                null,
+                false,
+                null,
+                null
+        );
+
+        assertFalse(decider.shouldProxy(beanDefinition, dependencyManager));
+    }
+}
+
+


### PR DESCRIPTION
Resolves #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extensible selective bean-proxying: pluggable decision points and a handler-driven decider to determine when beans are proxied.
  * Dependency management updated to honor deciders and instantiate proxies when applicable, with safe handling for non-proxyable types.
  * Method-handler registry helpers to inspect and clear registered handlers.

* **Tests**
  * Added tests validating selective proxying and the decider behavior across proxied and non-proxied scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->