### PR TITLE
fix(config-spigot): bind Material config values to modern materials

### DIFF
--- a/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/MaterialSerializer.java
+++ b/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/MaterialSerializer.java
@@ -28,6 +28,7 @@ import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
 import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
 import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
 import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
+import tech.guilhermekaua.spigotboot.core.spigot.utils.TypeUtil;
 
 /**
  * Serializer for {@link Material} enum.
@@ -41,15 +42,12 @@ public class MaterialSerializer implements TypeSerializer<Material> {
             return null;
         }
 
-        try {
-            return Material.valueOf("LEGACY_" + value);
-        } catch (Exception e) {
-            try {
-                return Material.getMaterial(value);
-            } catch (Exception exception) {
-                throw new SerializationException("Unknown material: " + value);
-            }
+        // resolve the modern material first, falling back to a LEGACY_ name; see TypeUtil#getMaterialFromLegacy
+        Material material = TypeUtil.getMaterialFromLegacy(value);
+        if (material == null) {
+            throw new SerializationException("Unknown material: " + value);
         }
+        return material;
     }
 
     @Override

--- a/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/binding/ConfigEnumListBindingTest.java
+++ b/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/binding/ConfigEnumListBindingTest.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ * Copyright © 2026 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.spigot.test.binding;
+
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.config.spigot.SpigotConfigManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * reproduces binding of a {@code List} whose element type is an enum that has a
+ * registered {@link TypeSerializer}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConfigEnumListBindingTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private SpigotConfigManager configManager;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = Logger.getLogger(ConfigEnumListBindingTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+
+        TypeSerializerRegistryCustomizer colorSerializer =
+                registry -> registry.register(Color.class, new ColorSerializer());
+
+        configManager = new SpigotConfigManager(plugin, null, Collections.singletonList(colorSerializer));
+    }
+
+    @Test
+    void bindsScalarEnumWithRegisteredSerializer() throws IOException {
+        writeYaml("scalar.yml", "favorite: GREEN\n");
+        configManager.register(ScalarEnumConfig.class);
+        configManager.initializeAll();
+
+        ScalarEnumConfig config = configManager.get(ScalarEnumConfig.class);
+
+        assertEquals(Color.GREEN, config.getFavorite());
+    }
+
+    @Test
+    void bindsListOfEnumWithRegisteredSerializer() throws IOException {
+        writeYaml("list.yml", "palette:\n  - RED\n  - BLUE\n");
+        configManager.register(ListEnumConfig.class);
+        configManager.initializeAll();
+
+        ListEnumConfig config = configManager.get(ListEnumConfig.class);
+
+        assertEquals(Arrays.asList(Color.RED, Color.BLUE), config.getPalette());
+    }
+
+    private void writeYaml(String fileName, String content) throws IOException {
+        Files.writeString(tempDir.resolve(fileName), content);
+    }
+
+    public enum Color {
+        RED, GREEN, BLUE
+    }
+
+    /**
+     * simple serializer that maps a scalar string to a {@link Color} constant by name.
+     */
+    public static class ColorSerializer implements TypeSerializer<Color> {
+        @Override
+        public Color deserialize(ConfigNode node, Class<Color> type) {
+            String value = node.get(String.class);
+            return value == null ? null : Color.valueOf(value);
+        }
+
+        @Override
+        public void serialize(Color value, MutableConfigNode node) {
+            node.set(value.name());
+        }
+    }
+
+    @Config(value = "scalar.yml", name = "scalar", generateDefaults = false)
+    public static class ScalarEnumConfig {
+        private Color favorite = Color.RED;
+
+        public ScalarEnumConfig() {
+        }
+
+        public Color getFavorite() {
+            return favorite;
+        }
+    }
+
+    @Config(value = "list.yml", name = "list", generateDefaults = false)
+    public static class ListEnumConfig {
+        private List<Color> palette = new ArrayList<>();
+
+        public ListEnumConfig() {
+        }
+
+        public List<Color> getPalette() {
+            return palette;
+        }
+    }
+}

