### PR TITLE
refactor(config): remove unused @ConfigProperty.advanced()

### DIFF
--- a/config/src/main/java/tech/guilhermekaua/spigotboot/config/annotation/ConfigProperty.java
+++ b/config/src/main/java/tech/guilhermekaua/spigotboot/config/annotation/ConfigProperty.java
@@ -48,11 +48,4 @@ public @interface ConfigProperty {
      * @return true if hidden
      */
     boolean hidden() default false;
-
-    /**
-     * If true, field is written to config but marked as advanced/internal.
-     *
-     * @return true if advanced
-     */
-    boolean advanced() default false;
 }


### PR DESCRIPTION
## Summary
`@ConfigProperty.advanced()` was dead code — declared on the annotation but never read anywhere. `DefaultBinder` (the only consumer of `@ConfigProperty`) reads `value()` and `hidden()`, never `advanced()`. No tests or public docs referenced it. This removes the unused member completely.

## Affected module
- `config` — `ConfigProperty` annotation (removed the `advanced()` method + its javadoc)

## Verification
- Searched the whole repo: the only references to `advanced()` were the annotation's own declaration/javadoc — no consumers, no test or doc mentions.
- `mvn -pl config -am test` → **BUILD SUCCESS**, 143 tests, 0 failures.

## Notes
`value()` and `hidden()` remain the supported `@ConfigProperty` attributes. This is a source-compatible removal only if no downstream code referenced `advanced()`; none does in this repo.