### PR TITLE
Resolve OrmLite repository generic types via hierarchy walk instead of fragile getGenericInterfaces()[0]

### DIFF
--- a/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/methodHandler/OrmLiteRepositoryMethodHandler.java
+++ b/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/methodHandler/OrmLiteRepositoryMethodHandler.java
@@ -28,10 +28,9 @@ import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.
 import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.context.MethodHandlerContext;
 import tech.guilhermekaua.spigotboot.data.ormLite.registry.OrmLiteRepositoryRegistry;
 import tech.guilhermekaua.spigotboot.data.ormLite.repository.OrmLiteRepository;
+import tech.guilhermekaua.spigotboot.data.ormLite.utils.OrmLiteTypeUtils;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 
 @RequiredArgsConstructor
 @RegisterMethodHandler
@@ -47,9 +46,7 @@ public class OrmLiteRepositoryMethodHandler {
         try {
             return context.proceed().invoke(context.self(), context.args());
         } catch (IllegalAccessException | IllegalArgumentException | NullPointerException e) {
-            Class<?> self = context.self().getClass().getInterfaces()[0];
-            Type[] types = ((ParameterizedType) self.getGenericInterfaces()[0]).getActualTypeArguments();
-            Class<?> entityType = (Class<?>) types[0];
+            Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(context.self().getClass());
 
             OrmLiteRepository<?, ?> repositoryImpl = repositoryRegistry.getDao(entityType);
 

--- a/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/methodHandler/OrmLiteRepositoryMethodHandler.java
+++ b/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/methodHandler/OrmLiteRepositoryMethodHandler.java
@@ -43,20 +43,20 @@ public class OrmLiteRepositoryMethodHandler {
             return null;
         }
 
-        try {
+        if (context.proceed() != null) {
             return context.proceed().invoke(context.self(), context.args());
-        } catch (IllegalAccessException | IllegalArgumentException | NullPointerException e) {
-            Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(context.self().getClass());
-
-            OrmLiteRepository<?, ?> repositoryImpl = repositoryRegistry.getDao(entityType);
-
-            if (repositoryImpl == null) {
-                throw new IllegalStateException("No repository found for entity type: " + entityType.getName());
-            }
-
-            Method method = repositoryImpl.getClass().getMethod(context.thisMethod().getName(), context.thisMethod().getParameterTypes());
-            method.setAccessible(true);
-            return method.invoke(repositoryImpl, context.args());
         }
+
+        Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(context.self().getClass());
+
+        OrmLiteRepository<?, ?> repositoryImpl = repositoryRegistry.getDao(entityType);
+
+        if (repositoryImpl == null) {
+            throw new IllegalStateException("No repository found for entity type: " + entityType.getName());
+        }
+
+        Method method = repositoryImpl.getClass().getMethod(context.thisMethod().getName(), context.thisMethod().getParameterTypes());
+        method.setAccessible(true);
+        return method.invoke(repositoryImpl, context.args());
     }
 }

--- a/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/registry/OrmLiteRepositoryRegistry.java
+++ b/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/registry/OrmLiteRepositoryRegistry.java
@@ -39,7 +39,6 @@ import tech.guilhermekaua.spigotboot.data.ormLite.repository.impl.OrmLiteReposit
 import tech.guilhermekaua.spigotboot.data.ormLite.utils.OrmLiteTypeUtils;
 
 import java.lang.reflect.Field;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -78,7 +77,7 @@ public class OrmLiteRepositoryRegistry {
     }
 
     @SuppressWarnings("unchecked")
-    private void initializeRepository(Class<? extends OrmLiteRepository> repositoryClass, DependencyManager dependencyManager, ConnectionSource connectionSource) throws ClassNotFoundException, SQLException {
+    private void initializeRepository(Class<? extends OrmLiteRepository> repositoryClass, DependencyManager dependencyManager, ConnectionSource connectionSource) {
         try {
             Class<?> entityClass = OrmLiteTypeUtils.resolveEntityType(repositoryClass);
             if (entityClass == null) {

--- a/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/registry/OrmLiteRepositoryRegistry.java
+++ b/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/registry/OrmLiteRepositoryRegistry.java
@@ -36,19 +36,22 @@ import tech.guilhermekaua.spigotboot.data.ormLite.annotations.OrmLiteDao;
 import tech.guilhermekaua.spigotboot.data.ormLite.registry.discovery.OrmLiteRepositoryDiscoveryService;
 import tech.guilhermekaua.spigotboot.data.ormLite.repository.OrmLiteRepository;
 import tech.guilhermekaua.spigotboot.data.ormLite.repository.impl.OrmLiteRepositoryImpl;
+import tech.guilhermekaua.spigotboot.data.ormLite.utils.OrmLiteTypeUtils;
 
 import java.lang.reflect.Field;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Component
 @SuppressWarnings("rawtypes")
 @RequiredArgsConstructor
 public class OrmLiteRepositoryRegistry {
+    private static final Logger LOGGER = Logger.getLogger(OrmLiteRepositoryRegistry.class.getName());
+
     private final Map<Class<?>, OrmLiteRepository<?, ?>> repositoryMap = new HashMap<>();
     private final OrmLiteRepositoryDiscoveryService repositoryDiscoveryService;
 
@@ -77,6 +80,12 @@ public class OrmLiteRepositoryRegistry {
     @SuppressWarnings("unchecked")
     private void initializeRepository(Class<? extends OrmLiteRepository> repositoryClass, DependencyManager dependencyManager, ConnectionSource connectionSource) throws ClassNotFoundException, SQLException {
         try {
+            Class<?> entityClass = OrmLiteTypeUtils.resolveEntityType(repositoryClass);
+            if (entityClass == null) {
+                LOGGER.log(Level.WARNING, "Skipping repository {0}: could not resolve entity type (unbound type variables).", repositoryClass.getName());
+                return;
+            }
+
             dependencyManager.registerDependency(
                     (Class<OrmLiteRepository>) repositoryClass,
                     repositoryClass,
@@ -85,10 +94,6 @@ public class OrmLiteRepositoryRegistry {
                     (clazz) -> ComponentProxy.createProxy(clazz, null, new Class[0], new Object[0])
             );
 
-            Type[] types = ((ParameterizedType) repositoryClass.getGenericInterfaces()[0]).getActualTypeArguments();
-            Type entityType = types[0];
-
-            Class<?> entityClass = Class.forName(entityType.getTypeName());
             Dao<?, ?> dao = DaoManager.createDao(connectionSource, entityClass);
 
             OrmLiteRepository repository = dependencyManager.resolveDependency(repositoryClass, BeanUtils.getQualifier(repositoryClass));

--- a/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/utils/OrmLiteTypeUtils.java
+++ b/modules/data-orm-lite/src/main/java/tech/guilhermekaua/spigotboot/data/ormLite/utils/OrmLiteTypeUtils.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.data.ormLite.utils;
+
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.data.ormLite.repository.OrmLiteRepository;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class OrmLiteTypeUtils {
+
+    /**
+     * Resolves the concrete entity type (first type argument of {@link OrmLiteRepository})
+     * from a class or interface that extends/implements OrmLiteRepository.
+     * <p>
+     * Walks the full type hierarchy, resolving type variables through intermediate
+     * classes and interfaces.
+     *
+     * @param clazz the class/interface that implements OrmLiteRepository
+     * @return the concrete entity class, or null if it cannot be resolved
+     */
+    public static @Nullable Class<?> resolveEntityType(Class<?> clazz) {
+        Type[] typeArgs = findTypeArguments(clazz, OrmLiteRepository.class);
+        if (typeArgs == null || typeArgs.length == 0) {
+            return null;
+        }
+
+        return toConcreteClass(typeArgs[0]);
+    }
+
+    private static @Nullable Type[] findTypeArguments(Class<?> clazz, Class<?> targetClass) {
+        if (clazz == null || clazz == Object.class) return null;
+
+        for (Type genericInterface : clazz.getGenericInterfaces()) {
+            Type[] result = extractFromType(genericInterface, targetClass);
+            if (result != null) return result;
+        }
+
+        Type genericSuperclass = clazz.getGenericSuperclass();
+        if (genericSuperclass != null) {
+            Type[] result = extractFromType(genericSuperclass, targetClass);
+            if (result != null) return result;
+        }
+
+        return null;
+    }
+
+    private static Type[] extractFromType(Type type, Class<?> targetClass) {
+        if (type instanceof ParameterizedType) {
+            ParameterizedType pt = (ParameterizedType) type;
+            Class<?> rawType = (Class<?>) pt.getRawType();
+
+            if (rawType == targetClass) {
+                return pt.getActualTypeArguments();
+            }
+
+            Type[] parentResult = findTypeArguments(rawType, targetClass);
+            if (parentResult != null) {
+                return substituteTypeVariables(parentResult, rawType, pt.getActualTypeArguments());
+            }
+        } else if (type instanceof Class) {
+            return findTypeArguments((Class<?>) type, targetClass);
+        }
+        return null;
+    }
+
+    private static Type[] substituteTypeVariables(Type[] types, Class<?> declaringClass, Type[] actualArgs) {
+        TypeVariable<?>[] typeParams = declaringClass.getTypeParameters();
+        Map<String, Type> typeVarMap = new HashMap<>();
+        for (int i = 0; i < typeParams.length && i < actualArgs.length; i++) {
+            typeVarMap.put(typeParams[i].getName(), actualArgs[i]);
+        }
+
+        Type[] result = new Type[types.length];
+        for (int i = 0; i < types.length; i++) {
+            if (types[i] instanceof TypeVariable) {
+                Type substitution = typeVarMap.get(((TypeVariable<?>) types[i]).getName());
+                result[i] = substitution != null ? substitution : types[i];
+            } else {
+                result[i] = types[i];
+            }
+        }
+        return result;
+    }
+
+    private static @Nullable Class<?> toConcreteClass(Type type) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        }
+        if (type instanceof ParameterizedType) {
+            return (Class<?>) ((ParameterizedType) type).getRawType();
+        }
+        return null;
+    }
+}

--- a/modules/data-orm-lite/src/test/java/tech/guilhermekaua/spigotboot/data/ormLite/utils/OrmLiteTypeUtilsTest.java
+++ b/modules/data-orm-lite/src/test/java/tech/guilhermekaua/spigotboot/data/ormLite/utils/OrmLiteTypeUtilsTest.java
@@ -1,9 +1,5 @@
 package tech.guilhermekaua.spigotboot.data.ormLite.utils;
 
-import com.j256.ormlite.dao.Dao;
-import com.j256.ormlite.stmt.DeleteBuilder;
-import com.j256.ormlite.stmt.QueryBuilder;
-import com.j256.ormlite.stmt.UpdateBuilder;
 import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.data.ormLite.repository.OrmLiteRepository;
 
@@ -43,66 +39,11 @@ class OrmLiteTypeUtilsTest {
     }
 
     // unresolvable (raw type variables like OrmLiteRepositoryImpl<T, ID>)
-    static class UnresolvableRepo<T, ID> implements OrmLiteRepository<T, ID> {
-        public T save(T entity) {
-            return null;
-        }
-
-        public java.util.List<T> saveAll(Iterable<T> iterable) {
-            return null;
-        }
-
-        public T findById(ID id) {
-            return null;
-        }
-
-        public java.util.List<T> findAll() {
-            return null;
-        }
-
-        public void delete(T entity) {
-        }
-
-        public void delete(Iterable<T> iterable) {
-        }
-
-        public void deleteById(ID id) {
-        }
-
-        public void deleteAll() {
-        }
-
-        public long count() {
-            return 0;
-        }
-
-        public boolean existsById(ID id) {
-            return false;
-        }
-
-        public QueryBuilder<T, ID> queryBuilder() {
-            return null;
-        }
-
-        public UpdateBuilder<T, ID> updateBuilder() {
-            return null;
-        }
-
-        public DeleteBuilder<T, ID> deleteBuilder() {
-            return null;
-        }
-
-        public Dao.CreateOrUpdateStatus createOrUpdate(T var1) {
-            return null;
-        }
-
-        public int update(T var1) {
-            return 0;
-        }
+    static abstract class UnresolvableRepo<T, ID> implements OrmLiteRepository<T, ID> {
     }
 
     // concrete class extending a generic impl with concrete types
-    static class ConcreteUserRepo extends UnresolvableRepo<People, UUID> {
+    static abstract class ConcreteUserRepo extends UnresolvableRepo<People, UUID> {
     }
 
     @Test

--- a/modules/data-orm-lite/src/test/java/tech/guilhermekaua/spigotboot/data/ormLite/utils/OrmLiteTypeUtilsTest.java
+++ b/modules/data-orm-lite/src/test/java/tech/guilhermekaua/spigotboot/data/ormLite/utils/OrmLiteTypeUtilsTest.java
@@ -1,0 +1,143 @@
+package tech.guilhermekaua.spigotboot.data.ormLite.utils;
+
+import com.j256.ormlite.dao.Dao;
+import com.j256.ormlite.stmt.DeleteBuilder;
+import com.j256.ormlite.stmt.QueryBuilder;
+import com.j256.ormlite.stmt.UpdateBuilder;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.data.ormLite.repository.OrmLiteRepository;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class OrmLiteTypeUtilsTest {
+
+    // test entity classes
+    static class People {
+    }
+
+    static class Order {
+    }
+
+    // direct interface extending OrmLiteRepository
+    interface UserRepository extends OrmLiteRepository<People, UUID> {
+    }
+
+    // intermediate interface with partial binding
+    interface BaseRepository<T> extends OrmLiteRepository<T, UUID> {
+    }
+
+    interface OrderRepository extends BaseRepository<Order> {
+    }
+
+    // multiple levels of indirection
+    interface AbstractRepo<E, I> extends OrmLiteRepository<E, I> {
+    }
+
+    interface TypedRepo<E> extends AbstractRepo<E, UUID> {
+    }
+
+    interface DeepRepository extends TypedRepo<People> {
+    }
+
+    // unresolvable (raw type variables like OrmLiteRepositoryImpl<T, ID>)
+    static class UnresolvableRepo<T, ID> implements OrmLiteRepository<T, ID> {
+        public T save(T entity) {
+            return null;
+        }
+
+        public java.util.List<T> saveAll(Iterable<T> iterable) {
+            return null;
+        }
+
+        public T findById(ID id) {
+            return null;
+        }
+
+        public java.util.List<T> findAll() {
+            return null;
+        }
+
+        public void delete(T entity) {
+        }
+
+        public void delete(Iterable<T> iterable) {
+        }
+
+        public void deleteById(ID id) {
+        }
+
+        public void deleteAll() {
+        }
+
+        public long count() {
+            return 0;
+        }
+
+        public boolean existsById(ID id) {
+            return false;
+        }
+
+        public QueryBuilder<T, ID> queryBuilder() {
+            return null;
+        }
+
+        public UpdateBuilder<T, ID> updateBuilder() {
+            return null;
+        }
+
+        public DeleteBuilder<T, ID> deleteBuilder() {
+            return null;
+        }
+
+        public Dao.CreateOrUpdateStatus createOrUpdate(T var1) {
+            return null;
+        }
+
+        public int update(T var1) {
+            return 0;
+        }
+    }
+
+    // concrete class extending a generic impl with concrete types
+    static class ConcreteUserRepo extends UnresolvableRepo<People, UUID> {
+    }
+
+    @Test
+    void resolveEntityType_directInterface() {
+        Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(UserRepository.class);
+        assertEquals(People.class, entityType);
+    }
+
+    @Test
+    void resolveEntityType_intermediateInterface() {
+        Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(OrderRepository.class);
+        assertEquals(Order.class, entityType);
+    }
+
+    @Test
+    void resolveEntityType_deepHierarchy() {
+        Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(DeepRepository.class);
+        assertEquals(People.class, entityType);
+    }
+
+    @Test
+    void resolveEntityType_unboundTypeVariables_returnsNull() {
+        Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(UnresolvableRepo.class);
+        assertNull(entityType, "Should return null for classes with unbound type variables");
+    }
+
+    @Test
+    void resolveEntityType_concreteSubclassOfGenericImpl() {
+        Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(ConcreteUserRepo.class);
+        assertEquals(People.class, entityType);
+    }
+
+    @Test
+    void resolveEntityType_unrelatedClass_returnsNull() {
+        Class<?> entityType = OrmLiteTypeUtils.resolveEntityType(String.class);
+        assertNull(entityType);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced repository type resolution with improved error handling and logging for initialization failures.
  * Strengthened support for complex generic type hierarchies in repository configurations.

* **Tests**
  * Added comprehensive test coverage for entity type resolution across various inheritance scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->