### PR TITLE
ci: publish dev snapshots to Maven Central

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
       - '**.java'
       - '**/pom.xml'
 
+# least privilege: tests only need to read the repo; nothing writes back to GitHub.
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # tests only read the repo; don't persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # this job only reads the repo and publishes to Maven Central with its
+          # own credentials — don't persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -31,7 +35,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
 
+# least privilege: only reads the repo to check out; the publish authenticates to
+# Maven Central with its own credentials and never writes back to GitHub.
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release to Maven Central

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -32,10 +32,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # this job only reads the repo and publishes to Maven Central with its
+          # own credentials — don't persist the GITHUB_TOKEN in .git/config.
+          persist-credentials: false
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -45,7 +49,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -20,6 +20,11 @@ concurrency:
   group: snapshot-${{ github.ref }}
   cancel-in-progress: true
 
+# least privilege: only reads the repo to check out; the publish authenticates to
+# Maven Central with its own credentials and never writes back to GitHub.
+permissions:
+  contents: read
+
 jobs:
   snapshot:
     name: Publish SNAPSHOT

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,64 @@
+name: Publish SNAPSHOT to Maven Central
+
+# Publishes a -SNAPSHOT build to the Central Portal snapshot repository
+# (https://central.sonatype.com/repository/maven-snapshots/) on every push to dev
+# that touches source, POMs, or main resources. The version is whatever -SNAPSHOT
+# string is committed in the POM; each push overwrites that rolling version, and
+# Maven's snapshot timestamping keeps every individual build resolvable. See
+# RELEASING.md "1b. Publish a snapshot".
+
+on:
+  push:
+    branches: [ dev ]
+    paths:
+      - '**.java'
+      - '**/pom.xml'
+      - '**/src/main/resources/**'
+
+# a burst of commits cancels superseded runs instead of queueing N deploys
+concurrency:
+  group: snapshot-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  snapshot:
+    name: Publish SNAPSHOT
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+
+      # safety net: a non-SNAPSHOT version would route to the validating RELEASE
+      # path and, with autoPublish=true, could publish a real release from dev.
+      # fail loudly instead. bump dev to the next -SNAPSHOT after each release.
+      - name: Verify POM version is a SNAPSHOT
+        run: |
+          VERSION=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)
+          echo "POM version: $VERSION"
+          case "$VERSION" in
+            *-SNAPSHOT) ;;
+            *) echo "::error::dev POM version ($VERSION) must end in -SNAPSHOT — bump it after the last release"; exit 1 ;;
+          esac
+
+      - name: Build and deploy snapshot
+        run: mvn clean deploy -B -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,6 +9,9 @@ This is the maintainer runbook for publishing `tech.guilhermekaua.spigot-boot` t
 > [`Release to Maven Central`](.github/workflows/release.yml) workflow does the rest.
 > The one-time setup below is only needed to (re)create the GitHub secrets after you
 > format your PC, or to deploy manually as a fallback.
