### PR TITLE
fix(utils,config-spigot): reference shaded javassist in shipped modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,17 @@ class UserService {
 }
 ```
 
+## Shading & javassist (relocation safety)
+`spigot-boot-core` bundles javassist **relocated** to `tech.guilhermekaua.spigotboot.shaded.javassist` (see `core/pom.xml`). Inside a downstream plugin jar that relocated copy is the **only** javassist present — the original `javassist.*` classes are never shipped. Any *shipped* module whose compiled bytecode references the original `javassist.*` package throws `NoClassDefFoundError: javassist/util/proxy/...` on a real server, even though it passes tests (where the original javassist is still on the classpath). Green tests do **not** prove runtime safety, because shading happens in the `package` phase, after tests run.
+
+When a module needs javassist, pick the matching rule:
+
+- **Only detecting/inspecting proxies (no proxy creation):** do **not** `import javassist.*`. Match javassist's `ProxyObject` marker interface by name so it recognizes both the original and the relocated name. See `utils/ProxyUtils#isJavassistProxy`; keep javassist at `test` scope there.
+- **Creating proxies or using the javassist API directly:** the module's own bytecode must reference the **shaded** names at runtime. Add a `maven-shade-plugin` execution that relocates `javassist` → `tech.guilhermekaua.spigotboot.shaded.javassist` and bundles nothing (`<artifactSet>` includes only the module's own `groupId:artifactId`, so `core` keeps ownership of the single bundled copy), and declare javassist as `provided`. See `platform-spigot/config-spigot/pom.xml` and `core/pom.xml`.
+- **Never** add javassist as a shipped `compile`-scope dependency without one of the above — that ships un-relocated references and reintroduces the crash.
+
+When touching proxy code, add a regression guard like `ProxyUtilsTest#proxyUtilsClassMustNotReferenceUnrelocatedJavassistPackage`, which asserts the compiled class carries no `javassist/` (slashed, internal-form) reference.
+
 ## Testing Guidelines
 Tests use JUnit 5, Mockito, and MockBukkit for Spigot-facing modules. Name test classes `*Test` or `*IntegrationTest` and place them beside the module they validate. Add focused regression coverage for every behavior change; there is no hard coverage threshold, but CI must stay green across modules.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,17 @@ class UserService {
 }
 ```
 
+## Shading & javassist (relocation safety)
+`spigot-boot-core` bundles javassist **relocated** to `tech.guilhermekaua.spigotboot.shaded.javassist` (see `core/pom.xml`). Inside a downstream plugin jar that relocated copy is the **only** javassist present — the original `javassist.*` classes are never shipped. Any *shipped* module whose compiled bytecode references the original `javassist.*` package throws `NoClassDefFoundError: javassist/util/proxy/...` on a real server, even though it passes tests (where the original javassist is still on the classpath). Green tests do **not** prove runtime safety, because shading happens in the `package` phase, after tests run.
+
+When a module needs javassist, pick the matching rule:
+
+- **Only detecting/inspecting proxies (no proxy creation):** do **not** `import javassist.*`. Match javassist's `ProxyObject` marker interface by name so it recognizes both the original and the relocated name. See `utils/ProxyUtils#isJavassistProxy`; keep javassist at `test` scope there.
+- **Creating proxies or using the javassist API directly:** the module's own bytecode must reference the **shaded** names at runtime. Add a `maven-shade-plugin` execution that relocates `javassist` → `tech.guilhermekaua.spigotboot.shaded.javassist` and bundles nothing (`<artifactSet>` includes only the module's own `groupId:artifactId`, so `core` keeps ownership of the single bundled copy), and declare javassist as `provided`. See `platform-spigot/config-spigot/pom.xml` and `core/pom.xml`.
+- **Never** add javassist as a shipped `compile`-scope dependency without one of the above — that ships un-relocated references and reintroduces the crash.
+
+When touching proxy code, add a regression guard like `ProxyUtilsTest#proxyUtilsClassMustNotReferenceUnrelocatedJavassistPackage`, which asserts the compiled class carries no `javassist/` (slashed, internal-form) reference.
+
 ## Testing Guidelines
 Tests use JUnit 5, Mockito, and MockBukkit for Spigot-facing modules. Name test classes `*Test` or `*IntegrationTest` and place them beside the module they validate. Add focused regression coverage for every behavior change; there is no hard coverage threshold, but CI must stay green across modules.
 

