### PR TITLE
Align data modules on HikariCP 4.0.3 for Java 8 compatibility

### DIFF
--- a/data/pom.xml
+++ b/data/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.1.0</version>
+            <version>4.0.3</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/modules/data-jdbc/pom.xml
+++ b/modules/data-jdbc/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.1.0</version>
+            <version>4.0.3</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
### Motivation
- Ensure the data modules use a Java 8-compatible HikariCP line by replacing 5.1.0 with 4.0.3 across the project so runtime on Java 8 does not encounter incompatibilities.

### Description
- Updated the HikariCP dependency version from `5.1.0` to `4.0.3` in `data/pom.xml` and `modules/data-jdbc/pom.xml` so both data artifacts depend on the same Java 8-compatible release.

### Testing
- Attempted to compile the updated modules with `mvn -pl data,modules/data-jdbc -DskipTests compile`, but the build failed to start due to an external Maven build extension resolution error (`org.sonatype.central:central-publishing-maven-plugin:0.8.0`) unrelated to the dependency version changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c47cb7c9d0832e933412c6b1781849)
Fixes #34 