### PR TITLE
Add custom injectors

### DIFF
--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/configuration/processor/ConfigurationProcessor.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/configuration/processor/ConfigurationProcessor.java
@@ -87,6 +87,9 @@ public class ConfigurationProcessor {
         }
 
         String qualifier = BeanUtils.getQualifier(method);
+        if (qualifier == null || qualifier.trim().isEmpty()) {
+            qualifier = method.getName();
+        }
         boolean isPrimary = BeanUtils.getIsPrimary(method);
 
         dependencyManager.registerDependency(

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/configuration/proxy/ConfigurationClassProxy.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/configuration/proxy/ConfigurationClassProxy.java
@@ -107,6 +107,9 @@ public class ConfigurationClassProxy implements MethodHandler {
             throws Throwable {
         Class<?> returnType = beanMethod.getReturnType();
         String qualifier = BeanUtils.getQualifier(beanMethod);
+        if (qualifier == null || qualifier.trim().isEmpty()) {
+            qualifier = beanMethod.getName();
+        }
 
         BeanDefinition definition = findBeanDefinition(returnType, qualifier);
         if (definition == null) {

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjector.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjector.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Interface for custom dependency injectors that can participate in the resolution process.
+ * <p>
+ * Custom injectors allow modules to provide alternative ways of resolving dependencies
+ * beyond the standard bean lookup. For example, a configuration module might provide
+ * an injector that resolves annotated parameters from configuration values.
+ * <p>
+ * Injectors are consulted in order (based on {@link #getOrder()}) before falling back
+ * to the default resolution. An injector should return {@link InjectionResult#notHandled()}
+ * if it doesn't want to handle a particular injection point, allowing the next injector
+ * or default resolution to proceed.
+ */
+public interface CustomInjector {
+
+    /**
+     * Determines whether this injector can handle the given injection point.
+     * <p>
+     * This method should be fast as it's called for every injection point.
+     * Complex logic should be deferred to {@link #resolve(InjectionPoint)}.
+     *
+     * @param injectionPoint the injection point to check, not null
+     * @return true if this injector should attempt to resolve this injection point
+     */
+    boolean supports(@NotNull InjectionPoint injectionPoint);
+
+    /**
+     * Attempts to resolve a dependency for the given injection point.
+     * <p>
+     * This method is only called if {@link #supports(InjectionPoint)} returned true.
+     * The injector should return:
+     * <ul>
+     *   <li>{@link InjectionResult#handled(Object)} if it successfully resolved the dependency</li>
+     *   <li>{@link InjectionResult#notHandled()} if it cannot resolve this particular injection
+     *       and wants the framework to try other injectors or default resolution</li>
+     * </ul>
+     *
+     * @param injectionPoint the injection point to resolve, not null
+     * @return the resolution result, never null
+     */
+    @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint);
+
+    /**
+     * Returns the order of this injector.
+     * <p>
+     * Injectors with lower order values are consulted first. The default order is 0.
+     * Use negative values for high-priority injectors, positive values for low-priority ones.
+     *
+     * @return the order value for this injector
+     */
+    default int getOrder() {
+        return 0;
+    }
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistry.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistry.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Registry that holds and manages custom injectors.
+ * <p>
+ * This registry maintains an ordered list of custom injectors. Injectors are sorted
+ * by their {@link CustomInjector#getOrder()} value, with lower values having higher priority.
+ * When multiple injectors have the same order, they are processed in registration order.
+ * <p>
+ * The registry is thread-safe and can be modified during the application lifecycle.
+ */
+public final class CustomInjectorRegistry {
+    private final List<CustomInjector> injectors = new CopyOnWriteArrayList<>();
+    private volatile List<CustomInjector> sortedView = Collections.emptyList();
+
+    /**
+     * Registers a custom injector.
+     * <p>
+     * The injector will be added to the registry and the sorted view will be updated.
+     * Injectors are ordered by their {@link CustomInjector#getOrder()} value.
+     *
+     * @param injector the custom injector to register, not null
+     * @throws NullPointerException if injector is null
+     */
+    public void register(@NotNull CustomInjector injector) {
+        Objects.requireNonNull(injector, "injector cannot be null");
+
+        injectors.add(injector);
+        updateSortedView();
+    }
+
+    /**
+     * Unregisters a custom injector.
+     *
+     * @param injector the custom injector to remove, not null
+     * @return true if the injector was found and removed, false otherwise
+     */
+    public boolean unregister(@NotNull CustomInjector injector) {
+        Objects.requireNonNull(injector, "injector cannot be null");
+
+        boolean removed = injectors.remove(injector);
+        if (removed) {
+            updateSortedView();
+        }
+        return removed;
+    }
+
+    /**
+     * Returns an unmodifiable ordered view of all registered injectors.
+     * <p>
+     * The list is sorted by {@link CustomInjector#getOrder()}, with lower values first.
+     *
+     * @return an unmodifiable list of injectors in order of priority
+     */
+    public @NotNull List<CustomInjector> getInjectors() {
+        return sortedView;
+    }
+
+    /**
+     * Clears all registered injectors.
+     */
+    public void clear() {
+        injectors.clear();
+        sortedView = Collections.emptyList();
+    }
+
+    /**
+     * Returns the number of registered injectors.
+     *
+     * @return the count of registered injectors
+     */
+    public int size() {
+        return injectors.size();
+    }
+
+    /**
+     * Checks if the registry is empty.
+     *
+     * @return true if no injectors are registered
+     */
+    public boolean isEmpty() {
+        return injectors.isEmpty();
+    }
+
+    /**
+     * Updates the sorted view after modifications.
+     */
+    private void updateSortedView() {
+        List<CustomInjector> sorted = new ArrayList<>(injectors);
+        sorted.sort(Comparator.comparingInt(CustomInjector::getOrder));
+        sortedView = Collections.unmodifiableList(sorted);
+    }
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistry.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistry.java
@@ -24,8 +24,7 @@ package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.*;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.List;
 
 /**
  * Registry that holds and manages custom injectors.
@@ -36,9 +35,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * <p>
  * The registry is thread-safe and can be modified during the application lifecycle.
  */
-public final class CustomInjectorRegistry {
-    private final List<CustomInjector> injectors = new CopyOnWriteArrayList<>();
-    private volatile List<CustomInjector> sortedView = Collections.emptyList();
+public interface CustomInjectorRegistry {
 
     /**
      * Registers a custom injector.
@@ -49,12 +46,7 @@ public final class CustomInjectorRegistry {
      * @param injector the custom injector to register, not null
      * @throws NullPointerException if injector is null
      */
-    public void register(@NotNull CustomInjector injector) {
-        Objects.requireNonNull(injector, "injector cannot be null");
-
-        injectors.add(injector);
-        updateSortedView();
-    }
+    void register(@NotNull CustomInjector injector);
 
     /**
      * Unregisters a custom injector.
@@ -62,15 +54,7 @@ public final class CustomInjectorRegistry {
      * @param injector the custom injector to remove, not null
      * @return true if the injector was found and removed, false otherwise
      */
-    public boolean unregister(@NotNull CustomInjector injector) {
-        Objects.requireNonNull(injector, "injector cannot be null");
-
-        boolean removed = injectors.remove(injector);
-        if (removed) {
-            updateSortedView();
-        }
-        return removed;
-    }
+    boolean unregister(@NotNull CustomInjector injector);
 
     /**
      * Returns an unmodifiable ordered view of all registered injectors.
@@ -79,9 +63,7 @@ public final class CustomInjectorRegistry {
      *
      * @return an unmodifiable list of injectors in order of priority
      */
-    public @NotNull List<CustomInjector> getInjectors() {
-        return sortedView;
-    }
+    @NotNull List<CustomInjector> getInjectors();
 
     /**
      * Checks if any registered custom injector supports the given injection point.
@@ -89,47 +71,24 @@ public final class CustomInjectorRegistry {
      * @param injectionPoint the injection point to check
      * @return true if any custom injector supports this injection point
      */
-    public boolean customInjectorSupported(@NotNull InjectionPoint injectionPoint) {
-        for (CustomInjector injector : getInjectors()) {
-            if (injector.supports(injectionPoint)) {
-                return true;
-            }
-        }
-        return false;
-    }
+    boolean customInjectorSupported(@NotNull InjectionPoint injectionPoint);
 
     /**
      * Clears all registered injectors.
      */
-    public void clear() {
-        injectors.clear();
-        sortedView = Collections.emptyList();
-    }
+    void clear();
 
     /**
      * Returns the number of registered injectors.
      *
      * @return the count of registered injectors
      */
-    public int size() {
-        return injectors.size();
-    }
+    int size();
 
     /**
      * Checks if the registry is empty.
      *
      * @return true if no injectors are registered
      */
-    public boolean isEmpty() {
-        return injectors.isEmpty();
-    }
-
-    /**
-     * Updates the sorted view after modifications.
-     */
-    private void updateSortedView() {
-        List<CustomInjector> sorted = new ArrayList<>(injectors);
-        sorted.sort(Comparator.comparingInt(CustomInjector::getOrder));
-        sortedView = Collections.unmodifiableList(sorted);
-    }
+    boolean isEmpty();
 }

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistry.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistry.java
@@ -84,6 +84,21 @@ public final class CustomInjectorRegistry {
     }
 
     /**
+     * Checks if any registered custom injector supports the given injection point.
+     *
+     * @param injectionPoint the injection point to check
+     * @return true if any custom injector supports this injection point
+     */
+    public boolean customInjectorSupported(@NotNull InjectionPoint injectionPoint) {
+        for (CustomInjector injector : getInjectors()) {
+            if (injector.supports(injectionPoint)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Clears all registered injectors.
      */
     public void clear() {

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistryCustomizer.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistryCustomizer.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kaua da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+
+/**
+ * Callback interface for customizing a {@link CustomInjectorRegistry}.
+ * <p>
+ * Users can provide beans of this type via {@code @Configuration} classes with {@code @Bean} methods
+ * to register custom injectors during context initialization.
+ * <p>
+ * Example usage:
+ * <pre>
+ * &#64;Configuration
+ * public class MyInjectorsConfig {
+ *
+ *     &#64;Bean
+ *     public CustomInjectorRegistryCustomizer registerMyInjector(SomeDep dep) {
+ *         return registry -&gt; registry.register(new MyInjector(dep));
+ *     }
+ * }
+ * </pre>
+ * <p>
+ * Customizers are applied in order during the DEFINITIONS_READY phase, before bean instantiation begins.
+ * Implement {@link Ordered#getOrder()} to control the order in which customizers are applied;
+ * lower values are applied first.
+ *
+ * @see CustomInjectorRegistry
+ * @see CustomInjector
+ */
+@FunctionalInterface
+public interface CustomInjectorRegistryCustomizer extends Ordered {
+
+    /**
+     * Customize the given registry by registering, unregistering, or otherwise modifying injectors.
+     *
+     * @param registry the registry to customize, not null
+     */
+    void customize(@NotNull CustomInjectorRegistry registry);
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistryFactory.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/CustomInjectorRegistryFactory.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kaua da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.registry.BeanDefinitionRegistry;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.listeners.BeanDefinitionsReadyListener;
+import tech.guilhermekaua.spigotboot.core.context.registration.BeanRegistrar;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Factory component that applies {@link CustomInjectorRegistryCustomizer} beans to the
+ * framework's {@link CustomInjectorRegistry} during context initialization.
+ * <p>
+ * This factory runs in the DEFINITIONS_READY phase, after all bean definitions have been
+ * discovered but before instantiation begins. This ensures custom injectors are registered
+ * and available for normal dependency injection.
+ * <p>
+ * The factory:
+ * <ol>
+ *   <li>Obtains the framework's registry instance from the {@link DependencyManager}</li>
+ *   <li>Resolves all {@link CustomInjectorRegistryCustomizer} beans</li>
+ *   <li>Sorts customizers by their {@link Ordered#getOrder()} value</li>
+ *   <li>Applies each customizer to the registry in order</li>
+ * </ol>
+ *
+ * @see CustomInjectorRegistryCustomizer
+ * @see CustomInjectorRegistry
+ */
+@Component
+public class CustomInjectorRegistryFactory implements BeanDefinitionsReadyListener, Ordered {
+
+    /**
+     * Order value ensuring this factory runs early in the DEFINITIONS_READY phase.
+     * Uses a negative value so internal framework setup occurs before user listeners.
+     */
+    private static final int ORDER = -1000;
+
+    @Override
+    public void onBeanDefinitionsReady(@NotNull Context context,
+                                       @NotNull BeanDefinitionRegistry definitionRegistry,
+                                       @NotNull BeanRegistrar registrar) {
+        DependencyManager dependencyManager = context.getDependencyManager();
+        CustomInjectorRegistry registry = dependencyManager.getCustomInjectorRegistry();
+        Logger logger = context.getPlugin().getLogger();
+
+        List<CustomInjectorRegistryCustomizer> customizers = resolveCustomizers(dependencyManager, definitionRegistry, logger);
+        if (customizers.isEmpty()) {
+            return;
+        }
+
+        sortByOrder(customizers);
+        applyCustomizers(customizers, registry, logger);
+    }
+
+    private @NotNull List<CustomInjectorRegistryCustomizer> resolveCustomizers(
+            @NotNull DependencyManager dependencyManager,
+            @NotNull BeanDefinitionRegistry definitionRegistry,
+            @NotNull Logger logger) {
+        List<BeanDefinition> definitions = definitionRegistry.getDefinitions(CustomInjectorRegistryCustomizer.class);
+        if (definitions.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<CustomInjectorRegistryCustomizer> customizers = new ArrayList<>(definitions.size());
+        for (BeanDefinition definition : definitions) {
+            try {
+                CustomInjectorRegistryCustomizer customizer = dependencyManager.resolveDependency(
+                        CustomInjectorRegistryCustomizer.class,
+                        definition.getQualifierName()
+                );
+                if (customizer != null) {
+                    customizers.add(customizer);
+                }
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Failed to resolve CustomInjectorRegistryCustomizer: " + definition.identifier(), e);
+            }
+        }
+        return customizers;
+    }
+
+    private void sortByOrder(@NotNull List<CustomInjectorRegistryCustomizer> customizers) {
+        customizers.sort(Comparator.comparingInt(Ordered::getOrder));
+    }
+
+    private void applyCustomizers(@NotNull List<CustomInjectorRegistryCustomizer> customizers,
+                                  @NotNull CustomInjectorRegistry registry,
+                                  @NotNull Logger logger) {
+        for (CustomInjectorRegistryCustomizer customizer : customizers) {
+            try {
+                customizer.customize(registry);
+            } catch (Exception e) {
+                logger.log(Level.SEVERE, "Error applying CustomInjectorRegistryCustomizer: " + customizer.getClass().getName(), e);
+            }
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return ORDER;
+    }
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/DefaultCustomInjectorRegistry.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/DefaultCustomInjectorRegistry.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kaua da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Default implementation of {@link CustomInjectorRegistry}.
+ * <p>
+ * This implementation is thread-safe and uses a {@link CopyOnWriteArrayList} for
+ * storage with a volatile sorted view for efficient reads.
+ */
+public final class DefaultCustomInjectorRegistry implements CustomInjectorRegistry {
+    private final List<CustomInjector> injectors = new CopyOnWriteArrayList<>();
+    private volatile List<CustomInjector> sortedView = Collections.emptyList();
+
+    @Override
+    public void register(@NotNull CustomInjector injector) {
+        Objects.requireNonNull(injector, "injector cannot be null");
+
+        injectors.add(injector);
+        updateSortedView();
+    }
+
+    @Override
+    public boolean unregister(@NotNull CustomInjector injector) {
+        Objects.requireNonNull(injector, "injector cannot be null");
+
+        boolean removed = injectors.remove(injector);
+        if (removed) {
+            updateSortedView();
+        }
+        return removed;
+    }
+
+    @Override
+    public @NotNull List<CustomInjector> getInjectors() {
+        return sortedView;
+    }
+
+    @Override
+    public boolean customInjectorSupported(@NotNull InjectionPoint injectionPoint) {
+        for (CustomInjector injector : getInjectors()) {
+            if (injector.supports(injectionPoint)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void clear() {
+        injectors.clear();
+        sortedView = Collections.emptyList();
+    }
+
+    @Override
+    public int size() {
+        return injectors.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return injectors.isEmpty();
+    }
+
+    /**
+     * Updates the sorted view after modifications.
+     */
+    private void updateSortedView() {
+        List<CustomInjector> sorted = new ArrayList<>(injectors);
+        sorted.sort(Comparator.comparingInt(CustomInjector::getOrder));
+        sortedView = Collections.unmodifiableList(sorted);
+    }
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/InjectionPoint.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/InjectionPoint.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
+
+import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.utils.BeanUtils;
+import tech.guilhermekaua.spigotboot.core.utils.CollectionTypeUtils;
+
+import java.lang.reflect.*;
+import java.util.Objects;
+
+/**
+ * Represents an injection point in the dependency injection system.
+ * <p>
+ * An injection point encapsulates information about where a dependency is being injected:
+ * the target type, the annotated element (field, parameter, or method), and the qualifier if any.
+ * This enables custom injectors to make decisions based on the full context of the injection site.
+ */
+@Getter
+public final class InjectionPoint {
+    /**
+     * The generic type of the dependency being requested.
+     */
+    private final Type type;
+
+    /**
+     * The annotated element representing the injection site (Field, Parameter, or Method).
+     */
+    private final AnnotatedElement annotatedElement;
+
+    /**
+     * The qualifier for this injection point, or null if none specified.
+     */
+    private final @Nullable String qualifier;
+
+    /**
+     * Creates an injection point with the specified type, element, and qualifier.
+     *
+     * @param type             the generic type of the dependency, not null
+     * @param annotatedElement the annotated element (field/parameter/method), not null
+     * @param qualifier        the qualifier value, or null if none
+     */
+    public InjectionPoint(@NotNull Type type,
+                          @NotNull AnnotatedElement annotatedElement,
+                          @Nullable String qualifier) {
+        this.type = Objects.requireNonNull(type, "type cannot be null");
+        this.annotatedElement = Objects.requireNonNull(annotatedElement, "annotatedElement cannot be null");
+        this.qualifier = qualifier;
+    }
+
+    /**
+     * Creates an injection point from a constructor or method parameter.
+     *
+     * @param parameter the parameter to create the injection point from, not null
+     * @return the injection point representing this parameter
+     */
+    public static @NotNull InjectionPoint fromParameter(@NotNull Parameter parameter) {
+        Objects.requireNonNull(parameter, "parameter cannot be null");
+
+        Type paramType = parameter.getParameterizedType();
+        if (paramType == null) {
+            paramType = parameter.getType();
+        }
+
+        return new InjectionPoint(paramType, parameter, BeanUtils.getQualifier(parameter));
+    }
+
+    /**
+     * Creates an injection point from an injected field.
+     *
+     * @param field the field to create the injection point from, not null
+     * @return the injection point representing this field
+     */
+    public static @NotNull InjectionPoint fromField(@NotNull Field field) {
+        Objects.requireNonNull(field, "field cannot be null");
+
+        return new InjectionPoint(field.getGenericType(), field, BeanUtils.getQualifier(field));
+    }
+
+    /**
+     * Creates an injection point from a setter method.
+     * <p>
+     * The injection point is created from the first (and expected only) parameter of the setter.
+     * The qualifier is extracted from the method itself.
+     *
+     * @param method the setter method to create the injection point from, not null
+     * @return the injection point representing the setter's parameter
+     * @throws IllegalArgumentException if the method has no parameters
+     */
+    public static @NotNull InjectionPoint fromSetterMethod(@NotNull Method method) {
+        Objects.requireNonNull(method, "method cannot be null");
+
+        Type[] genericParameterTypes = method.getGenericParameterTypes();
+        if (genericParameterTypes.length == 0) {
+            throw new IllegalArgumentException("Setter method must have at least one parameter: " + method);
+        }
+
+        Type paramType = genericParameterTypes[0];
+        return new InjectionPoint(paramType, method, BeanUtils.getQualifier(method));
+    }
+
+    /**
+     * Returns the raw class of this injection point's type.
+     *
+     * @return the raw class, or null if the type cannot be resolved to a class
+     */
+    public @Nullable Class<?> getRawType() {
+        return CollectionTypeUtils.getRawClass(type);
+    }
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/InjectionResult.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/injector/InjectionResult.java
@@ -1,0 +1,97 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Represents the result of a custom injector's resolution attempt.
+ * <p>
+ * This class provides a tri-state result to distinguish between:
+ * <ul>
+ *   <li>{@link #notHandled()} - The injector did not handle this injection point</li>
+ *   <li>{@link #handled(Object)} - The injector handled the injection and provided a value (which may be null)</li>
+ * </ul>
+ * This distinction is important because returning null from a custom injector might be intentional,
+ * and the injection should not fall back to the default resolution in that case.
+ */
+public final class InjectionResult {
+    private static final InjectionResult NOT_HANDLED = new InjectionResult(false, null);
+
+    private final boolean handled;
+    private final @Nullable Object value;
+
+    private InjectionResult(boolean handled, @Nullable Object value) {
+        this.handled = handled;
+        this.value = value;
+    }
+
+    /**
+     * Creates a result indicating that the injector did not handle this injection point.
+     * <p>
+     * When returned, the framework will continue to the next injector or fall back to default resolution.
+     *
+     * @return a result indicating the injection point was not handled
+     */
+    public static @NotNull InjectionResult notHandled() {
+        return NOT_HANDLED;
+    }
+
+    /**
+     * Creates a result indicating that the injector handled this injection point.
+     * <p>
+     * The provided value will be used for injection. Note that null is a valid value here;
+     * returning {@code handled(null)} is different from returning {@code notHandled()}.
+     *
+     * @param value the resolved value to inject, may be null
+     * @return a result indicating the injection point was handled with the given value
+     */
+    public static @NotNull InjectionResult handled(@Nullable Object value) {
+        return new InjectionResult(true, value);
+    }
+
+    /**
+     * Returns whether this injection point was handled by the custom injector.
+     *
+     * @return true if handled, false if the framework should try other injectors or default resolution
+     */
+    public boolean isHandled() {
+        return handled;
+    }
+
+    /**
+     * Returns the resolved value if this result was handled.
+     * <p>
+     * This method should only be called after verifying {@link #isHandled()} returns true.
+     *
+     * @return the resolved value, may be null even when handled
+     * @throws IllegalStateException if called on a not-handled result
+     */
+    public @Nullable Object getValue() {
+        if (!handled) {
+            throw new IllegalStateException("Cannot get value from a not-handled result");
+        }
+        return value;
+    }
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/BeanNamingDefiner.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/BeanNamingDefiner.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ * Copyright 陡 2025 Guilherme Kau菧 da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.manager;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyResolveResolver;
+
+public interface BeanNamingDefiner {
+
+    @NotNull String defineQualifier(@NotNull Class<?> dependencyClass,
+                                    @Nullable Object instance,
+                                    @Nullable DependencyResolveResolver<?> resolver,
+                                    @Nullable String qualifier);
+}
+

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DefaultBeanNamingDefiner.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DefaultBeanNamingDefiner.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ * Copyright 陡 2025 Guilherme Kau菧 da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.context.dependency.manager;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyResolveResolver;
+import tech.guilhermekaua.spigotboot.utils.ProxyUtils;
+
+import java.beans.Introspector;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class DefaultBeanNamingDefiner implements BeanNamingDefiner {
+    private final AtomicInteger generatedQualifierCounter = new AtomicInteger(0);
+
+    @Override
+    public @NotNull String defineQualifier(@NotNull Class<?> dependencyClass,
+                                           @Nullable Object instance,
+                                           @Nullable DependencyResolveResolver<?> resolver,
+                                           @Nullable String qualifier) {
+        Objects.requireNonNull(dependencyClass, "dependencyClass cannot be null.");
+
+        String normalizedQualifier = normalizeQualifier(qualifier);
+        if (normalizedQualifier != null) {
+            return normalizedQualifier;
+        }
+
+        Class<?> namingClass = dependencyClass;
+        if (instance != null) {
+            namingClass = ProxyUtils.getRealClass(instance);
+        }
+
+        String baseName = Introspector.decapitalize(getSimpleNameOrFallback(namingClass));
+        if (baseName.isEmpty()) {
+            baseName = "bean";
+        }
+
+        if (!dependencyClass.isInterface()) {
+            return baseName;
+        }
+
+        if (resolver == null) {
+            return baseName;
+        }
+
+        return baseName + "#" + generatedQualifierCounter.incrementAndGet();
+    }
+
+    private @Nullable String normalizeQualifier(@Nullable String qualifier) {
+        if (qualifier == null) {
+            return null;
+        }
+
+        String normalized = qualifier.trim();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        return normalized;
+    }
+
+    private @NotNull String getSimpleNameOrFallback(@NotNull Class<?> type) {
+        String simpleName = type.getSimpleName();
+        if (simpleName != null && !simpleName.isEmpty()) {
+            return simpleName;
+        }
+
+        String name = type.getName();
+        int lastDotIndex = name.lastIndexOf('.');
+        if (lastDotIndex >= 0) {
+            return name.substring(lastDotIndex + 1);
+        }
+
+        return name;
+    }
+}
+

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
@@ -40,9 +40,12 @@ import tech.guilhermekaua.spigotboot.core.exceptions.MultipleConstructorExceptio
 import tech.guilhermekaua.spigotboot.core.utils.BeanUtils;
 import tech.guilhermekaua.spigotboot.core.utils.CollectionTypeUtils;
 import tech.guilhermekaua.spigotboot.core.utils.ReflectionUtils;
+import tech.guilhermekaua.spigotboot.utils.ProxyUtils;
 
+import java.beans.Introspector;
 import java.lang.reflect.*;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 // Context.initialize -> Context.scan -> DependencyManager.registerDependency -> Context.scan -> DependencyManager.resolveDependency
@@ -58,6 +61,8 @@ public class DependencyManager {
 
     @Getter
     private final CustomInjectorRegistry customInjectorRegistry;
+
+    private final AtomicInteger generatedQualifierCounter = new AtomicInteger(0);
 
     public DependencyManager() {
         this(new BeanDefinitionRegistry(), new BeanInstanceRegistry(), new BeanProxyDeciderResolver(), new DefaultCustomInjectorRegistry());
@@ -204,12 +209,13 @@ public class DependencyManager {
         Objects.requireNonNull(instance, "instance cannot be null.");
 
         Class<T> dependencyClass = (Class<T>) instance.getClass();
+        String resolvedQualifier = resolveQualifier(dependencyClass, instance, null, qualifier);
 
         for (Class<? super T> superInterface : ReflectionUtils.getSuperInterfaces(dependencyClass)) {
-            registerDependency(superInterface, dependencyClass, instance, qualifier, primary, null, reloadCallback);
+            registerDependency(superInterface, dependencyClass, instance, resolvedQualifier, primary, null, reloadCallback);
         }
 
-        registerDependency(dependencyClass, dependencyClass, instance, qualifier, primary, null, reloadCallback);
+        registerDependency(dependencyClass, dependencyClass, instance, resolvedQualifier, primary, null, reloadCallback);
         return instance;
     }
 
@@ -245,11 +251,13 @@ public class DependencyManager {
                                     @Nullable DependencyReloadCallback reloadCallback) {
         Objects.requireNonNull(dependencyClass, "dependencyClass cannot be null.");
 
+        String resolvedQualifier = resolveQualifier(dependencyClass, null, resolver, qualifier);
+
         for (Class<? super T> superInterface : ReflectionUtils.getSuperInterfaces(dependencyClass)) {
-            registerDependency((Class<T>) superInterface, dependencyClass, null, qualifier, primary, resolver, reloadCallback);
+            registerDependency((Class<T>) superInterface, dependencyClass, null, resolvedQualifier, primary, resolver, reloadCallback);
         }
 
-        registerDependency(dependencyClass, dependencyClass, null, qualifier, primary, resolver, reloadCallback);
+        registerDependency(dependencyClass, dependencyClass, null, resolvedQualifier, primary, resolver, reloadCallback);
         return null;
     }
 
@@ -302,7 +310,9 @@ public class DependencyManager {
 
             BeanUtils.detectCircularDependencies(dependencyClass, beanDefinitionRegistry.asMapView());
 
-            BeanDefinition definition = new BeanDefinition(clazz, dependencyClass, qualifier, primary, resolver, reloadCallback);
+            String resolvedQualifier = resolveQualifier(dependencyClass, instance, resolver, qualifier);
+
+            BeanDefinition definition = new BeanDefinition(clazz, dependencyClass, resolvedQualifier, primary, resolver, reloadCallback);
             beanDefinitionRegistry.register(clazz, definition);
 
             if (instance != null) {
@@ -313,6 +323,64 @@ public class DependencyManager {
         } catch (Exception e) {
             throw new RuntimeException("Failed to register dependency using (" + clazz + " -> " + dependencyClass + "): ", e);
         }
+    }
+
+    private @Nullable String normalizeQualifier(@Nullable String qualifier) {
+        if (qualifier == null) {
+            return null;
+        }
+
+        String normalized = qualifier.trim();
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        return normalized;
+    }
+
+    private @NotNull String resolveQualifier(@NotNull Class<?> dependencyClass,
+                                             @Nullable Object instance,
+                                             @Nullable DependencyResolveResolver<?> resolver,
+                                             @Nullable String qualifier) {
+        String normalizedQualifier = normalizeQualifier(qualifier);
+        if (normalizedQualifier != null) {
+            return normalizedQualifier;
+        }
+
+        Class<?> namingClass = dependencyClass;
+        if (instance != null) {
+            namingClass = ProxyUtils.getRealClass(instance);
+        }
+
+        String baseName = Introspector.decapitalize(getSimpleNameOrFallback(namingClass));
+        if (baseName.isEmpty()) {
+            baseName = "bean";
+        }
+
+        if (!dependencyClass.isInterface()) {
+            return baseName;
+        }
+
+        if (resolver == null) {
+            return baseName;
+        }
+
+        return baseName + "#" + generatedQualifierCounter.incrementAndGet();
+    }
+
+    private @NotNull String getSimpleNameOrFallback(@NotNull Class<?> type) {
+        String simpleName = type.getSimpleName();
+        if (!simpleName.isEmpty()) {
+            return simpleName;
+        }
+
+        String name = type.getName();
+        int lastDotIndex = name.lastIndexOf('.');
+        if (lastDotIndex >= 0) {
+            return name.substring(lastDotIndex + 1);
+        }
+
+        return name;
     }
 
     public void reloadDependencies() {

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
@@ -477,8 +477,15 @@ public class DependencyManager {
         Objects.requireNonNull(instance, "instance cannot be null.");
 
         for (Method method : type.getDeclaredMethods()) {
-            if (method.isAnnotationPresent(Inject.class) && method.getParameterCount() == 1) {
-                InjectionPoint injectionPoint = InjectionPoint.fromSetterMethod(method);
+            if (method.getParameterCount() != 1) {
+                continue;
+            }
+
+            InjectionPoint injectionPoint = InjectionPoint.fromSetterMethod(method);
+            boolean hasInjectAnnotation = method.isAnnotationPresent(Inject.class);
+            boolean customInjectorSupports = customInjectorRegistry.customInjectorSupported(injectionPoint);
+
+            if (hasInjectAnnotation || customInjectorSupports) {
                 Object dep = resolveDependency(injectionPoint);
 
                 method.setAccessible(true);
@@ -492,8 +499,11 @@ public class DependencyManager {
         Objects.requireNonNull(instance, "instance cannot be null.");
 
         for (Field field : type.getDeclaredFields()) {
-            if (field.isAnnotationPresent(Inject.class)) {
-                InjectionPoint injectionPoint = InjectionPoint.fromField(field);
+            InjectionPoint injectionPoint = InjectionPoint.fromField(field);
+            boolean hasInjectAnnotation = field.isAnnotationPresent(Inject.class);
+            boolean customInjectorSupports = customInjectorRegistry.customInjectorSupported(injectionPoint);
+
+            if (hasInjectAnnotation || customInjectorSupports) {
                 Object dep = resolveDependency(injectionPoint);
 
                 field.setAccessible(true);

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
@@ -33,6 +33,10 @@ import tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.strate
 import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
 import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyReloadCallback;
 import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyResolveResolver;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjector;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjectorRegistry;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
 import tech.guilhermekaua.spigotboot.core.context.dependency.registry.BeanDefinitionRegistry;
 import tech.guilhermekaua.spigotboot.core.context.dependency.registry.BeanInstanceRegistry;
 import tech.guilhermekaua.spigotboot.core.exceptions.MultipleConstructorException;
@@ -55,16 +59,40 @@ public class DependencyManager {
     @Getter
     private final BeanProxyDeciderResolver beanProxyDeciderResolver;
 
+    @Getter
+    private final CustomInjectorRegistry customInjectorRegistry;
+
     public DependencyManager() {
-        this(new BeanDefinitionRegistry(), new BeanInstanceRegistry(), new BeanProxyDeciderResolver());
+        this(new BeanDefinitionRegistry(), new BeanInstanceRegistry(), new BeanProxyDeciderResolver(), new CustomInjectorRegistry());
     }
 
     public DependencyManager(@NotNull BeanDefinitionRegistry beanDefinitionRegistry,
                              @NotNull BeanInstanceRegistry beanInstanceRegistry,
                              @NotNull BeanProxyDeciderResolver beanProxyDeciderResolver) {
+        this(beanDefinitionRegistry, beanInstanceRegistry, beanProxyDeciderResolver, new CustomInjectorRegistry());
+    }
+
+    public DependencyManager(@NotNull BeanDefinitionRegistry beanDefinitionRegistry,
+                             @NotNull BeanInstanceRegistry beanInstanceRegistry,
+                             @NotNull BeanProxyDeciderResolver beanProxyDeciderResolver,
+                             @NotNull CustomInjectorRegistry customInjectorRegistry) {
         this.beanDefinitionRegistry = Objects.requireNonNull(beanDefinitionRegistry, "beanDefinitionRegistry cannot be null.");
         this.beanInstanceRegistry = Objects.requireNonNull(beanInstanceRegistry, "beanInstanceRegistry cannot be null.");
         this.beanProxyDeciderResolver = Objects.requireNonNull(beanProxyDeciderResolver, "beanProxyDeciderResolver cannot be null.");
+        this.customInjectorRegistry = Objects.requireNonNull(customInjectorRegistry, "customInjectorRegistry cannot be null.");
+    }
+
+    /**
+     * Registers a custom injector.
+     * <p>
+     * Custom injectors allow modules to provide alternative ways of resolving dependencies.
+     * They are consulted in order before falling back to the default bean resolution.
+     *
+     * @param injector the custom injector to register, not null
+     */
+    public void registerInjector(@NotNull CustomInjector injector) {
+        Objects.requireNonNull(injector, "injector cannot be null");
+        customInjectorRegistry.register(injector);
     }
 
     public <T> T resolveDependency(@NotNull Class<T> clazz, @Nullable String qualifier) {
@@ -139,6 +167,32 @@ public class DependencyManager {
         }
 
         return registerDependency(instance, qualifier, false);
+    }
+
+    /**
+     * Resolves a dependency for the given injection point.
+     * <p>
+     * This method first consults all registered custom injectors in order. If any injector
+     * handles the injection point, its result is returned. Otherwise, the default resolution
+     * using the bean registry is performed.
+     *
+     * @param injectionPoint the injection point to resolve, not null
+     * @return the resolved dependency, or null if not found
+     */
+    @SuppressWarnings("unchecked")
+    public <T> @Nullable T resolveDependency(@NotNull InjectionPoint injectionPoint) {
+        Objects.requireNonNull(injectionPoint, "injectionPoint cannot be null");
+
+        for (CustomInjector injector : customInjectorRegistry.getInjectors()) {
+            if (injector.supports(injectionPoint)) {
+                InjectionResult result = injector.resolve(injectionPoint);
+                if (result.isHandled()) {
+                    return (T) result.getValue();
+                }
+            }
+        }
+
+        return resolveDependency(injectionPoint.getType(), injectionPoint.getQualifier());
     }
 
     public <T> T registerDependency(@NotNull T instance, @Nullable String qualifier, boolean primary) {
@@ -317,13 +371,8 @@ public class DependencyManager {
         Object[] args = new Object[parameters.length];
         for (int i = 0; i < parameters.length; i++) {
             Parameter param = parameters[i];
-            Type paramType = param.getParameterizedType();
-
-            if (paramType == null) {
-                paramType = param.getType();
-            }
-
-            args[i] = resolveDependency(paramType, BeanUtils.getQualifier(param));
+            InjectionPoint injectionPoint = InjectionPoint.fromParameter(param);
+            args[i] = resolveDependency(injectionPoint);
         }
 
         return args;
@@ -429,10 +478,8 @@ public class DependencyManager {
 
         for (Method method : type.getDeclaredMethods()) {
             if (method.isAnnotationPresent(Inject.class) && method.getParameterCount() == 1) {
-                Type[] genericParameterTypes = method.getGenericParameterTypes();
-                Type paramType = genericParameterTypes.length > 0 ? genericParameterTypes[0] : method.getParameterTypes()[0];
-
-                Object dep = resolveDependency(paramType, BeanUtils.getQualifier(method));
+                InjectionPoint injectionPoint = InjectionPoint.fromSetterMethod(method);
+                Object dep = resolveDependency(injectionPoint);
 
                 method.setAccessible(true);
                 method.invoke(instance, dep);
@@ -446,9 +493,8 @@ public class DependencyManager {
 
         for (Field field : type.getDeclaredFields()) {
             if (field.isAnnotationPresent(Inject.class)) {
-                Type fieldType = field.getGenericType();
-
-                Object dep = resolveDependency(fieldType, BeanUtils.getQualifier(field));
+                InjectionPoint injectionPoint = InjectionPoint.fromField(field);
+                Object dep = resolveDependency(injectionPoint);
 
                 field.setAccessible(true);
                 field.set(instance, dep);

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
@@ -33,10 +33,7 @@ import tech.guilhermekaua.spigotboot.core.context.component.proxy.decider.strate
 import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
 import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyReloadCallback;
 import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyResolveResolver;
-import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjector;
-import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjectorRegistry;
-import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
-import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.*;
 import tech.guilhermekaua.spigotboot.core.context.dependency.registry.BeanDefinitionRegistry;
 import tech.guilhermekaua.spigotboot.core.context.dependency.registry.BeanInstanceRegistry;
 import tech.guilhermekaua.spigotboot.core.exceptions.MultipleConstructorException;
@@ -63,13 +60,13 @@ public class DependencyManager {
     private final CustomInjectorRegistry customInjectorRegistry;
 
     public DependencyManager() {
-        this(new BeanDefinitionRegistry(), new BeanInstanceRegistry(), new BeanProxyDeciderResolver(), new CustomInjectorRegistry());
+        this(new BeanDefinitionRegistry(), new BeanInstanceRegistry(), new BeanProxyDeciderResolver(), new DefaultCustomInjectorRegistry());
     }
 
     public DependencyManager(@NotNull BeanDefinitionRegistry beanDefinitionRegistry,
                              @NotNull BeanInstanceRegistry beanInstanceRegistry,
                              @NotNull BeanProxyDeciderResolver beanProxyDeciderResolver) {
-        this(beanDefinitionRegistry, beanInstanceRegistry, beanProxyDeciderResolver, new CustomInjectorRegistry());
+        this(beanDefinitionRegistry, beanInstanceRegistry, beanProxyDeciderResolver, new DefaultCustomInjectorRegistry());
     }
 
     public DependencyManager(@NotNull BeanDefinitionRegistry beanDefinitionRegistry,

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/lifecycle/ContextLifecycle.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/lifecycle/ContextLifecycle.java
@@ -9,6 +9,7 @@ import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.
 import tech.guilhermekaua.spigotboot.core.context.component.registry.ComponentRegistry;
 import tech.guilhermekaua.spigotboot.core.context.configuration.processor.ConfigurationProcessor;
 import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjectorRegistry;
 import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
 import tech.guilhermekaua.spigotboot.core.context.dependency.registry.BeanDefinitionRegistry;
 import tech.guilhermekaua.spigotboot.core.context.lifecycle.listeners.BeanDefinitionsReadyListener;
@@ -68,6 +69,9 @@ public class ContextLifecycle {
         beanRegistrar.registerInstance(Plugin.class, plugin, null, false);
         beanRegistrar.registerInstance(ProxyUtils.getRealClass(plugin), plugin, null, false);
         beanRegistrar.registerInstance(dependencyManager, null, false);
+
+        CustomInjectorRegistry customInjectorRegistry = dependencyManager.getCustomInjectorRegistry();
+        beanRegistrar.registerInstance(CustomInjectorRegistry.class, customInjectorRegistry, null, false);
     }
 
     private void scanPackages() {

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/configuration/ConfigurationProcessorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/configuration/ConfigurationProcessorTest.java
@@ -273,7 +273,7 @@ public class ConfigurationProcessorTest {
 
         dependencyManager.registerDependency(
                 TestService.class,
-                null,
+                "testService",
                 true,
                 (type) -> null);
 

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorRegistryFactoryTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorRegistryFactoryTest.java
@@ -1,0 +1,184 @@
+
+package tech.guilhermekaua.spigotboot.core.test.context.dependency.injector;
+
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.*;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.registry.BeanDefinitionRegistry;
+import tech.guilhermekaua.spigotboot.core.context.registration.BeanRegistrar;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CustomInjectorRegistryFactoryTest {
+    private DependencyManager dependencyManager;
+    private BeanDefinitionRegistry definitionRegistry;
+    private CustomInjectorRegistry registry;
+    private Context mockContext;
+    private BeanRegistrar mockRegistrar;
+
+    @BeforeEach
+    void setUp() {
+        dependencyManager = new DependencyManager();
+        definitionRegistry = dependencyManager.getBeanDefinitionRegistry();
+        registry = dependencyManager.getCustomInjectorRegistry();
+
+        mockContext = mock(Context.class);
+        mockRegistrar = mock(BeanRegistrar.class);
+
+        Plugin plugin = mock(Plugin.class);
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+
+        when(mockContext.getDependencyManager()).thenReturn(dependencyManager);
+        when(mockContext.getPlugin()).thenReturn(plugin);
+    }
+
+    @Test
+    void testFactoryAppliesCustomizersInOrder() {
+        List<String> callOrder = new ArrayList<>();
+
+        CustomInjectorRegistryCustomizer first = new CustomInjectorRegistryCustomizer() {
+            @Override
+            public void customize(@NotNull CustomInjectorRegistry registry) {
+                callOrder.add("first");
+            }
+
+            @Override
+            public int getOrder() {
+                return -10;
+            }
+        };
+
+        CustomInjectorRegistryCustomizer second = new CustomInjectorRegistryCustomizer() {
+            @Override
+            public void customize(@NotNull CustomInjectorRegistry registry) {
+                callOrder.add("second");
+            }
+
+            @Override
+            public int getOrder() {
+                return 10;
+            }
+        };
+
+        dependencyManager.registerDependency(second, "second", false);
+        dependencyManager.registerDependency(first, "first", false);
+
+        CustomInjectorRegistryFactory factory = new CustomInjectorRegistryFactory();
+        factory.onBeanDefinitionsReady(mockContext, definitionRegistry, mockRegistrar);
+
+        assertEquals(List.of("first", "second"), callOrder);
+    }
+
+    @Test
+    void testFactoryResolvesCustomizerFromDefinitionAndAppliesIt() {
+        CustomInjector injector = createTestInjector(0);
+
+        dependencyManager.registerDependency(
+                CustomInjectorRegistryCustomizer.class,
+                "fromDefinition",
+                false,
+                (type) -> reg -> reg.register(injector),
+                null
+        );
+
+        CustomInjectorRegistryFactory factory = new CustomInjectorRegistryFactory();
+        factory.onBeanDefinitionsReady(mockContext, definitionRegistry, mockRegistrar);
+
+        assertEquals(1, registry.size());
+        assertSame(injector, registry.getInjectors().get(0));
+    }
+
+    @Test
+    void testFactoryContinuesWhenCustomizerThrows() {
+        CustomInjector injector = createTestInjector(0);
+
+        CustomInjectorRegistryCustomizer failing = new CustomInjectorRegistryCustomizer() {
+            @Override
+            public void customize(@NotNull CustomInjectorRegistry registry) {
+                throw new RuntimeException("boom");
+            }
+
+            @Override
+            public int getOrder() {
+                return -10;
+            }
+        };
+
+        CustomInjectorRegistryCustomizer succeeding = new CustomInjectorRegistryCustomizer() {
+            @Override
+            public void customize(@NotNull CustomInjectorRegistry registry) {
+                registry.register(injector);
+            }
+
+            @Override
+            public int getOrder() {
+                return 10;
+            }
+        };
+
+        dependencyManager.registerDependency(failing, "failing", false);
+        dependencyManager.registerDependency(succeeding, "succeeding", false);
+
+        CustomInjectorRegistryFactory factory = new CustomInjectorRegistryFactory();
+
+        assertDoesNotThrow(() -> factory.onBeanDefinitionsReady(mockContext, definitionRegistry, mockRegistrar));
+        assertEquals(1, registry.size());
+    }
+
+    @Test
+    void testFactoryContinuesWhenCustomizerResolutionFails() {
+        CustomInjector injector = createTestInjector(0);
+
+        dependencyManager.registerDependency(
+                CustomInjectorRegistryCustomizer.class,
+                "failsToResolve",
+                false,
+                (type) -> {
+                    throw new RuntimeException("resolve boom");
+                },
+                null
+        );
+
+        dependencyManager.registerDependency(
+                CustomInjectorRegistryCustomizer.class,
+                "ok",
+                false,
+                (type) -> reg -> reg.register(injector),
+                null
+        );
+
+        CustomInjectorRegistryFactory factory = new CustomInjectorRegistryFactory();
+
+        assertDoesNotThrow(() -> factory.onBeanDefinitionsReady(mockContext, definitionRegistry, mockRegistrar));
+        assertEquals(1, registry.size());
+    }
+
+    private static @NotNull CustomInjector createTestInjector(int order) {
+        return new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint injectionPoint) {
+                return false;
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+                return InjectionResult.notHandled();
+            }
+
+            @Override
+            public int getOrder() {
+                return order;
+            }
+        };
+    }
+}

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorRegistryFactoryTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorRegistryFactoryTest.java
@@ -80,7 +80,52 @@ public class CustomInjectorRegistryFactoryTest {
     }
 
     @Test
+    void testFactoryAppliesMultipleUnqualifiedCustomizers() {
+        List<String> callOrder = new ArrayList<>();
+
+        dependencyManager.registerDependency(
+                CustomInjectorRegistryCustomizer.class,
+                null,
+                false,
+                type -> new CustomInjectorRegistryCustomizer() {
+                    @Override
+                    public void customize(@NotNull CustomInjectorRegistry registry) {
+                        callOrder.add("first");
+                    }
+
+                    @Override
+                    public int getOrder() {
+                        return -10;
+                    }
+                }
+        );
+
+        dependencyManager.registerDependency(
+                CustomInjectorRegistryCustomizer.class,
+                null,
+                false,
+                type -> new CustomInjectorRegistryCustomizer() {
+                    @Override
+                    public void customize(@NotNull CustomInjectorRegistry registry) {
+                        callOrder.add("second");
+                    }
+
+                    @Override
+                    public int getOrder() {
+                        return 10;
+                    }
+                }
+        );
+
+        CustomInjectorRegistryFactory factory = new CustomInjectorRegistryFactory();
+        factory.onBeanDefinitionsReady(mockContext, definitionRegistry, mockRegistrar);
+
+        assertEquals(List.of("first", "second"), callOrder);
+    }
+
+    @Test
     void testFactoryResolvesCustomizerFromDefinitionAndAppliesIt() {
+
         CustomInjector injector = createTestInjector(0);
 
         dependencyManager.registerDependency(

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorTest.java
@@ -1,0 +1,398 @@
+package tech.guilhermekaua.spigotboot.core.test.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Inject;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Qualifier;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.MethodHandlerRegistry;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjector;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjectorRegistry;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CustomInjectorTest {
+    private DependencyManager dependencyManager;
+
+    @BeforeEach
+    void setUp() {
+        MethodHandlerRegistry.clear();
+        dependencyManager = new DependencyManager();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MethodHandlerRegistry.clear();
+    }
+
+    @Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.METHOD})
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface CustomValue {
+        String value();
+    }
+
+    static class CustomValueInjector implements CustomInjector {
+        private final String valueToInject;
+
+        public CustomValueInjector(String valueToInject) {
+            this.valueToInject = valueToInject;
+        }
+
+        @Override
+        public boolean supports(@NotNull InjectionPoint injectionPoint) {
+            return injectionPoint.getAnnotatedElement().isAnnotationPresent(CustomValue.class);
+        }
+
+        @Override
+        public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+            CustomValue annotation = injectionPoint.getAnnotatedElement().getAnnotation(CustomValue.class);
+            if (annotation != null) {
+                return InjectionResult.handled(valueToInject + ":" + annotation.value());
+            }
+            return InjectionResult.notHandled();
+        }
+    }
+
+    static class FieldInjectedBean {
+        @Inject
+        @CustomValue("field-key")
+        String customField;
+
+        public String getCustomField() {
+            return customField;
+        }
+    }
+
+    static class ConstructorInjectedBean {
+        private final String customValue;
+
+        public ConstructorInjectedBean(@CustomValue("ctor-key") String customValue) {
+            this.customValue = customValue;
+        }
+
+        public String getCustomValue() {
+            return customValue;
+        }
+    }
+
+    static class SetterInjectedBean {
+        private String customValue;
+
+        @Inject
+        @CustomValue("setter-key")
+        public void setCustomValue(String customValue) {
+            this.customValue = customValue;
+        }
+
+        public String getCustomValue() {
+            return customValue;
+        }
+    }
+
+    interface Service {
+        String getValue();
+    }
+
+    static class ServiceImpl implements Service {
+        @Override
+        public String getValue() {
+            return "service-value";
+        }
+    }
+
+    static class MixedInjectionBean {
+        @Inject
+        @CustomValue("mixed-custom")
+        String customField;
+
+        @Inject
+        Service regularService;
+
+        public String getCustomField() {
+            return customField;
+        }
+
+        public Service getRegularService() {
+            return regularService;
+        }
+    }
+
+    @Test
+    void testCustomInjectorRegistration() {
+        CustomValueInjector injector = new CustomValueInjector("test");
+
+        dependencyManager.registerInjector(injector);
+
+        assertEquals(1, dependencyManager.getCustomInjectorRegistry().size());
+    }
+
+    @Test
+    void testCustomInjectorFieldInjection() {
+        dependencyManager.registerInjector(new CustomValueInjector("injected"));
+        dependencyManager.registerDependency(FieldInjectedBean.class, null, false, null, null);
+
+        FieldInjectedBean bean = dependencyManager.resolveDependency(FieldInjectedBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("injected:field-key", bean.getCustomField());
+    }
+
+    @Test
+    void testCustomInjectorConstructorInjection() {
+        dependencyManager.registerInjector(new CustomValueInjector("ctor-injected"));
+        dependencyManager.registerDependency(ConstructorInjectedBean.class, null, false, null, null);
+
+        ConstructorInjectedBean bean = dependencyManager.resolveDependency(ConstructorInjectedBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("ctor-injected:ctor-key", bean.getCustomValue());
+    }
+
+    @Test
+    void testCustomInjectorSetterInjection() {
+        dependencyManager.registerInjector(new CustomValueInjector("setter-injected"));
+        dependencyManager.registerDependency(SetterInjectedBean.class, null, false, null, null);
+
+        SetterInjectedBean bean = dependencyManager.resolveDependency(SetterInjectedBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("setter-injected:setter-key", bean.getCustomValue());
+    }
+
+    @Test
+    void testCustomInjectorWithFallbackToDefaultResolution() {
+        dependencyManager.registerInjector(new CustomValueInjector("custom"));
+        dependencyManager.registerDependency(Service.class, ServiceImpl.class, null, false);
+        dependencyManager.registerDependency(MixedInjectionBean.class, null, false, null, null);
+
+        MixedInjectionBean bean = dependencyManager.resolveDependency(MixedInjectionBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("custom:mixed-custom", bean.getCustomField());
+        assertNotNull(bean.getRegularService());
+        assertEquals("service-value", bean.getRegularService().getValue());
+    }
+
+    @Test
+    void testCustomInjectorPrecedence() {
+        dependencyManager.registerInjector(new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint injectionPoint) {
+                return injectionPoint.getAnnotatedElement().isAnnotationPresent(CustomValue.class);
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+                return InjectionResult.handled("low-priority");
+            }
+
+            @Override
+            public int getOrder() {
+                return 10;
+            }
+        });
+
+        dependencyManager.registerInjector(new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint injectionPoint) {
+                return injectionPoint.getAnnotatedElement().isAnnotationPresent(CustomValue.class);
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+                return InjectionResult.handled("high-priority");
+            }
+
+            @Override
+            public int getOrder() {
+                return -10;
+            }
+        });
+
+        dependencyManager.registerDependency(FieldInjectedBean.class, null, false, null, null);
+
+        FieldInjectedBean bean = dependencyManager.resolveDependency(FieldInjectedBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("high-priority", bean.getCustomField());
+    }
+
+    @Test
+    void testCustomInjectorNotHandledFallsThrough() {
+        dependencyManager.registerInjector(new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint injectionPoint) {
+                return true;
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+                return InjectionResult.notHandled();
+            }
+        });
+
+        dependencyManager.registerInjector(new CustomValueInjector("fallthrough"));
+
+        dependencyManager.registerDependency(FieldInjectedBean.class, null, false, null, null);
+
+        FieldInjectedBean bean = dependencyManager.resolveDependency(FieldInjectedBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("fallthrough:field-key", bean.getCustomField());
+    }
+
+    @Test
+    void testCustomInjectorCanInjectNull() {
+        dependencyManager.registerInjector(new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint injectionPoint) {
+                return injectionPoint.getAnnotatedElement().isAnnotationPresent(CustomValue.class);
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+                return InjectionResult.handled(null); // intentionally inject null
+            }
+        });
+
+        dependencyManager.registerDependency(FieldInjectedBean.class, null, false, null, null);
+
+        FieldInjectedBean bean = dependencyManager.resolveDependency(FieldInjectedBean.class, null);
+
+        assertNotNull(bean);
+        assertNull(bean.getCustomField());
+    }
+
+    @Test
+    void testInjectionPointFromField() throws NoSuchFieldException {
+        InjectionPoint point = InjectionPoint.fromField(FieldInjectedBean.class.getDeclaredField("customField"));
+
+        assertEquals(String.class, point.getType());
+        assertNull(point.getQualifier());
+        assertNotNull(point.getAnnotatedElement());
+        assertTrue(point.getAnnotatedElement().isAnnotationPresent(CustomValue.class));
+    }
+
+    @Test
+    void testInjectionPointFromParameter() throws NoSuchMethodException {
+        Parameter param = ConstructorInjectedBean.class
+                .getConstructor(String.class)
+                .getParameters()[0];
+
+        InjectionPoint point = InjectionPoint.fromParameter(param);
+
+        assertEquals(String.class, point.getType());
+        assertNull(point.getQualifier());
+        assertNotNull(point.getAnnotatedElement());
+    }
+
+    @Test
+    void testInjectionPointWithQualifier() throws NoSuchFieldException {
+        class QualifiedBean {
+            @Inject
+            @Qualifier("myQualifier")
+            String qualifiedField;
+        }
+
+        InjectionPoint point = InjectionPoint.fromField(QualifiedBean.class.getDeclaredField("qualifiedField"));
+
+        assertEquals("myQualifier", point.getQualifier());
+    }
+
+    @Test
+    void testInjectionResultNotHandled() {
+        InjectionResult result = InjectionResult.notHandled();
+
+        assertFalse(result.isHandled());
+        assertThrows(IllegalStateException.class, result::getValue);
+    }
+
+    @Test
+    void testInjectionResultHandledWithValue() {
+        InjectionResult result = InjectionResult.handled("test-value");
+
+        assertTrue(result.isHandled());
+        assertEquals("test-value", result.getValue());
+    }
+
+    @Test
+    void testInjectionResultHandledWithNull() {
+        InjectionResult result = InjectionResult.handled(null);
+
+        assertTrue(result.isHandled());
+        assertNull(result.getValue());
+    }
+
+    @Test
+    void testCustomInjectorRegistryOrder() {
+        CustomInjectorRegistry registry = dependencyManager.getCustomInjectorRegistry();
+
+        CustomInjector lowPriority = new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint ip) {
+                return false;
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint ip) {
+                return InjectionResult.notHandled();
+            }
+
+            @Override
+            public int getOrder() {
+                return 100;
+            }
+        };
+
+        CustomInjector highPriority = new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint ip) {
+                return false;
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint ip) {
+                return InjectionResult.notHandled();
+            }
+
+            @Override
+            public int getOrder() {
+                return -100;
+            }
+        };
+
+        CustomInjector defaultPriority = new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint ip) {
+                return false;
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint ip) {
+                return InjectionResult.notHandled();
+            }
+        };
+
+        // register in random order
+        registry.register(lowPriority);
+        registry.register(defaultPriority);
+        registry.register(highPriority);
+
+        List<CustomInjector> sorted = registry.getInjectors();
+        assertEquals(3, sorted.size());
+        assertSame(highPriority, sorted.get(0));
+        assertSame(defaultPriority, sorted.get(1));
+        assertSame(lowPriority, sorted.get(2));
+    }
+}

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/CustomInjectorTest.java
@@ -74,6 +74,21 @@ public class CustomInjectorTest {
         }
     }
 
+    static class FieldInjectedWithoutInjectBean {
+        @CustomValue("field-no-inject")
+        String customField;
+
+        String plainField;
+
+        public String getCustomField() {
+            return customField;
+        }
+
+        public String getPlainField() {
+            return plainField;
+        }
+    }
+
     static class ConstructorInjectedBean {
         private final String customValue;
 
@@ -97,6 +112,28 @@ public class CustomInjectorTest {
 
         public String getCustomValue() {
             return customValue;
+        }
+    }
+
+    static class SetterInjectedWithoutInjectBean {
+        private String customValue;
+        private String plainValue;
+
+        @CustomValue("setter-no-inject")
+        public void setCustomValue(String customValue) {
+            this.customValue = customValue;
+        }
+
+        public void setPlainValue(String plainValue) {
+            this.plainValue = plainValue;
+        }
+
+        public String getCustomValue() {
+            return customValue;
+        }
+
+        public String getPlainValue() {
+            return plainValue;
         }
     }
 
@@ -168,6 +205,30 @@ public class CustomInjectorTest {
 
         assertNotNull(bean);
         assertEquals("setter-injected:setter-key", bean.getCustomValue());
+    }
+
+    @Test
+    void testFieldInjectionWithoutInjectAnnotation() {
+        dependencyManager.registerInjector(new CustomValueInjector("no-inject"));
+        dependencyManager.registerDependency(FieldInjectedWithoutInjectBean.class, null, false, null, null);
+
+        FieldInjectedWithoutInjectBean bean = dependencyManager.resolveDependency(FieldInjectedWithoutInjectBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("no-inject:field-no-inject", bean.getCustomField());
+        assertNull(bean.getPlainField());
+    }
+
+    @Test
+    void testSetterInjectionWithoutInjectAnnotation() {
+        dependencyManager.registerInjector(new CustomValueInjector("no-inject-setter"));
+        dependencyManager.registerDependency(SetterInjectedWithoutInjectBean.class, null, false, null, null);
+
+        SetterInjectedWithoutInjectBean bean = dependencyManager.resolveDependency(SetterInjectedWithoutInjectBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("no-inject-setter:setter-no-inject", bean.getCustomValue());
+        assertNull(bean.getPlainValue());
     }
 
     @Test

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/DefaultCustomInjectorRegistryTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/injector/DefaultCustomInjectorRegistryTest.java
@@ -1,0 +1,118 @@
+
+package tech.guilhermekaua.spigotboot.core.test.context.dependency.injector;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjector;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.DefaultCustomInjectorRegistry;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DefaultCustomInjectorRegistryTest {
+
+    static class Target {
+        String value;
+    }
+
+    @Test
+    void testRegisterNullThrows() {
+        DefaultCustomInjectorRegistry registry = new DefaultCustomInjectorRegistry();
+
+        assertThrows(NullPointerException.class, () -> registry.register(null));
+    }
+
+    @Test
+    void testGetInjectorsSortedAndStableForSameOrder() {
+        DefaultCustomInjectorRegistry registry = new DefaultCustomInjectorRegistry();
+
+        CustomInjector first = createTestInjector(0, false);
+        CustomInjector higherPriority = createTestInjector(-1, false);
+        CustomInjector second = createTestInjector(0, false);
+
+        registry.register(first);
+        registry.register(higherPriority);
+        registry.register(second);
+
+        List<CustomInjector> sorted = registry.getInjectors();
+        assertEquals(3, sorted.size());
+        assertSame(higherPriority, sorted.get(0));
+        assertSame(first, sorted.get(1));
+        assertSame(second, sorted.get(2));
+    }
+
+    @Test
+    void testGetInjectorsIsUnmodifiable() {
+        DefaultCustomInjectorRegistry registry = new DefaultCustomInjectorRegistry();
+        registry.register(createTestInjector(0, false));
+
+        List<CustomInjector> view = registry.getInjectors();
+
+        assertThrows(UnsupportedOperationException.class, () -> view.add(createTestInjector(0, false)));
+    }
+
+    @Test
+    void testUnregisterRemovesInjector() {
+        DefaultCustomInjectorRegistry registry = new DefaultCustomInjectorRegistry();
+        CustomInjector injector = createTestInjector(0, false);
+
+        registry.register(injector);
+
+        assertTrue(registry.unregister(injector));
+        assertTrue(registry.isEmpty());
+        assertEquals(0, registry.size());
+        assertFalse(registry.getInjectors().contains(injector));
+    }
+
+    @Test
+    void testCustomInjectorSupportedReturnsTrueWhenAnySupports() throws NoSuchFieldException {
+        Field field = Target.class.getDeclaredField("value");
+        InjectionPoint injectionPoint = InjectionPoint.fromField(field);
+
+        DefaultCustomInjectorRegistry registry = new DefaultCustomInjectorRegistry();
+        registry.register(createTestInjector(0, false));
+
+        assertFalse(registry.customInjectorSupported(injectionPoint));
+
+        registry.register(createTestInjector(0, true));
+
+        assertTrue(registry.customInjectorSupported(injectionPoint));
+    }
+
+    @Test
+    void testClearResetsRegistry() {
+        DefaultCustomInjectorRegistry registry = new DefaultCustomInjectorRegistry();
+        registry.register(createTestInjector(1, false));
+        registry.register(createTestInjector(-1, false));
+
+        registry.clear();
+
+        assertTrue(registry.isEmpty());
+        assertEquals(0, registry.size());
+        assertTrue(registry.getInjectors().isEmpty());
+    }
+
+    private static @NotNull CustomInjector createTestInjector(int order, boolean supports) {
+        return new CustomInjector() {
+            @Override
+            public boolean supports(@NotNull InjectionPoint injectionPoint) {
+                return supports;
+            }
+
+            @Override
+            public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+                return InjectionResult.notHandled();
+            }
+
+            @Override
+            public int getOrder() {
+                return order;
+            }
+        };
+    }
+}
+


### PR DESCRIPTION
Add custom injectors, removing the need to have @Inject explicitly to get a dependency injected.
Custom injectors allow injection based on custom criteria via `CustomInjector.supports` method, which could be useful for future implementation of a `@Value("foo")` annotation, where the value inside the annotation would be the path of a config, like `@Value("database.host")`.