--- a/platform-spigot/config-spigot/pom.xml
+++ b/platform-spigot/config-spigot/pom.xml
@@ -48,10 +48,55 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <!-- version managed by the parent pluginManagement -->
+                <executions>
+                    <execution>
+                        <id>relocate-javassist-references</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <!-- ConfigProxy uses the javassist proxy API directly. javassist ships only as the
+                                 relocated copy bundled inside spigot-boot-core, so this module's own bytecode must
+                                 reference the shaded names too; otherwise it throws NoClassDefFoundError:
+                                 javassist/util/proxy/* at runtime. nothing is bundled here (core owns the shaded
+                                 javassist) — this execution only rewrites this module's references. -->
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <!-- include only this module's own classes so nothing is bundled; the execution
+                                 exists purely to rewrite this module's javassist references to the shaded package. -->
+                            <artifactSet>
+                                <includes>
+                                    <include>tech.guilhermekaua.spigot-boot:spigot-boot-config-spigot</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>javassist</pattern>
+                                    <shadedPattern>tech.guilhermekaua.spigotboot.shaded.javassist</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
     <dependencies>
+        <!-- ConfigProxy uses the javassist proxy API; it is provided (never bundled) because the relocated
+             copy is supplied at runtime by spigot-boot-core, and this module's references are rewritten to the
+             shaded package by the maven-shade-plugin execution above. -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.30.2-GA</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>io.papermc.paper</groupId>
             <artifactId>paper-api</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -21,11 +21,13 @@
     </properties>
 
     <dependencies>
+        <!-- javassist is only needed by tests (to construct a real proxy); ProxyUtils detects proxies by
+             interface name and carries no compile-time reference to the javassist package. see ProxyUtils. -->
         <dependency>
             <groupId>org.javassist</groupId>
             <artifactId>javassist</artifactId>
             <version>3.30.2-GA</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -20,6 +20,32 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <configuration>
+                            <!-- utils is built before spigot-boot-annotation-processor-spigot in the reactor and
+                                 its tests need no annotation processing; override the inherited test processor path
+                                 so a clean build does not try to resolve that not-yet-built SNAPSHOT. -->
+                            <annotationProcessorPaths combine.self="override">
+                                <path>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>1.18.36</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- javassist is only needed by tests (to construct a real proxy); ProxyUtils detects proxies by
              interface name and carries no compile-time reference to the javassist package. see ProxyUtils. -->

--- a/utils/src/main/java/tech/guilhermekaua/spigotboot/utils/ProxyUtils.java
+++ b/utils/src/main/java/tech/guilhermekaua/spigotboot/utils/ProxyUtils.java
@@ -22,14 +22,18 @@
  */
 package tech.guilhermekaua.spigotboot.utils;
 
