### PR TITLE
feat(config): wire @ConfigValue type-mismatch callback during reference resolution

### DIFF
--- a/config/src/main/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceErrorHandler.java
+++ b/config/src/main/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceErrorHandler.java
@@ -62,11 +62,14 @@ public interface ConfigReferenceErrorHandler {
     void onCircularReference(@NotNull ConfigCircularReferenceContext context);
 
     /**
-     * Called when the resolved value's type doesn't match the expected
-     * type of the target field.
+     * Called when a resolved reference value cannot be coerced into the
+     * scalar or primitive type expected by the target field (for example, a
+     * non-numeric resolved value bound to an {@code int} field).
      * <p>
-     * Note: The binder may still attempt type coercion after this method
-     * returns. This is called when the raw types are incompatible.
+     * The returned value is used in place of the resolved value (typically
+     * {@code null}, which binds the field to its default); the binder will then
+     * bind/coerce that fallback as usual. Implementations may also throw to
+     * abort binding.
      *
      * @param context context information about the type mismatch
      * @return a fallback value to use (typically null), or throw an exception

--- a/config/src/main/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolver.java
+++ b/config/src/main/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolver.java
@@ -27,11 +27,14 @@ import org.jetbrains.annotations.Nullable;
 import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
 import tech.guilhermekaua.spigotboot.config.reference.context.ConfigCircularReferenceContext;
 import tech.guilhermekaua.spigotboot.config.reference.context.ConfigReferenceNotFoundContext;
+import tech.guilhermekaua.spigotboot.config.reference.context.ConfigTypeMismatchContext;
 import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
 import tech.guilhermekaua.spigotboot.config.reference.key.ResolutionTarget;
 import tech.guilhermekaua.spigotboot.config.spigot.node.SnapshotConfigNode;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.*;
 
 /**
@@ -83,7 +86,29 @@ public class ConfigReferenceResolver {
             @NotNull ConfigNode node,
             @NotNull ReferenceKey sourceKey,
             @Nullable Field sourceField) {
-        return resolveIfReference(node, sourceKey, sourceField, new LinkedHashSet<>());
+        return resolveIfReference(node, sourceKey, sourceField, null);
+    }
+
+    /**
+     * Resolves a config node if it's a reference, checking the resolved value against
+     * an expected target type.
+     * <p>
+     * Behaves like {@link #resolveIfReference(ConfigNode, ReferenceKey, Field)}, but when
+     * {@code expectedType} is provided and the resolved value cannot be coerced into it,
+     * {@link ConfigReferenceErrorHandler#onTypeMismatch(ConfigTypeMismatchContext)} is invoked.
+     *
+     * @param node         the node to potentially resolve
+     * @param sourceKey    the key of the config containing this node
+     * @param sourceField  the field being bound (may be null)
+     * @param expectedType the expected target type, or null to skip the type-mismatch check
+     * @return the resolved node, or null if reference not found
+     */
+    public @Nullable ConfigNode resolveIfReference(
+            @NotNull ConfigNode node,
+            @NotNull ReferenceKey sourceKey,
+            @Nullable Field sourceField,
+            @Nullable Type expectedType) {
+        return resolveIfReference(node, sourceKey, sourceField, expectedType, new LinkedHashSet<>());
     }
 
     /**
@@ -92,6 +117,7 @@ public class ConfigReferenceResolver {
      * @param node            the node to potentially resolve
      * @param sourceKey       the key of the config containing this node
      * @param sourceField     the field being bound (may be null)
+     * @param expectedType    the expected target type, or null to skip the type-mismatch check
      * @param resolutionStack the stack of keys currently being resolved (for cycle detection)
      * @return the resolved node, or null if reference not found
      */
@@ -99,6 +125,7 @@ public class ConfigReferenceResolver {
             @NotNull ConfigNode node,
             @NotNull ReferenceKey sourceKey,
             @Nullable Field sourceField,
+            @Nullable Type expectedType,
             @NotNull Set<ResolutionTarget> resolutionStack) {
 
         if (!node.isScalar()) {
@@ -139,7 +166,113 @@ public class ConfigReferenceResolver {
         Set<ResolutionTarget> newStack = new LinkedHashSet<>(resolutionStack);
         newStack.add(target);
 
-        return deepResolve(targetNode, targetKey, newStack);
+        ConfigNode resolved = deepResolve(targetNode, targetKey, newStack);
+        return checkTypeMismatch(resolved, ref, sourceKey, sourceField, expectedType);
+    }
+
+    /**
+     * Verifies a resolved reference value against the expected target type.
+     * <p>
+     * When the resolved value is a scalar that cannot be coerced into the expected
+     * scalar/primitive type, {@link ConfigReferenceErrorHandler#onTypeMismatch} is
+     * invoked and its fallback value (typically null) is used instead.
+     *
+     * @param resolved     the resolved node (may be null)
+     * @param ref          the reference that produced the value
+     * @param sourceKey    the key of the config containing the reference
+     * @param sourceField  the field being bound (may be null)
+     * @param expectedType the expected target type, or null to skip the check
+     * @return the resolved node, the wrapped fallback value, or null
+     */
+    private @Nullable ConfigNode checkTypeMismatch(
+            @Nullable ConfigNode resolved,
+            @NotNull ConfigReference ref,
+            @NotNull ReferenceKey sourceKey,
+            @Nullable Field sourceField,
+            @Nullable Type expectedType) {
+
+        if (resolved == null || expectedType == null || !resolved.isScalar()) {
+            return resolved;
+        }
+
+        Class<?> expectedClass = rawClassOf(expectedType);
+        if (expectedClass == null || !isScalarTarget(expectedClass)) {
+            return resolved;
+        }
+
+        Object actualValue = resolved.raw();
+        if (actualValue == null || canCoerce(actualValue, expectedClass)) {
+            return resolved;
+        }
+
+        ConfigTypeMismatchContext ctx = new ConfigTypeMismatchContext(
+                sourceKey, sourceField, ref.getRawToken(), expectedType, actualValue.getClass(), actualValue);
+        Object fallback = errorHandler.onTypeMismatch(ctx);
+        if (fallback == null) {
+            return null;
+        }
+        return SnapshotConfigNode.of(fallback, resolved.path());
+    }
+
+    private static @Nullable Class<?> rawClassOf(@NotNull Type type) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        }
+        if (type instanceof ParameterizedType) {
+            Type raw = ((ParameterizedType) type).getRawType();
+            if (raw instanceof Class) {
+                return (Class<?>) raw;
+            }
+        }
+        return null;
+    }
+
+    // only primitives and java.lang scalar wrappers are coerced by the binder via
+    // ConfigNode#get; complex types, collections, and enums use other binding paths
+    private static boolean isScalarTarget(@NotNull Class<?> type) {
+        return type.isPrimitive() || type.getName().startsWith("java.lang.");
+    }
+
+    // mirrors AbstractValueConfigNode#get coercion rules so detection is independent
+    // of the concrete ConfigNode implementation
+    private static boolean canCoerce(@NotNull Object value, @NotNull Class<?> targetType) {
+        if (targetType.isInstance(value)) {
+            return true;
+        }
+        if (targetType == String.class || targetType == CharSequence.class || targetType == Object.class) {
+            return true;
+        }
+        if (targetType == Boolean.class || targetType == boolean.class) {
+            return true;
+        }
+        if (isNumericType(targetType)) {
+            return value instanceof Number || canParseNumber(String.valueOf(value), targetType);
+        }
+        return false;
+    }
+
+    private static boolean isNumericType(@NotNull Class<?> type) {
+        return type == Integer.class || type == int.class
+                || type == Long.class || type == long.class
+                || type == Double.class || type == double.class
+                || type == Float.class || type == float.class;
+    }
+
+    private static boolean canParseNumber(@NotNull String value, @NotNull Class<?> targetType) {
+        try {
+            if (targetType == Integer.class || targetType == int.class) {
+                Integer.valueOf(value);
+            } else if (targetType == Long.class || targetType == long.class) {
+                Long.valueOf(value);
+            } else if (targetType == Double.class || targetType == double.class) {
+                Double.valueOf(value);
+            } else if (targetType == Float.class || targetType == float.class) {
+                Float.valueOf(value);
+            }
+            return true;
+        } catch (NumberFormatException e) {
+            return false;
+        }
     }
 
     /**
@@ -176,7 +309,7 @@ public class ConfigReferenceResolver {
         }
 
         if (node.isScalar()) {
-            ConfigNode resolved = resolveIfReference(node, sourceKey, null, resolutionStack);
+            ConfigNode resolved = resolveIfReference(node, sourceKey, null, null, resolutionStack);
             return resolved != null ? resolved : node;
         }
 

--- a/config/src/main/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolver.java
+++ b/config/src/main/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolver.java
@@ -227,26 +227,28 @@ public class ConfigReferenceResolver {
         return null;
     }
 
-    // only primitives and java.lang scalar wrappers are coerced by the binder via
-    // ConfigNode#get; complex types, collections, and enums use other binding paths
+    // only primitives and java.lang scalar wrappers are coerced by the built-in
+    // scalar serializers; complex types, collections, and enums use other binding paths
     private static boolean isScalarTarget(@NotNull Class<?> type) {
         return type.isPrimitive() || type.getName().startsWith("java.lang.");
     }
 
-    // mirrors AbstractValueConfigNode#get coercion rules so detection is independent
-    // of the concrete ConfigNode implementation
+    // mirrors the built-in scalar serializers (see PrimitiveSerializers) so detection
+    // matches how the binder actually coerces these targets
     private static boolean canCoerce(@NotNull Object value, @NotNull Class<?> targetType) {
         if (targetType.isInstance(value)) {
             return true;
         }
-        if (targetType == String.class || targetType == CharSequence.class || targetType == Object.class) {
-            return true;
-        }
-        if (targetType == Boolean.class || targetType == boolean.class) {
+        // String/CharSequence accept any value (String.valueOf); boolean parsing is lenient;
+        // char takes the first character of any non-empty scalar, so it never fails to coerce
+        if (targetType == String.class || targetType == CharSequence.class || targetType == Object.class
+                || targetType == Boolean.class || targetType == boolean.class
+                || targetType == Character.class || targetType == char.class) {
             return true;
         }
         if (isNumericType(targetType)) {
-            return value instanceof Number || canParseNumber(String.valueOf(value), targetType);
+            // numeric serializers accept any Number and trim string values before parsing
+            return value instanceof Number || canParseNumber(String.valueOf(value).trim(), targetType);
         }
         return false;
     }
@@ -255,19 +257,25 @@ public class ConfigReferenceResolver {
         return type == Integer.class || type == int.class
                 || type == Long.class || type == long.class
                 || type == Double.class || type == double.class
-                || type == Float.class || type == float.class;
+                || type == Float.class || type == float.class
+                || type == Short.class || type == short.class
+                || type == Byte.class || type == byte.class;
     }
 
     private static boolean canParseNumber(@NotNull String value, @NotNull Class<?> targetType) {
         try {
             if (targetType == Integer.class || targetType == int.class) {
-                Integer.valueOf(value);
+                Integer.parseInt(value);
             } else if (targetType == Long.class || targetType == long.class) {
-                Long.valueOf(value);
+                Long.parseLong(value);
             } else if (targetType == Double.class || targetType == double.class) {
-                Double.valueOf(value);
+                Double.parseDouble(value);
             } else if (targetType == Float.class || targetType == float.class) {
-                Float.valueOf(value);
+                Float.parseFloat(value);
+            } else if (targetType == Short.class || targetType == short.class) {
+                Short.parseShort(value);
+            } else if (targetType == Byte.class || targetType == byte.class) {
+                Byte.parseByte(value);
             }
             return true;
         } catch (NumberFormatException e) {

--- a/config/src/test/java/tech/guilhermekaua/spigotboot/config/binding/BinderReferenceIntegrationTest.java
+++ b/config/src/test/java/tech/guilhermekaua/spigotboot/config/binding/BinderReferenceIntegrationTest.java
@@ -193,6 +193,25 @@ class BinderReferenceIntegrationTest {
         }
 
         @Test
+        @DisplayName("fires onTypeMismatch when a reference resolves to a value incompatible with the field")
+        void firesTypeMismatchForIncompatibleReference() {
+            lookup.addConfig("label", "not a number");
+
+            Map<String, Object> data = new HashMap<>();
+            data.put("count", "${label}");
+
+            ConfigNode node = testNode(data);
+            BindingResult<ConfigWithInt> result = binder.bind(node, ConfigWithInt.class, NamingStrategy.IDENTITY);
+
+            assertTrue(errorHandler.typeMismatchCalled);
+            assertEquals("${label}", errorHandler.typeMismatchContext.getFullReference());
+            assertEquals(String.class, errorHandler.typeMismatchContext.getActualType());
+            // default handler returns null, so the incompatible value binds to the field default (no crash)
+            assertTrue(result.isSuccess());
+            assertEquals(0, result.get().getCount());
+        }
+
+        @Test
         @DisplayName("resolves reference inside list element")
         void resolvesReferenceInsideListElement() {
             lookup.addConfig("other", "resolved value");
@@ -270,7 +289,9 @@ class BinderReferenceIntegrationTest {
             if (value == null || !resolver.isReference(value)) {
                 return null;
             }
-            return resolver.resolveIfReference(node, ReferenceKey.singleConfig("test"), field);
+            ConfigNode resolved = resolver.resolveIfReference(node, ReferenceKey.singleConfig("test"), field, expectedType);
+            // mirror the production preprocessor: a null resolution binds to a null node, not the raw "${...}" string
+            return resolved != null ? resolved : new TestConfigNode(null);
         }
     }
 

--- a/config/src/test/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolverTest.java
+++ b/config/src/test/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolverTest.java
@@ -519,6 +519,46 @@ class ConfigReferenceResolverTest {
         }
 
         @Test
+        @DisplayName("does not call onTypeMismatch for a whitespace-padded numeric string")
+        void doesNotCallForWhitespacePaddedNumericString() {
+            // the numeric serializers trim before parsing, so " 5 " binds successfully
+            lookup.addConfig("count", "  5  ");
+
+            ConfigNode node = testNode("${count}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            resolver.resolveIfReference(node, sourceKey, null, Integer.class);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+        }
+
+        @Test
+        @DisplayName("does not call onTypeMismatch for short and byte targets the binder can coerce")
+        void doesNotCallForShortAndByteTargets() {
+            lookup.addConfig("small", 1);
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            resolver.resolveIfReference(testNode("${small}"), sourceKey, null, Short.class);
+            resolver.resolveIfReference(testNode("${small}"), sourceKey, null, Byte.class);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+        }
+
+        @Test
+        @DisplayName("does not call onTypeMismatch for a char target")
+        void doesNotCallForCharTarget() {
+            // the character serializer takes the first character of any non-empty value
+            lookup.addConfig("letter", "x");
+
+            ConfigNode node = testNode("${letter}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            resolver.resolveIfReference(node, sourceKey, null, Character.class);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+        }
+
+        @Test
         @DisplayName("uses the handler fallback value when one is returned")
         void usesHandlerFallbackValue() {
             TrackingConfigReferenceErrorHandler fallbackHandler = new TrackingConfigReferenceErrorHandler() {
@@ -546,7 +586,6 @@ class ConfigReferenceResolverTest {
         return new TestConfigNode(value);
     }
 
-    public static class SamplePojo {
-        private String name;
+    private static final class SamplePojo {
     }
 }

--- a/config/src/test/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolverTest.java
+++ b/config/src/test/java/tech/guilhermekaua/spigotboot/config/reference/ConfigReferenceResolverTest.java
@@ -22,12 +22,14 @@
  */
 package tech.guilhermekaua.spigotboot.config.reference;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.context.ConfigTypeMismatchContext;
 import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
 import tech.guilhermekaua.spigotboot.config.test.TestConfigNode;
 import tech.guilhermekaua.spigotboot.config.test.TestConfigReferenceLookup;
@@ -421,7 +423,130 @@ class ConfigReferenceResolverTest {
         }
     }
 