+>
+> For unreleased **snapshots** you don't even tag — just push to `dev` and CI publishes a
+> `-SNAPSHOT`. See [§1b](#1b-publish-a-snapshot-dev-builds).
 
 ---
 
@@ -37,6 +40,81 @@ This is the maintainer runbook for publishing `tech.guilhermekaua.spigot-boot` t
    `https://repo1.maven.org/maven2/tech/guilhermekaua/spigot-boot/`.
 
 That's the whole day-to-day flow.
+
+---
+
+## 1b. Publish a snapshot (`dev` builds)
+
+Sometimes you want consumers (or another of your projects) to pull in unreleased work without
+cutting a real release. The Central Portal hosts **`-SNAPSHOT`** artifacts for exactly this,
+and a separate workflow keeps it fully automatic.
+
+### How it works
+
+[`.github/workflows/snapshot.yml`](.github/workflows/snapshot.yml) runs on **every push to
+`dev`** that touches `**.java`, `**/pom.xml`, or `**/src/main/resources/**`, and runs
+`mvn clean deploy`. Because the committed version ends in `-SNAPSHOT`, the
+`central-publishing-maven-plugin` (≥ 0.7.0; we're on 0.10.0) automatically routes the upload to
+the snapshot repository `https://central.sonatype.com/repository/maven-snapshots/` instead of
+the validating release path — same `central` user token, same GPG secrets, **no new
+configuration**. The same modules are excluded as for releases ([§3](#3-which-modules-publish-and-which-dont)).
+
+Snapshots are **not validated** (no GPG/sources/javadoc enforcement — ours are still signed,
+which is harmless), `autoPublish` is irrelevant to them, they **can't be browsed** in the portal
+UI, and Central **auto-deletes them after ~90 days**.
+
+### Versioning — one rolling version, not one per commit
+
+A `-SNAPSHOT` is a *moving* coordinate. Every `dev` push deploys the **same** version string
+(e.g. `3.1.0-SNAPSHOT`); the repo keeps each build under a unique Maven **timestamp**
+(`3.1.0-20260610.143022-7`) and points "latest" at the newest. So:
+
+- consumers normally use `3.1.0-SNAPSHOT` → always the freshest `dev` build;
+- a specific commit's build can be pinned via its timestamped coordinate.
+
+You therefore **pick the version once** and bump it only at release time:
+
+1. The `dev` POM carries the *next* unreleased version, `X.Y.Z-SNAPSHOT`.
+2. After you cut release `X.Y.Z` ([§1](#1-cut-a-release-the-normal-path)), bump `dev` to the next
+   snapshot so dev builds don't collide with the release:
+   ```powershell
+   .\mvnw.cmd versions:set "-DnewVersion=<next>-SNAPSHOT" "-DprocessAllModules=true" "-DgenerateBackupPoms=false"
+   ```
+   `snapshot.yml` hard-fails if the `dev` POM version is **not** a `-SNAPSHOT` — that guard stops
+   an accidental real-release publish from `dev` (with `autoPublish=true` it would otherwise go live).
+
+### One-time: enable SNAPSHOTs for the namespace
+
+On [central.sonatype.com](https://central.sonatype.com/) → **Publish → Namespaces** → the
+`tech.guilhermekaua` row → three-dot menu → **Enable SNAPSHOTs** → confirm. This is tied to the
+(already-verified, [§4a](#4a-central-portal-account--namespace)) namespace, so you do it once.
+Until it's enabled, snapshot deploys are rejected.
+
+### Consuming a snapshot
+
+Snapshots are **not** on `repo1.maven.org`; add the portal snapshot repo:
+
+```xml
+<repositories>
+  <repository>
+    <id>central-portal-snapshots</id>
+    <name>Central Portal Snapshots</name>
+    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    <releases><enabled>false</enabled></releases>
+    <snapshots><enabled>true</enabled></snapshots>
+  </repository>
+</repositories>
+```
+
+### Manual / local snapshot deploy
+
+Same as the [emergency release path](#5-manual--emergency-deploy-from-your-machine) but the
+version already ends in `-SNAPSHOT`, so no tag and no `versions:set` are needed. With **JDK 17
+or 21**:
+
+```powershell
+.\mvnw.cmd clean deploy "-Dgpg.passphrase=YOUR_PASSPHRASE"
+```
 
 ---
 
@@ -218,6 +296,11 @@ The user token is wrong or revoked. Generate a new one ([§4b](#4b-generate-a-pu
 `tech.guilhermekaua` isn't verified on the account. Complete DNS verification on the portal
 ([§4a](#4a-central-portal-account--namespace)).
 
+### Snapshot deploy rejected / SNAPSHOTs not allowed
+SNAPSHOTs aren't enabled for the namespace — enable them once in the portal
+([§1b](#1b-publish-a-snapshot-dev-builds)). Also confirm the `dev` POM version actually ends in
+`-SNAPSHOT` (the workflow guards this, but a local deploy doesn't).
+
 ---
 
 ## Pre-release checklist
@@ -227,3 +310,4 @@ The user token is wrong or revoked. Generate a new one ([§4b](#4b-generate-a-pu
 - [ ] Version decided
 - [ ] `git tag vX.Y.Z && git push origin vX.Y.Z`
 - [ ] Actions run green; artifact visible on central.sonatype.com
+- [ ] After release: bump `dev` to the next `-SNAPSHOT` ([§1b](#1b-publish-a-snapshot-dev-builds))

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -18,7 +18,7 @@ This is the maintainer runbook for publishing `tech.guilhermekaua.spigot-boot` t
 ## 1. Cut a release (the normal path)
 
 1. Be on `master` with a clean working tree and **everything committed** — including any
-   publishing-related POM changes (see [§3](#3-which-modules-publish-and-which-dont), this
+   publishing-related POM changes (see [§3](#3-which-modules-publish--and-which-dont), this
    bit us once: a fix that only lived in the working tree was not in the tag CI built from).
 2. Verify the build is green locally (use JDK 17 or 21 — **never 25**, see
    [troubleshooting](#lombok-crashes-with-typetag--unknown)):
@@ -57,7 +57,7 @@ and a separate workflow keeps it fully automatic.
 `central-publishing-maven-plugin` (≥ 0.7.0; we're on 0.10.0) automatically routes the upload to
 the snapshot repository `https://central.sonatype.com/repository/maven-snapshots/` instead of
 the validating release path — same `central` user token, same GPG secrets, **no new
-configuration**. The same modules are excluded as for releases ([§3](#3-which-modules-publish-and-which-dont)).
+configuration**. The same modules are excluded as for releases ([§3](#3-which-modules-publish--and-which-dont)).
 
 Snapshots are **not validated** (no GPG/sources/javadoc enforcement — ours are still signed,
 which is harmless), `autoPublish` is irrelevant to them, they **can't be browsed** in the portal

--- a/commands/pom.xml
+++ b/commands/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/config/pom.xml
+++ b/config/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>tech.guilhermekaua.spigot-boot</groupId>
             <artifactId>spigot-boot-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/data/pom.xml
+++ b/data/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/modules/data-jdbc/pom.xml
+++ b/modules/data-jdbc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-modules</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/modules/data-orm-lite/pom.xml
+++ b/modules/data-orm-lite/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-modules</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>tech.guilhermekaua.spigot-boot</groupId>
             <artifactId>spigot-boot-core</artifactId>
-            <version>3.0.0</version>
+            <version>3.1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/platform-spigot/annotation-processor/pom.xml
+++ b/platform-spigot/annotation-processor/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.groupId}</name>

--- a/platform-spigot/commands-config-spigot/pom.xml
+++ b/platform-spigot/commands-config-spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/commands-spigot/pom.xml
+++ b/platform-spigot/commands-spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/config-spigot/pom.xml
+++ b/platform-spigot/config-spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/core-spigot/pom.xml
+++ b/platform-spigot/core-spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/api/pom.xml
+++ b/platform-spigot/inventory-api/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms-1_12_R1/pom.xml
+++ b/platform-spigot/inventory-api/nms-1_12_R1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms-1_16_R3/pom.xml
+++ b/platform-spigot/inventory-api/nms-1_16_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms-1_17_R1/pom.xml
+++ b/platform-spigot/inventory-api/nms-1_17_R1/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms-1_18_R2/pom.xml
+++ b/platform-spigot/inventory-api/nms-1_18_R2/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms-1_19_R3/pom.xml
+++ b/platform-spigot/inventory-api/nms-1_19_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms-1_8_R3/pom.xml
+++ b/platform-spigot/inventory-api/nms-1_8_R3/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms-api/pom.xml
+++ b/platform-spigot/inventory-api/nms-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/nms/pom.xml
+++ b/platform-spigot/inventory-api/nms/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-inventory-api-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/inventory-api/pom.xml
+++ b/platform-spigot/inventory-api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/placeholder/pom.xml
+++ b/platform-spigot/placeholder/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/pmc/pom.xml
+++ b/platform-spigot/pmc/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot-platform-spigot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/platform-spigot/pom.xml
+++ b/platform-spigot/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>tech.guilhermekaua.spigot-boot</groupId>
     <artifactId>spigot-boot</artifactId>
-    <version>3.0.0</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>${project.artifactId}</name>
     <description>${project.artifactId} parent project for Spigot Boot modules.</description>
     <url>https://github.com/guikaua12/spigot-boot</url>

--- a/test-plugin/pom.xml
+++ b/test-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>tech.guilhermekaua.spigot-boot</groupId>
         <artifactId>spigot-boot</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.0-SNAPSHOT</version>
     </parent>
 
     <name>${project.artifactId}</name>


### PR DESCRIPTION
## What

Adds automatic **SNAPSHOT publishing** to the Central Portal so unreleased `dev` work is consumable without cutting a release.

- **`.github/workflows/snapshot.yml`** — on every push to `dev` touching `**.java`, `**/pom.xml`, or `**/src/main/resources/**`, runs `mvn clean deploy`. The existing `central-publishing-maven-plugin` (0.10.0) auto-routes `-SNAPSHOT` versions to `https://central.sonatype.com/repository/maven-snapshots/`. Reuses the same `central` user token + GPG secrets as `release.yml` — **no new secrets**.
  - `concurrency: cancel-in-progress` so a burst of commits doesn't queue N full deploys.
  - A **guard step** fails the run if the `dev` POM version isn't a `-SNAPSHOT`, preventing an accidental real-release publish from `dev` (which `autoPublish=true` would otherwise make live).
- **Version bump `3.0.0` → `3.1.0-SNAPSHOT`** across all 28 reactor modules (`versions:set -DprocessAllModules=true`) — parent refs and intra-reactor dependency versions moved in lockstep.
- **`RELEASING.md`** — new §1b documenting the flow, the rolling-version/timestamping model, the one-time namespace enablement, and the consumer `<repository>` snippet; plus a TL;DR pointer, a troubleshooting entry, and a post-release checklist item.

## Affected modules

All reactor modules (version coordinate only) + new CI workflow + docs. No Java/source changes.

## Test notes

- `mvn validate` passes (reactor parses coherently after the bump).
- Full `mvn test` not run locally: changes are CI config + version strings + docs (no Java touched), and the suite needs JDK 21 (local default is JDK 25, which crashes Lombok). `ci.yml` (JDK 17) will run the suite on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)