### PR TITLE
Fix command unregistration in BukkitCommandRegistrar

### DIFF
--- a/platform-spigot/commands-spigot/src/main/java/tech/guilhermekaua/spigotboot/commands/spigot/BukkitCommandRegistrar.java
+++ b/platform-spigot/commands-spigot/src/main/java/tech/guilhermekaua/spigotboot/commands/spigot/BukkitCommandRegistrar.java
@@ -8,7 +8,13 @@ import tech.guilhermekaua.spigotboot.commands.internal.CommandSupport;
 import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
 import tech.guilhermekaua.spigotboot.core.context.Context;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 public class BukkitCommandRegistrar {
     private final BukkitCommandMapAccessor commandMapAccessor;
@@ -37,7 +43,7 @@ public class BukkitCommandRegistrar {
 
         for (Command existing : toRemove) {
             existing.unregister(commandMap);
-            knownCommands.entrySet().removeIf(entry -> entry.getValue() == existing);
+            removeKnownCommandEntries(knownCommands, existing);
         }
 
         String prefix = context.getPlugin().getName().toLowerCase(Locale.ROOT);
@@ -53,13 +59,26 @@ public class BukkitCommandRegistrar {
         Map<String, Command> knownCommands = commandMapAccessor.getKnownCommands(commandMap);
         for (SpigotBootCommand command : registeredCommandSet.getCommands()) {
             command.unregister(commandMap);
-            knownCommands.entrySet().removeIf(entry -> entry.getValue() == command);
+            removeKnownCommandEntries(knownCommands, command);
+        }
+    }
+
+    private void removeKnownCommandEntries(Map<String, Command> knownCommands, Command command) {
+        List<String> labelsToRemove = new ArrayList<>();
+        for (Map.Entry<String, Command> entry : knownCommands.entrySet()) {
+            if (entry.getValue() == command) {
+                labelsToRemove.add(entry.getKey());
+            }
+        }
+
+        for (String label : labelsToRemove) {
+            knownCommands.remove(label, command);
         }
     }
 
     private void collectCollisions(Context context,
-                                    CompiledRootCommand root,
-                                    Map<String, Command> knownCommands,
+                                   CompiledRootCommand root,
+                                   Map<String, Command> knownCommands,
                                     Set<Command> toRemove) {
         for (String label : root.getAliases().allValues()) {
             Command existing = knownCommands.get(CommandSupport.normalizeLabel(label));

--- a/platform-spigot/commands-spigot/src/test/java/tech/guilhermekaua/spigotboot/commands/test/BukkitCommandRegistrarTest.java
+++ b/platform-spigot/commands-spigot/src/test/java/tech/guilhermekaua/spigotboot/commands/test/BukkitCommandRegistrarTest.java
@@ -38,8 +38,12 @@ import tech.guilhermekaua.spigotboot.core.context.Context;
 import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
 import tech.guilhermekaua.spigotboot.core.spigot.SpigotBootPlugin;
 
+import java.util.AbstractMap;
+import java.util.AbstractSet;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -85,6 +89,31 @@ class BukkitCommandRegistrarTest {
         assertFalse(knownCommands.containsKey("adm"));
     }
 
+    @Test
+    void unregisterRemovesCommandsWhenKnownCommandsIteratorDoesNotSupportRemoval() {
+        JavaPlugin plugin = MockBukkit.createMockPlugin("TestPlugin");
+        Context context = mock(Context.class);
+        when(context.getPlugin()).thenReturn(new SpigotBootPlugin(plugin));
+        when(context.getDependencyManager()).thenReturn(new DependencyManager());
+
+        CompiledRootCommand root = compileRoot(new RootCommands());
+        CommandDispatcher dispatcher = newDispatcher();
+        BukkitCommandMapAccessor accessor = new UnsupportedIteratorRemoveAccessor();
+        BukkitCommandRegistrar registrar = new BukkitCommandRegistrar(accessor, dispatcher, platformSupport);
+
+        RegisteredCommandSet set = registrar.register(context, Collections.singletonList(root));
+        CommandMap commandMap = accessor.getCommandMap();
+        Map<String, Command> knownCommands = accessor.getKnownCommands(commandMap);
+
+        assertTrue(knownCommands.containsKey("admin"));
+        assertTrue(knownCommands.containsKey("adm"));
+
+        registrar.unregister(set);
+
+        assertFalse(knownCommands.containsKey("admin"));
+        assertFalse(knownCommands.containsKey("adm"));
+    }
+
     private CompiledRootCommand compileRoot(Object handler) {
         CommandReplacementRegistry replacementRegistry = new DefaultCommandReplacementRegistry(Collections.emptyList());
         CommandRouteFactory factory = new CommandRouteFactory(
@@ -113,6 +142,69 @@ class BukkitCommandRegistrarTest {
     static class RootCommands {
         @DefaultCommand
         public void root() {
+        }
+    }
+
+    private static final class UnsupportedIteratorRemoveAccessor extends BukkitCommandMapAccessor {
+        private final BukkitCommandMapAccessor delegate = new BukkitCommandMapAccessor();
+        private Map<String, Command> knownCommands;
+
+        @Override
+        public CommandMap getCommandMap() {
+            return delegate.getCommandMap();
+        }
+
+        @Override
+        public Map<String, Command> getKnownCommands(CommandMap commandMap) {
+            if (knownCommands == null) {
+                knownCommands = new UnsupportedIteratorRemoveMap(delegate.getKnownCommands(commandMap));
+            }
+
+            return knownCommands;
+        }
+    }
+
+    private static final class UnsupportedIteratorRemoveMap extends AbstractMap<String, Command> {
+        private final Map<String, Command> delegate;
+
+        private UnsupportedIteratorRemoveMap(Map<String, Command> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Set<Map.Entry<String, Command>> entrySet() {
+            return new AbstractSet<Map.Entry<String, Command>>() {
+                @Override
+                public Iterator<Map.Entry<String, Command>> iterator() {
+                    Iterator<Map.Entry<String, Command>> iterator = delegate.entrySet().iterator();
+                    return new Iterator<Map.Entry<String, Command>>() {
+                        @Override
+                        public boolean hasNext() {
+                            return iterator.hasNext();
+                        }
+
+                        @Override
+                        public Map.Entry<String, Command> next() {
+                            return iterator.next();
+                        }
+                    };
+                }
+
+                @Override
+                public int size() {
+                    return delegate.size();
+                }
+            };
+        }
+
+        @Override
+        public Command get(Object key) {
+            return delegate.get(key);
+        }
+
+        @Override
+        public Command remove(Object key) {
+            return delegate.remove(key);
         }
     }
 }


### PR DESCRIPTION
fixed `java.lang.UnsupportedOperationException: remove` during commands unregistration when the server stops