-import javassist.util.proxy.ProxyObject;
-
 public final class ProxyUtils {
+    // javassist marks every generated proxy with the ProxyObject interface. it is matched by name (not by a
+    // compile-time class reference) so detection keeps working after the javassist package is relocated into
+    // a downstream plugin jar (e.g. tech.guilhermekaua.spigotboot.shaded.javassist.util.proxy.ProxyObject).
+    private static final String PROXY_OBJECT_CLASS_NAME = "javassist.util.proxy.ProxyObject";
+    private static final String RELOCATED_PROXY_OBJECT_SUFFIX = "." + PROXY_OBJECT_CLASS_NAME;
+
     public static boolean isProxy(Object object) {
         try {
             Class<?> clazz = object.getClass();
 
-            if (ProxyObject.class.isAssignableFrom(clazz)) {
+            if (isJavassistProxy(clazz)) {
                 return true;
             }
 
@@ -43,7 +47,7 @@ public final class ProxyUtils {
     }
 
     public static Class<?> unwrapProxyType(Class<?> type) {
-        if (ProxyObject.class.isAssignableFrom(type)) {
+        if (isJavassistProxy(type)) {
             return type.getSuperclass();
         }
         return type;
@@ -56,5 +60,19 @@ public final class ProxyUtils {
         }
 
         return (Class<T>) object.getClass().getSuperclass();
+    }
+
+    // walks the type hierarchy looking for javassist's ProxyObject marker interface, matching by name so
+    // both the original (javassist.util.proxy.ProxyObject) and the shaded/relocated name are recognized.
+    private static boolean isJavassistProxy(Class<?> type) {
+        for (Class<?> current = type; current != null && current != Object.class; current = current.getSuperclass()) {
+            for (Class<?> iface : current.getInterfaces()) {
+                String name = iface.getName();
+                if (name.equals(PROXY_OBJECT_CLASS_NAME) || name.endsWith(RELOCATED_PROXY_OBJECT_SUFFIX)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/utils/src/test/java/tech/guilhermekaua/spigotboot/utils/ProxyUtilsTest.java
+++ b/utils/src/test/java/tech/guilhermekaua/spigotboot/utils/ProxyUtilsTest.java
@@ -1,0 +1,98 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.utils;
+
+import javassist.util.proxy.ProxyFactory;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ProxyUtilsTest {
+
+    public static class Sample {
+        public String greet() {
+            return "hello";
+        }
+    }
+
+    /**
+     * regression for the shaded-javassist NoClassDefFoundError: ProxyUtils ships inside downstream
+     * plugins, but javassist is only present at runtime under the relocated
+     * {@code tech.guilhermekaua.spigotboot.shaded.javassist} package. if the compiled class carries a
+     * hard reference to the original {@code javassist/...} package it throws
+     * {@code NoClassDefFoundError: javassist/util/proxy/ProxyObject} on a real server while still
+     * passing tests (where the original javassist is on the classpath). proxy detection must therefore
+     * not bake the original package name into the bytecode.
+     */
+    @Test
+    void proxyUtilsClassMustNotReferenceUnrelocatedJavassistPackage() throws Exception {
+        byte[] bytes;
+        try (InputStream in = ProxyUtils.class.getResourceAsStream("ProxyUtils.class")) {
+            assertNotNull(in, "could not load ProxyUtils.class to inspect");
+            bytes = in.readAllBytes();
+        }
+
+        // type references in the constant pool use the internal slashed form (e.g. javassist/util/proxy/ProxyObject);
+        // a string literal such as "javassist.util.proxy.ProxyObject" uses dots and is fine.
+        String constantPool = new String(bytes, StandardCharsets.ISO_8859_1);
+        assertFalse(
+                constantPool.contains("javassist/"),
+                "ProxyUtils must not reference the un-relocated javassist package; detect proxies by interface name instead"
+        );
+    }
+
+    @Test
+    void isProxyDetectsJavassistProxies() throws Exception {
+        Object proxy = newJavassistProxy(Sample.class);
+        assertTrue(ProxyUtils.isProxy(proxy), "a javassist proxy instance must be detected as a proxy");
+        assertFalse(ProxyUtils.isProxy(new Sample()), "a plain instance must not be detected as a proxy");
+    }
+
+    @Test
+    void unwrapProxyTypeReturnsRealSuperclass() throws Exception {
+        Class<?> proxyClass = newJavassistProxy(Sample.class).getClass();
+        assertSame(Sample.class, ProxyUtils.unwrapProxyType(proxyClass), "proxy type must unwrap to its real superclass");
+        assertSame(Sample.class, ProxyUtils.unwrapProxyType(Sample.class), "a non-proxy type must be returned unchanged");
+    }
+
+    @Test
+    void getRealClassReturnsRealType() throws Exception {
+        Object proxy = newJavassistProxy(Sample.class);
+        assertSame(Sample.class, ProxyUtils.getRealClass(proxy), "proxy instance must resolve to its real class");
+        Sample plain = new Sample();
+        assertSame(Sample.class, ProxyUtils.getRealClass(plain), "plain instance must resolve to its own class");
+    }
+
+    private static Object newJavassistProxy(Class<?> superclass) throws Exception {
+        ProxyFactory factory = new ProxyFactory();
+        factory.setSuperclass(superclass);
+        Class<?> proxyClass = factory.createClass();
+        return proxyClass.getDeclaredConstructor().newInstance();
+    }
+}


### PR DESCRIPTION
ProxyUtils and ConfigProxy referenced the original javassist.* package, but downstream plugin jars only ship javassist relocated to tech.guilhermekaua.spigotboot.shaded.javassist (bundled by core). At runtime this threw NoClassDefFoundError: javassist/util/proxy/ProxyObject even though tests passed, because the original javassist is on the test classpath.

- utils: ProxyUtils now detects javassist proxies by the ProxyObject interface name, carrying no compile-time javassist reference, so it survives relocation. javassist drops to test scope. Adds ProxyUtilsTest with a bytecode regression guard plus behavioral coverage.
- config-spigot: ConfigProxy uses the javassist proxy API directly, so the module relocates its own references via maven-shade-plugin (bundling nothing; core owns the single bundled copy) with javassist as provided.
- docs: AGENTS.md/CLAUDE.md gain a "Shading & javassist" guide so future modules avoid this trap.