--- a/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/binding/MaterialSerializerBindingTest.java
+++ b/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/test/binding/MaterialSerializerBindingTest.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License
+ * Copyright © 2026 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.spigot.test.binding;
+
+import org.bukkit.Material;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.config.spigot.SpigotConfigManager;
+import tech.guilhermekaua.spigotboot.config.spigot.serialization.BukkitSerializers;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * reproduces the binding of {@link Material} values from config, both as a scalar field
+ * and as a {@code List<Material>}, using the built-in {@link BukkitSerializers}.
+ */
+@ExtendWith(MockitoExtension.class)
+class MaterialSerializerBindingTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private SpigotConfigManager configManager;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = Logger.getLogger(MaterialSerializerBindingTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+
+        TypeSerializerRegistryCustomizer bukkit = BukkitSerializers::registerAll;
+        configManager = new SpigotConfigManager(plugin, null, Collections.singletonList(bukkit));
+    }
+
+    @Test
+    void bindsListOfMaterialFromNames() throws IOException {
+        writeYaml("mat.yml", "blacklisted_items:\n  - BEDROCK\n  - BAMBOO\n");
+        configManager.register(MaterialListConfig.class);
+        configManager.initializeAll();
+
+        MaterialListConfig config = configManager.get(MaterialListConfig.class);
+
+        assertEquals(Arrays.asList(Material.BEDROCK, Material.BAMBOO), config.getBlacklistedItems());
+    }
+
+    @Test
+    void bindsScalarMaterialFromName() throws IOException {
+        writeYaml("scalarmat.yml", "favorite: BEDROCK\n");
+        configManager.register(ScalarMaterialConfig.class);
+        configManager.initializeAll();
+
+        ScalarMaterialConfig config = configManager.get(ScalarMaterialConfig.class);
+
+        assertEquals(Material.BEDROCK, config.getFavorite());
+        assertFalse(config.getFavorite().isLegacy(), "expected a modern material, not a LEGACY_ one");
+    }
+
+    private void writeYaml(String fileName, String content) throws IOException {
+        Files.writeString(tempDir.resolve(fileName), content);
+    }
+
+    @Config(value = "mat.yml", name = "mat", generateDefaults = false)
+    public static class MaterialListConfig {
+        private List<Material> blacklistedItems = new ArrayList<>();
+
+        public MaterialListConfig() {
+        }
+
+        public List<Material> getBlacklistedItems() {
+            return blacklistedItems;
+        }
+    }
+
+    @Config(value = "scalarmat.yml", name = "scalarmat", generateDefaults = false)
+    public static class ScalarMaterialConfig {
+        private Material favorite;
+
+        public ScalarMaterialConfig() {
+        }
+
+        public Material getFavorite() {
+            return favorite;
+        }
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/TypeUtil.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/TypeUtil.java
@@ -38,14 +38,26 @@ public final class TypeUtil {
         }
     }
 
