### PR TITLE
Refine duplicate-bean error message with actionable qualifier details

### DIFF
--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/context/dependency/manager/DependencyManager.java
@@ -167,7 +167,17 @@ public class DependencyManager {
             List<BeanDefinition> primary = definitions.stream().filter(BeanDefinition::isPrimary).collect(Collectors.toList());
 
             if (primary.isEmpty()) {
-                throw new IllegalStateException(String.format("No primary dependency found for class %s and qualifier %s", clazz.getSimpleName(), qualifier));
+                String candidates = definitions.stream()
+                        .map(def -> {
+                            String candidateQualifier = def.getQualifierName();
+                            return candidateQualifier == null ? "<default>" : candidateQualifier;
+                        })
+                        .collect(Collectors.joining(", "));
+                throw new IllegalStateException(String.format(
+                        "Multiple dependencies found for type %s but none is marked as @Primary. Available qualifiers: [%s]. " +
+                                "Add @Primary to one bean or use @Qualifier at the injection point.",
+                        clazz.getName(),
+                        candidates));
             }
 
             if (primary.size() > 1) {

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/manager/DependencyManagerTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/manager/DependencyManagerTest.java
@@ -190,8 +190,15 @@ public class DependencyManagerTest {
 
         Exception exception = assertThrows(RuntimeException.class,
                 () -> dependencyManager.resolveDependency(Service.class, null));
-        assertTrue(exception.getCause().getMessage().contains("Multiple dependencies found for type"));
-        assertTrue(exception.getCause().getMessage().contains("Available qualifiers: [serviceImpl, someQualifier]"));
+        Throwable cause = exception.getCause();
+        assertNotNull(cause);
+        String message = cause.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("Multiple dependencies found for type " + Service.class.getName()));
+        assertTrue(message.contains("Available qualifiers: ["));
+        assertTrue(message.contains("serviceImpl"));
+        assertTrue(message.contains("someQualifier"));
+        assertTrue(message.contains("Add @Primary to one bean or use @Qualifier at the injection point."));
     }
 
     @Test

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/manager/DependencyManagerTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/context/dependency/manager/DependencyManagerTest.java
@@ -190,7 +190,8 @@ public class DependencyManagerTest {
 
         Exception exception = assertThrows(RuntimeException.class,
                 () -> dependencyManager.resolveDependency(Service.class, null));
-        assertTrue(exception.getCause().getMessage().contains("No primary dependency found for class"));
+        assertTrue(exception.getCause().getMessage().contains("Multiple dependencies found for type"));
+        assertTrue(exception.getCause().getMessage().contains("Available qualifiers: [serviceImpl, someQualifier]"));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- Improve the clarity of the exception thrown when multiple beans of the same type exist and none is marked `@Primary` so developers can quickly identify and fix ambiguous injections.
- Provide actionable information (available qualifiers and remediation steps) instead of the terse message that previously caused confusion.

### Description
- Replace the previous `IllegalStateException` message in `DependencyManager.resolveDependency(...)` with a descriptive message that includes the fully-qualified type, a comma-separated list of available qualifiers (shows `<default>` when qualifier is null), and guidance to add `@Primary` or use `@Qualifier` at the injection point.
- Update the unit test `DependencyManagerTest.testNotResolveWithTwoDependenciesAndNoPrimary` to assert the new message content and the qualifier list.
- Modified files: `core/src/main/java/.../DependencyManager.java` and `core/src/test/java/.../DependencyManagerTest.java`.

### Testing
- Updated unit test `DependencyManagerTest` to validate the new error message and qualifier list; the test was committed alongside the code change.
- Attempted to run `mvn -pl core test -Dtest=DependencyManagerTest` and `mvn -pl core test -Dtest=DependencyManagerTest -U`, but test execution could not proceed because Maven failed to load a build extension (`org.sonatype.central:central-publishing-maven-plugin:0.8.0`), causing the build to abort before tests ran.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c47ca8e52c832e9ece43b2a0b2d5cc)