+    @Nested
+    @DisplayName("type mismatch")
+    class TypeMismatch {
+
+        @Test
+        @DisplayName("calls onTypeMismatch when resolved scalar cannot coerce to expected type")
+        void callsOnTypeMismatchForIncompatibleScalar() {
+            lookup.addConfig("label", "not a number");
+
+            ConfigNode node = testNode("${label}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            ConfigNode result = resolver.resolveIfReference(node, sourceKey, null, Integer.class);
+
+            assertNull(result);
+            assertTrue(errorHandler.typeMismatchCalled);
+            assertEquals("${label}", errorHandler.typeMismatchContext.getFullReference());
+            assertEquals(Integer.class, errorHandler.typeMismatchContext.getExpectedType());
+            assertEquals(String.class, errorHandler.typeMismatchContext.getActualType());
+            assertEquals("not a number", errorHandler.typeMismatchContext.getActualValue());
+        }
+
+        @Test
+        @DisplayName("does not call onTypeMismatch when resolved scalar matches expected type")
+        void doesNotCallForMatchingScalar() {
+            lookup.addConfig("count", 42);
+
+            ConfigNode node = testNode("${count}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            ConfigNode result = resolver.resolveIfReference(node, sourceKey, null, Integer.class);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+            assertEquals(42, result.get(Integer.class));
+        }
+
+        @Test
+        @DisplayName("does not call onTypeMismatch when scalar string is coercible to expected type")
+        void doesNotCallForCoercibleNumericString() {
+            lookup.addConfig("count", "5");
+
+            ConfigNode node = testNode("${count}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            ConfigNode result = resolver.resolveIfReference(node, sourceKey, null, Integer.class);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+            assertEquals("5", result.raw());
+        }
+
+        @Test
+        @DisplayName("does not call onTypeMismatch when expected type is null")
+        void doesNotCallForUntypedResolution() {
+            lookup.addConfig("label", "not a number");
+
+            ConfigNode node = testNode("${label}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            ConfigNode result = resolver.resolveIfReference(node, sourceKey, null, null);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+            assertEquals("not a number", result.get(String.class));
+        }
+
+        @Test
+        @DisplayName("does not call onTypeMismatch when expected type is a complex (non-scalar) type")
+        void doesNotCallForComplexExpectedType() {
+            lookup.addConfig("label", "text");
+
+            ConfigNode node = testNode("${label}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            // a user-defined type is bound through the binder's recursive path, not scalar coercion
+            ConfigNode result = resolver.resolveIfReference(node, sourceKey, null, SamplePojo.class);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+            assertEquals("text", result.get(String.class));
+        }
+
+        @Test
+        @DisplayName("does not call onTypeMismatch when resolved value is not a scalar")
+        void doesNotCallForNonScalarResolvedValue() {
+            Map<String, Object> data = new HashMap<>();
+            data.put("name", "sword");
+            lookup.addConfig("item", data);
+
+            ConfigNode node = testNode("${item}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            ConfigNode result = resolver.resolveIfReference(node, sourceKey, null, Integer.class);
+
+            assertFalse(errorHandler.typeMismatchCalled);
+            assertTrue(result.isMap());
+        }
+
+        @Test
+        @DisplayName("uses the handler fallback value when one is returned")
+        void usesHandlerFallbackValue() {
+            TrackingConfigReferenceErrorHandler fallbackHandler = new TrackingConfigReferenceErrorHandler() {
+                @Override
+                public @Nullable Object onTypeMismatch(@NotNull ConfigTypeMismatchContext context) {
+                    super.onTypeMismatch(context);
+                    return 7;
+                }
+            };
+            ConfigReferenceResolver fallbackResolver = new ConfigReferenceResolver(lookup, parser, fallbackHandler);
+            lookup.addConfig("label", "not a number");
+
+            ConfigNode node = testNode("${label}");
+            ReferenceKey sourceKey = ReferenceKey.singleConfig("myconfig");
+
+            ConfigNode result = fallbackResolver.resolveIfReference(node, sourceKey, null, Integer.class);
+
+            assertTrue(fallbackHandler.typeMismatchCalled);
+            assertNotNull(result);
+            assertEquals(7, result.get(Integer.class));
+        }
+    }
+
     private ConfigNode testNode(@Nullable Object value) {
         return new TestConfigNode(value);
+    }
+
+    public static class SamplePojo {
+        private String name;
     }
 }

--- a/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/reference/ReferenceResolvingPreprocessor.java
+++ b/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/reference/ReferenceResolvingPreprocessor.java
@@ -112,7 +112,7 @@ public class ReferenceResolvingPreprocessor implements ConfigNodePreprocessor {
             sourceKey = ReferenceKey.singleConfig("unknown");
         }
 
-        ConfigNode resolved = resolver.resolveIfReference(node, sourceKey, field);
+        ConfigNode resolved = resolver.resolveIfReference(node, sourceKey, field, expectedType);
 
         // if resolver returns null, it means the reference was not found
         // we must return a "null node" (not java null) so the binder binds to null.

--- a/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/reference/ReferenceResolvingPreprocessorTest.java
+++ b/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/reference/ReferenceResolvingPreprocessorTest.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.spigot.test.reference;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceErrorHandler;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceLookup;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceParser;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceResolver;
+import tech.guilhermekaua.spigotboot.config.reference.context.ConfigCircularReferenceContext;
+import tech.guilhermekaua.spigotboot.config.reference.context.ConfigReferenceNotFoundContext;
+import tech.guilhermekaua.spigotboot.config.reference.context.ConfigTypeMismatchContext;
+import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
+import tech.guilhermekaua.spigotboot.config.spigot.node.YamlConfigNode;
+import tech.guilhermekaua.spigotboot.config.spigot.reference.ReferenceResolvingPreprocessor;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ReferenceResolvingPreprocessor")
+class ReferenceResolvingPreprocessorTest {
+
+    @Test
+    @DisplayName("passes the expected type to the resolver so onTypeMismatch fires")
+    void firesTypeMismatchWhenResolvedValueIncompatibleWithExpectedType() {
+        RecordingErrorHandler errorHandler = new RecordingErrorHandler();
+        ConfigReferenceResolver resolver = new ConfigReferenceResolver(
+                new SingleValueLookup("label", "not a number"),
+                new ConfigReferenceParser(),
+                errorHandler);
+
+        ReferenceResolvingPreprocessor preprocessor = new ReferenceResolvingPreprocessor(resolver);
+        preprocessor.setCurrentSourceKey(ReferenceKey.singleConfig("source"));
+
+        try {
+            ConfigNode input = new YamlConfigNode("${label}");
+            preprocessor.preprocess(input, null, Integer.class);
+        } finally {
+            preprocessor.clearCurrentSourceKey();
+        }
+
+        assertTrue(errorHandler.typeMismatchCalled);
+        assertEquals("${label}", errorHandler.typeMismatchContext.getFullReference());
+        assertEquals(Integer.class, errorHandler.typeMismatchContext.getExpectedType());
+    }
+
+    /**
+     * minimal lookup that resolves a single root config name to a scalar value.
+     */
+    private static final class SingleValueLookup implements ConfigReferenceLookup {
+
+        private final String configName;
+        private final Object value;
+
+        private SingleValueLookup(String configName, Object value) {
+            this.configName = configName;
+            this.value = value;
+        }
+
+        @Override
+        public @Nullable ConfigNode findSingleConfigRoot(@NotNull String configName) {
+            return this.configName.equals(configName) ? new YamlConfigNode(value) : null;
+        }
+
+        @Override
+        public @Nullable ConfigNode findSingleConfigPath(@NotNull String configName, @NotNull String path) {
+            return null;
+        }
+
+        @Override
+        public @Nullable ConfigNode findFolderConfigItemRoot(@NotNull String folderConfigName, @NotNull String itemId) {
+            return null;
+        }
+
+        @Override
+        public @Nullable ConfigNode findFolderConfigItemPath(@NotNull String folderConfigName, @NotNull String itemId, @NotNull String path) {
+            return null;
+        }
+
+        @Override
+        public @NotNull Set<String> getAvailableConfigNames() {
+            return Collections.singleton(configName);
+        }
+
+        @Override
+        public @NotNull Set<String> getAvailableFolderConfigNames() {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public @NotNull Set<String> getAvailableItemIds(@NotNull String folderConfigName) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public @NotNull Set<String> getAvailableKeysAt(@NotNull String configName, @Nullable String path) {
+            return Collections.emptySet();
+        }
+
+        @Override
+        public boolean hasConfig(@NotNull String configName) {
+            return this.configName.equals(configName);
+        }
+
+        @Override
+        public boolean hasFolderConfig(@NotNull String folderConfigName) {
+            return false;
+        }
+
+        @Override
+        public boolean hasFolderConfigItem(@NotNull String folderConfigName, @NotNull String itemId) {
+            return false;
+        }
+    }
+
+    private static final class RecordingErrorHandler implements ConfigReferenceErrorHandler {
+
+        private boolean typeMismatchCalled;
+        private ConfigTypeMismatchContext typeMismatchContext;
+
+        @Override
+        public @Nullable Object onReferenceNotFound(@NotNull ConfigReferenceNotFoundContext context) {
+            return null;
+        }
+
+        @Override
+        public void onCircularReference(@NotNull ConfigCircularReferenceContext context) {
+        }
+
+        @Override
+        public @Nullable Object onTypeMismatch(@NotNull ConfigTypeMismatchContext context) {
+            this.typeMismatchCalled = true;
+            this.typeMismatchContext = context;
+            return null;
+        }
+    }
+}

--- a/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/reference/ReferenceResolvingPreprocessorTest.java
+++ b/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/reference/ReferenceResolvingPreprocessorTest.java
@@ -22,40 +22,43 @@
  */
 package tech.guilhermekaua.spigotboot.config.spigot.test.reference;
 
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
 import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceErrorHandler;
 import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceLookup;
 import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceParser;
 import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceResolver;
-import tech.guilhermekaua.spigotboot.config.reference.context.ConfigCircularReferenceContext;
-import tech.guilhermekaua.spigotboot.config.reference.context.ConfigReferenceNotFoundContext;
 import tech.guilhermekaua.spigotboot.config.reference.context.ConfigTypeMismatchContext;
 import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
 import tech.guilhermekaua.spigotboot.config.spigot.node.YamlConfigNode;
 import tech.guilhermekaua.spigotboot.config.spigot.reference.ReferenceResolvingPreprocessor;
 
-import java.util.Collections;
-import java.util.Set;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayName("ReferenceResolvingPreprocessor")
 class ReferenceResolvingPreprocessorTest {
+
+    @Mock
+    private ConfigReferenceLookup lookup;
+
+    @Mock
+    private ConfigReferenceErrorHandler errorHandler;
 
     @Test
     @DisplayName("passes the expected type to the resolver so onTypeMismatch fires")
     void firesTypeMismatchWhenResolvedValueIncompatibleWithExpectedType() {
-        RecordingErrorHandler errorHandler = new RecordingErrorHandler();
-        ConfigReferenceResolver resolver = new ConfigReferenceResolver(
-                new SingleValueLookup("label", "not a number"),
-                new ConfigReferenceParser(),
-                errorHandler);
+        when(lookup.resolve(any())).thenReturn(new YamlConfigNode("not a number"));
 
+        ConfigReferenceResolver resolver = new ConfigReferenceResolver(lookup, new ConfigReferenceParser(), errorHandler);
         ReferenceResolvingPreprocessor preprocessor = new ReferenceResolvingPreprocessor(resolver);
         preprocessor.setCurrentSourceKey(ReferenceKey.singleConfig("source"));
 
@@ -66,99 +69,9 @@ class ReferenceResolvingPreprocessorTest {
             preprocessor.clearCurrentSourceKey();
         }
 
-        assertTrue(errorHandler.typeMismatchCalled);
-        assertEquals("${label}", errorHandler.typeMismatchContext.getFullReference());
-        assertEquals(Integer.class, errorHandler.typeMismatchContext.getExpectedType());
-    }
-
-    /**
-     * minimal lookup that resolves a single root config name to a scalar value.
-     */
-    private static final class SingleValueLookup implements ConfigReferenceLookup {
-
-        private final String configName;
-        private final Object value;
-
-        private SingleValueLookup(String configName, Object value) {
-            this.configName = configName;
-            this.value = value;
-        }
-
-        @Override
-        public @Nullable ConfigNode findSingleConfigRoot(@NotNull String configName) {
-            return this.configName.equals(configName) ? new YamlConfigNode(value) : null;
-        }
-
-        @Override
-        public @Nullable ConfigNode findSingleConfigPath(@NotNull String configName, @NotNull String path) {
-            return null;
-        }
-
-        @Override
-        public @Nullable ConfigNode findFolderConfigItemRoot(@NotNull String folderConfigName, @NotNull String itemId) {
-            return null;
-        }
-
-        @Override
-        public @Nullable ConfigNode findFolderConfigItemPath(@NotNull String folderConfigName, @NotNull String itemId, @NotNull String path) {
-            return null;
-        }
-
-        @Override
-        public @NotNull Set<String> getAvailableConfigNames() {
-            return Collections.singleton(configName);
-        }
-
-        @Override
-        public @NotNull Set<String> getAvailableFolderConfigNames() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public @NotNull Set<String> getAvailableItemIds(@NotNull String folderConfigName) {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public @NotNull Set<String> getAvailableKeysAt(@NotNull String configName, @Nullable String path) {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public boolean hasConfig(@NotNull String configName) {
-            return this.configName.equals(configName);
-        }
-
-        @Override
-        public boolean hasFolderConfig(@NotNull String folderConfigName) {
-            return false;
-        }
-
-        @Override
-        public boolean hasFolderConfigItem(@NotNull String folderConfigName, @NotNull String itemId) {
-            return false;
-        }
-    }
-
-    private static final class RecordingErrorHandler implements ConfigReferenceErrorHandler {
-
-        private boolean typeMismatchCalled;
-        private ConfigTypeMismatchContext typeMismatchContext;
-
-        @Override
-        public @Nullable Object onReferenceNotFound(@NotNull ConfigReferenceNotFoundContext context) {
-            return null;
-        }
-
-        @Override
-        public void onCircularReference(@NotNull ConfigCircularReferenceContext context) {
-        }
-
-        @Override
-        public @Nullable Object onTypeMismatch(@NotNull ConfigTypeMismatchContext context) {
-            this.typeMismatchCalled = true;
-            this.typeMismatchContext = context;
-            return null;
-        }
+        ArgumentCaptor<ConfigTypeMismatchContext> captor = ArgumentCaptor.forClass(ConfigTypeMismatchContext.class);
+        verify(errorHandler).onTypeMismatch(captor.capture());
+        assertEquals("${label}", captor.getValue().getFullReference());
+        assertEquals(Integer.class, captor.getValue().getExpectedType());
     }
 }


### PR DESCRIPTION
## Why

`ConfigReferenceErrorHandler.onTypeMismatch` + `ConfigTypeMismatchContext` were defined and unit-tested (`DefaultConfigReferenceErrorHandlerTest`), but **no production code path ever constructed the context or invoked the callback** — so it never fired at runtime.

Root cause (two gaps):
- `ConfigReferenceResolver` reported only **not-found** and **circular** errors; it had no notion of the expected target type, so it could not detect a mismatch.
- `ReferenceResolvingPreprocessor` knew the expected field type (`preprocess(node, field, expectedType)`) but dropped it, calling the resolver's 3-arg `resolveIfReference` without the type.

Consequently a reference resolving to a value incompatible with a scalar/primitive field either bound to `null` silently or threw `NumberFormatException` from the binder's coercion (`AbstractValueConfigNode.get`).

## What changed

- **`ConfigReferenceResolver`** — new `resolveIfReference(node, sourceKey, field, expectedType)` overload; after resolution, `checkTypeMismatch` fires `onTypeMismatch` when a resolved **scalar** cannot be coerced into the expected **scalar/primitive** type, and uses the handler's fallback (default `null`) in place of the resolved value. Coercion rules mirror `AbstractValueConfigNode` and are independent of the concrete `ConfigNode` implementation. Complex types, collections, and enums (bound via other paths) are intentionally **not** flagged.
- **`ReferenceResolvingPreprocessor`** — passes the expected type through to the resolver (the actual runtime wiring).
- **`ConfigReferenceErrorHandler`** — `onTypeMismatch` Javadoc updated to match the implemented behavior.

Graceful degradation: on mismatch the field binds to the fallback (default null / field default) instead of crashing.

## Scope notes

- The existing 3-arg `resolveIfReference` is preserved (delegates with `null` expectedType), so `ConfigBackedCommandTextResolver` and other callers are unaffected.
- No javassist/shading surface touched.

## Test plan

- [x] `ConfigReferenceResolverTest` — mismatch fires; matching / coercible-numeric-string / untyped / complex-type / non-scalar cases do **not** fire; handler fallback value is used. (RED→GREEN verified)
- [x] `BinderReferenceIntegrationTest` — end-to-end binder→preprocessor→resolver fires `onTypeMismatch` and binds the field to its default without crashing. (RED→GREEN verified)
- [x] `ReferenceResolvingPreprocessorTest` (new) — proves the production preprocessor passes the expected type so the callback fires. (verified RED with wiring reverted, GREEN restored)
- [x] Full suites green: `spigot-boot-config` (151), `spigot-boot-config-spigot` (110), `spigot-boot-commands-config-spigot` (7), all upstream modules SUCCESS.