+    /**
+     * Resolves a {@link Material} from a config name, preferring the modern (non-legacy) material.
+     * <p>
+     * The modern name is tried first so that names such as {@code BEDROCK} resolve to
+     * {@link Material#BEDROCK} instead of {@code LEGACY_BEDROCK} on post-flattening servers (1.13+).
+     * Only when no modern material matches is a {@code LEGACY_}-prefixed lookup attempted, so that
+     * pre-1.13 names still resolve. On 1.8.8 (no {@code LEGACY_*} constants exist) the first lookup
+     * already returns the native material.
+     *
+     * @param materialName the material name from config, may be null or empty
+     * @return the resolved material, or null if the name is null, empty, or unknown
+     */
     public static Material getMaterialFromLegacy(String materialName) {
         if (materialName == null || materialName.equalsIgnoreCase("")) return null;
 
         try {
-            return Material.valueOf("LEGACY_" + materialName);
+            return Material.valueOf(materialName);
         } catch (Exception error) {
             try {
-                return Material.getMaterial(materialName);
+                return Material.valueOf("LEGACY_" + materialName);
             } catch (Exception exception) {
                 Logger.getGlobal().warning("Material " + materialName + " is invalid!");
                 return null;

--- a/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/test/utils/TypeUtilTest.java
+++ b/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/test/utils/TypeUtilTest.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License
+ * Copyright © 2026 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.test.utils;
+
+import org.bukkit.Material;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.utils.TypeUtil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class TypeUtilTest {
+
+    @Test
+    void getMaterialFromLegacy_resolvesModernMaterialNotLegacyVariant() {
+        Material material = TypeUtil.getMaterialFromLegacy("BEDROCK");
+
+        assertEquals(Material.BEDROCK, material);
+        assertFalse(material.isLegacy(), "expected the modern BEDROCK, not LEGACY_BEDROCK");
+    }
+
+    @Test
+    void getMaterialFromLegacy_resolvesModernOnlyMaterial() {
+        // BAMBOO has no LEGACY_ counterpart, so it only resolves via the modern lookup
+        assertEquals(Material.BAMBOO, TypeUtil.getMaterialFromLegacy("BAMBOO"));
+    }
+
+    @Test
+    void getMaterialFromLegacy_returnsNullForUnknownMaterial() {
+        assertNull(TypeUtil.getMaterialFromLegacy("DEFINITELY_NOT_A_MATERIAL"));
+    }
+
+    @Test
+    void getMaterialFromLegacy_returnsNullForNullOrEmpty() {
+        assertNull(TypeUtil.getMaterialFromLegacy(null));
+        assertNull(TypeUtil.getMaterialFromLegacy(""));
+    }
+}


### PR DESCRIPTION
## Problem
Binding `org.bukkit.Material` from config (e.g. `List<org.bukkit.Material>` like `blacklisted_items: [BEDROCK, BAMBOO]`) produced the wrong values. `MaterialSerializer.deserialize` tried `Material.valueOf("LEGACY_" + value)` **first**, so any name with a legacy counterpart (BEDROCK, STONE, DIRT, …) resolved to the deprecated `LEGACY_*` constant on post-flattening servers (1.13+). Legacy materials then throw `"Cannot use legacy material"` in many Bukkit APIs downstream.

`TypeUtil.getMaterialFromLegacy` (core-spigot) carried the identical bug.

## Investigation (TDD)
- The `List<enum>` binding machinery is **not** broken: a custom enum with a registered `TypeSerializer` binds correctly as `List`, `Set`, and nested. Without a serializer, scalar and list fail identically (no list-specific asymmetry).
- The only defect was the built-in Material name resolver.

## Fix
- **`TypeUtil.getMaterialFromLegacy`** (core-spigot): prefer the modern material (`Material.valueOf(name)`), fall back to `LEGACY_`-prefixed only when no modern match exists.
- **`MaterialSerializer.deserialize`** (config-spigot): delegate to `TypeUtil.getMaterialFromLegacy` (DRY) and throw `SerializationException` on unknown names.

### Cross-version
- **1.8.8**: no `LEGACY_*` constants exist, so the modern lookup returns the native material.
- **1.13+/1.21.x**: modern names resolve correctly (the fix); pre-1.13-only names still fall back to `LEGACY_`.
- `serialize()` already writes `value.name()`, so round-trips stay stable.

## Affected modules
- `platform-spigot/core-spigot` — `TypeUtil`
- `platform-spigot/config-spigot` — `MaterialSerializer`

## Test notes
- `MaterialSerializerBindingTest` — scalar `Material` and `List<Material>` bind to modern constants (was red before the fix).
- `TypeUtilTest` — `getMaterialFromLegacy` prefers modern, handles unknown/null.
- `ConfigEnumListBindingTest` — documents that `List<enum>` with a registered serializer works.
- Full suites green: utils 4 · core 309 · core-spigot 10 · config 143 · config-spigot 113.