### PR TITLE
feat: Folia scheduler abstraction + region-correct inventory views

### DIFF
--- a/docs/superpowers/plans/2026-06-14-folia-scheduler-compat.md
+++ b/docs/superpowers/plans/2026-06-14-folia-scheduler-compat.md
@@ -1,0 +1,1219 @@
+# Folia scheduler & region-correctness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the spigot-boot runtime Folia-safe — a platform-conditional scheduler abstraction, region-correct inventory views, Folia-correct `Utils` helpers, and a cross-version `Sound` serializer — without regressing legacy Spigot/Paper support.
+
+**Architecture:** A new `PlatformScheduler` abstraction in `core-spigot` with two lazily-isolated impls (legacy `BukkitScheduler`; Folia/modern-Paper region/entity/global schedulers), selected once at startup like the existing `InventoryApiNMS` title-updater. inventory-api injects it and routes all scheduling + region-ownership checks through it. `Utils` helpers are redesigned to require a target. `SoundSerializer` is re-enabled with runtime branching for the enum→interface ABI change.
+
+**Tech Stack:** Java 8 source level, Maven (build with JDK 21 — `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10`), paper-api 1.20.1 (Folia scheduler API present), JUnit 5 + Mockito + MockBukkit (global test deps), animal-sniffer 1.8.8 signature check.
+
+**Spec:** `docs/superpowers/specs/2026-06-14-folia-scheduler-compat-design.md`
+
+**Build/test commands (run from repo root):**
+- Single module test: `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10 ./mvnw -pl platform-spigot/core-spigot -am test -Danimal.sniffer.skip=true`
+- Package test-plugin: `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10 ./mvnw -pl test-plugin -am package -Danimal.sniffer.skip=true`
+- Sniffer check (CI parity, run before final commit): drop `-Danimal.sniffer.skip=true`.
+
+**Branch:** `feat/folia-scheduler-compat` (already created; the prior load-time fixes are uncommitted in the working tree — commit them in Increment 0).
+
+---
+
+## File Structure
+
+**New (Increment 1):** under `platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/`
+- `PlatformScheduler.java` — interface (no version-specific refs)
+- `PlatformTask.java` — cancellable handle interface
+- `BukkitPlatformScheduler.java` — legacy `BukkitScheduler` impl
+- `BukkitPlatformTask.java` — wraps `org.bukkit.scheduler.BukkitTask`
+- `FoliaPlatformScheduler.java` — Folia/modern-Paper impl (reflective accessors + typed scheduler calls)
+- `FoliaPlatformTask.java` — wraps `io.papermc.paper.threadedregions.scheduler.ScheduledTask`
+- `PlatformSchedulers.java` — detection + factory
+- config: `platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/SpigotSchedulerConfiguration.java` — `@Bean`
+- test: `platform-spigot/core-spigot/src/test/java/.../scheduler/PlatformSchedulersTest.java`
+- modify: `platform-spigot/core-spigot/pom.xml` (animal-sniffer ignores)
+
+**Modified (Increment 2):** inventory-api/api — `ViewEngine`, `FirstRenderPhase`, `FlushCoordinator`, `ViewSession`, `PageRequest`, `AsyncPageSource`, `BukkitSettleDispatcher`, `ThreadUtils`, `InventoryApiAutoConfiguration` (+ wherever `PageRequest` is constructed).
+
+**Modified (Increment 3):** `core-spigot` `Utils.java` (+ a `SoundCompat` helper).
+
+**Modified (Increment 4):** config-spigot `SoundSerializer.java`, `BukkitSerializers.java`.
+
+---
+
+## Increment 0: Commit the load-time fixes
+
+### Task 0: Commit the already-validated load-time fixes
+
+**Files:** (already changed in working tree) `Plugin.java`, `PluginAnnotationProcessor.java`, `Main.java`, `InventoryApiNMS.java`, `InventoryApiNMSTest.java`.
+
+- [ ] **Step 1: Confirm tree state**
+
+Run: `git status --short`
+Expected: shows the 5 modified/added files above (plus untracked scratch logs in the Folia server dir, which are outside the repo).
+
+- [ ] **Step 2: Stage and commit only the source changes**
+
+```bash
+git add platform-spigot/annotation-processor/src/main/java/tech/guilhermekaua/spigotboot/spigot/annotationprocessor/annotations/Plugin.java \
+        platform-spigot/annotation-processor/src/main/java/tech/guilhermekaua/spigotboot/spigot/annotationprocessor/plugin/PluginAnnotationProcessor.java \
+        test-plugin/src/main/java/tech/guilhermekaua/spigotboot/testPlugin/Main.java \
+        platform-spigot/inventory-api/nms/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/nms/InventoryApiNMS.java \
+        platform-spigot/inventory-api/nms/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/nms/InventoryApiNMSTest.java
+git commit -m "fix(folia): generate folia-supported and select title updater on un-versioned servers"
+```
+
+---
+
+## Increment 1: PlatformScheduler abstraction
+
+### Task 1: `PlatformTask` and `PlatformScheduler` interfaces
+
+**Files:**
+- Create: `platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformTask.java`
+- Create: `platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java`
+
+- [ ] **Step 1: Create `PlatformTask`**
+
+```java
+/* <MIT license header — copy verbatim from any existing core-spigot file> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+/**
+ * A cancellable handle to a task scheduled through a {@link PlatformScheduler}. Abstracts over
+ * the legacy {@code BukkitTask} and the Folia {@code ScheduledTask} so callers can cancel a
+ * repeating task without referencing a platform-specific type.
+ */
+public interface PlatformTask {
+
+    /** Cancels the task; a no-op if it has already run or been cancelled. */
+    void cancel();
+
+    /**
+     * @return {@code true} if this task has been cancelled.
+     */
+    boolean isCancelled();
+}
+```
+
+- [ ] **Step 2: Create `PlatformScheduler`**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Platform-neutral scheduling. On Folia every task is bound to a region (an entity's, a
+ * location's, or the global region); on legacy Spigot/Paper all variants fall back to the
+ * single main thread. Obtain the configured instance by injecting this type.
+ *
+ * <p>Times are in server ticks (20 per second), matching the legacy scheduler.
+ */
+public interface PlatformScheduler {
+
+    /**
+     * Runs a task on the thread owning the entity's region (Folia) or the main thread (legacy).
+     *
+     * @param entity  the entity whose region owns the task
+     * @param task    the work to run
+     * @param retired run instead of {@code task} if the entity is removed before it fires
+     *                (Folia only); ignored on legacy
+     * @return a cancellable handle
+     */
+    @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired);
+
+    @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks);
+
+    @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks);
+
+    @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task);
+
+    @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks);
+
+    @NotNull PlatformTask runGlobal(@NotNull Runnable task);
+
+    @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks);
+
+    /**
+     * @return {@code true} if the current thread owns the entity's region (Folia) or is the
+     * main thread (legacy) — i.e. it is safe to touch the entity now.
+     */
+    boolean ownsRegion(@NotNull Entity entity);
+
+    boolean ownsRegion(@NotNull Location location);
+}
+```
+
+- [ ] **Step 3: Compile**
+
+Run: `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10 ./mvnw -pl platform-spigot/core-spigot -am compile -Danimal.sniffer.skip=true -o`
+Expected: BUILD SUCCESS (if `-o` offline fails on a missing artifact, drop `-o`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformTask.java \
+        platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java
+git commit -m "feat(scheduler): add PlatformScheduler and PlatformTask interfaces"
+```
+
+### Task 2: Legacy `BukkitPlatformScheduler` + `BukkitPlatformTask`
+
+**Files:**
+- Create: `.../scheduler/BukkitPlatformTask.java`
+- Create: `.../scheduler/BukkitPlatformScheduler.java`
+
+- [ ] **Step 1: Create `BukkitPlatformTask`**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+/** {@link PlatformTask} backed by a legacy {@link BukkitTask}. */
+final class BukkitPlatformTask implements PlatformTask {
+
+    private final BukkitTask task;
+
+    BukkitPlatformTask(@NotNull BukkitTask task) {
+        this.task = task;
+    }
+
+    @Override
+    public void cancel() {
+        task.cancel();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return task.isCancelled();
+    }
+}
+```
+
+- [ ] **Step 2: Create `BukkitPlatformScheduler`**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Legacy {@link PlatformScheduler}: every variant maps to {@link org.bukkit.scheduler.BukkitScheduler}
+ * and runs on the single main thread. {@code retired} callbacks have no legacy equivalent and are
+ * ignored. Selected on Spigot / Paper builds that lack the Folia scheduler API.
+ */
+public final class BukkitPlatformScheduler implements PlatformScheduler {
+
+    private final Plugin plugin;
+
+    public BukkitPlatformScheduler(@NotNull Plugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTask(plugin, task));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTask(plugin, task));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobal(@NotNull Runnable task) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTask(plugin, task));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Entity entity) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Location location) {
+        return Bukkit.isPrimaryThread();
+    }
+}
+```
+
+- [ ] **Step 3: Compile** — `JAVA_HOME=… ./mvnw -pl platform-spigot/core-spigot -am compile -Danimal.sniffer.skip=true` → BUILD SUCCESS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformTask.java \
+        platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformScheduler.java
+git commit -m "feat(scheduler): add legacy BukkitPlatformScheduler"
+```
+
+### Task 3: Folia `FoliaPlatformScheduler` + `FoliaPlatformTask` + animal-sniffer ignores
+
+**Files:**
+- Create: `.../scheduler/FoliaPlatformTask.java`
+- Create: `.../scheduler/FoliaPlatformScheduler.java`
+- Modify: `platform-spigot/core-spigot/pom.xml` (add scheduler-package ignores)
+
+**Rationale (read before coding):** the modern scheduler API exists in paper-api 1.20.1, so the scheduler-interface calls are typed. The 5 *accessors* on `org.bukkit.Bukkit`/`Entity` (`getRegionScheduler`, `getGlobalRegionScheduler`, `isOwnedByCurrentRegion(Entity)`, `isOwnedByCurrentRegion(Location)`, `Entity#getScheduler`) are reached via cached reflection so we do NOT have to add broad `org.bukkit.Bukkit`/`org.bukkit.entity.Entity` ignores to animal-sniffer (keeping the 1.8 net intact). Only the genuinely-new scheduler-package classes are ignored. This class is instantiated only when detection passes (Task 4), so legacy servers never load it.
+
+- [ ] **Step 1: Create `FoliaPlatformTask`**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.jetbrains.annotations.NotNull;
+
+/** {@link PlatformTask} backed by a Folia {@link ScheduledTask}. */
+final class FoliaPlatformTask implements PlatformTask {
+
+    private final ScheduledTask task;
+
+    FoliaPlatformTask(@NotNull ScheduledTask task) {
+        this.task = task;
+    }
+
+    @Override
+    public void cancel() {
+        task.cancel();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return task.isCancelled();
+    }
+}
+```
+
+- [ ] **Step 2: Create `FoliaPlatformScheduler`**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Folia / modern-Paper {@link PlatformScheduler}. Region/entity/global tasks land on the owning
+ * region thread. The scheduler accessors on {@link Bukkit}/{@link Entity} are invoked reflectively
+ * (so the 1.8.8 animal-sniffer net over {@code org.bukkit.*} stays intact); the scheduler
+ * interfaces themselves are used with normal typed calls. Instantiated only when the Folia
+ * scheduler API is present (see {@link PlatformSchedulers}).
+ */
+public final class FoliaPlatformScheduler implements PlatformScheduler {
+
+    private static final Method GET_REGION_SCHEDULER;
+    private static final Method GET_GLOBAL_SCHEDULER;
+    private static final Method IS_OWNED_ENTITY;
+    private static final Method IS_OWNED_LOCATION;
+    private static final Method ENTITY_GET_SCHEDULER;
+
+    static {
+        try {
+            GET_REGION_SCHEDULER = Bukkit.class.getMethod("getRegionScheduler");
+            GET_GLOBAL_SCHEDULER = Bukkit.class.getMethod("getGlobalRegionScheduler");
+            IS_OWNED_ENTITY = Bukkit.class.getMethod("isOwnedByCurrentRegion", Entity.class);
+            IS_OWNED_LOCATION = Bukkit.class.getMethod("isOwnedByCurrentRegion", Location.class);
+            ENTITY_GET_SCHEDULER = Entity.class.getMethod("getScheduler");
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Folia scheduler API expected but not found", e);
+        }
+    }
+
+    private final Plugin plugin;
+
+    public FoliaPlatformScheduler(@NotNull Plugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    private EntityScheduler entityScheduler(Entity entity) {
+        try {
+            return (EntityScheduler) ENTITY_GET_SCHEDULER.invoke(entity);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private RegionScheduler regionScheduler() {
+        try {
+            return (RegionScheduler) GET_REGION_SCHEDULER.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private GlobalRegionScheduler globalScheduler() {
+        try {
+            return (GlobalRegionScheduler) GET_GLOBAL_SCHEDULER.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired) {
+        return new FoliaPlatformTask(entityScheduler(entity).run(plugin, scheduled -> task.run(), retired));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks) {
+        return new FoliaPlatformTask(entityScheduler(entity).runDelayed(plugin, scheduled -> task.run(), retired, Math.max(1L, delayTicks)));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks) {
+        return new FoliaPlatformTask(entityScheduler(entity).runAtFixedRate(plugin, scheduled -> task.run(), retired, Math.max(1L, delayTicks), Math.max(1L, periodTicks)));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task) {
+        return new FoliaPlatformTask(regionScheduler().run(plugin, location, scheduled -> task.run()));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks) {
+        return new FoliaPlatformTask(regionScheduler().runDelayed(plugin, location, scheduled -> task.run(), Math.max(1L, delayTicks)));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobal(@NotNull Runnable task) {
+        return new FoliaPlatformTask(globalScheduler().run(plugin, scheduled -> task.run()));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks) {
+        return new FoliaPlatformTask(globalScheduler().runDelayed(plugin, scheduled -> task.run(), Math.max(1L, delayTicks)));
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Entity entity) {
+        try {
+            return (boolean) IS_OWNED_ENTITY.invoke(null, entity);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Location location) {
+        try {
+            return (boolean) IS_OWNED_LOCATION.invoke(null, location);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add animal-sniffer ignores** to `platform-spigot/core-spigot/pom.xml`. Find the existing block and extend it:
+
+Before:
+```xml
+                    <ignores combine.children="append">
+                        <ignore>org.bukkit.UnsafeValues</ignore>
+                    </ignores>
+```
+After:
+```xml
+                    <ignores combine.children="append">
+                        <ignore>org.bukkit.UnsafeValues</ignore>
+                        <!-- Folia scheduler API; referenced only by FoliaPlatformScheduler/FoliaPlatformTask,
+                             which load only when the API is present at runtime -->
+                        <ignore>io.papermc.paper.threadedregions.scheduler.EntityScheduler</ignore>
+                        <ignore>io.papermc.paper.threadedregions.scheduler.RegionScheduler</ignore>
+                        <ignore>io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler</ignore>
+                        <ignore>io.papermc.paper.threadedregions.scheduler.ScheduledTask</ignore>
+                    </ignores>
+```
+
+- [ ] **Step 4: Compile WITH the sniffer enabled** (proves the ignores are sufficient and no `org.bukkit.*` modern method leaked in typed):
+
+Run: `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10 ./mvnw -pl platform-spigot/core-spigot -am verify -DskipTests`
+Expected: BUILD SUCCESS, animal-sniffer passes. (If it flags an `org.bukkit.*` method, a typed modern call leaked — move it to a reflective accessor.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformTask.java \
+        platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformScheduler.java \
+        platform-spigot/core-spigot/pom.xml
+git commit -m "feat(scheduler): add Folia PlatformScheduler with reflective accessors"
+```
+
+### Task 4: `PlatformSchedulers` factory + detection (TDD)
+
+**Files:**
+- Create: `.../scheduler/PlatformSchedulers.java`
+- Test: `platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulersTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class PlatformSchedulersTest {
+
+    @Test
+    void selects_folia_scheduler_when_api_present() {
+        Plugin plugin = Mockito.mock(Plugin.class);
+        assertInstanceOf(FoliaPlatformScheduler.class, PlatformSchedulers.create(plugin, true));
+    }
+
+    @Test
+    void selects_bukkit_scheduler_when_api_absent() {
+        Plugin plugin = Mockito.mock(Plugin.class);
+        assertInstanceOf(BukkitPlatformScheduler.class, PlatformSchedulers.create(plugin, false));
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails** — Run: `JAVA_HOME=… ./mvnw -pl platform-spigot/core-spigot -am test -Dtest=PlatformSchedulersTest -Danimal.sniffer.skip=true` → FAIL (`PlatformSchedulers` not found).
+
+- [ ] **Step 3: Create `PlatformSchedulers`**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/** Detects the platform and builds the matching {@link PlatformScheduler}. */
+public final class PlatformSchedulers {
+
+    private static final String FOLIA_SCHEDULER_CLASS = "io.papermc.paper.threadedregions.scheduler.RegionScheduler";
+
+    private PlatformSchedulers() {
+    }
+
+    /**
+     * Builds the scheduler for the running server.
+     *
+     * @param plugin the owning plugin
+     * @return a Folia scheduler when the modern scheduler API is present, else a legacy one
+     */
+    public static @NotNull PlatformScheduler create(@NotNull Plugin plugin) {
+        return create(plugin, isFoliaSchedulerApiPresent());
+    }
+
+    // package-private seam so the branch is unit-testable without a live server
+    static @NotNull PlatformScheduler create(@NotNull Plugin plugin, boolean foliaApiPresent) {
+        Objects.requireNonNull(plugin, "plugin");
+        return foliaApiPresent ? new FoliaPlatformScheduler(plugin) : new BukkitPlatformScheduler(plugin);
+    }
+
+    static boolean isFoliaSchedulerApiPresent() {
+        try {
+            Class.forName(FOLIA_SCHEDULER_CLASS, false, PlatformSchedulers.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes** — same command as Step 2 → PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulers.java \
+        platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulersTest.java
+git commit -m "feat(scheduler): add PlatformSchedulers detection factory with tests"
+```
+
+### Task 5: DI bean
+
+**Files:**
+- Create: `.../scheduler/SpigotSchedulerConfiguration.java`
+
+- [ ] **Step 1: Create the configuration**
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Bean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.ConditionalOnMissingBean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Configuration;
+
+/**
+ * Registers the platform {@link PlatformScheduler}. Guarded by {@code @ConditionalOnMissingBean}
+ * so a plugin may register its own implementation.
+ */
+@Configuration
+public class SpigotSchedulerConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(PlatformScheduler.class)
+    public PlatformScheduler platformScheduler(Plugin plugin) {
+        return PlatformSchedulers.create(plugin);
+    }
+}
+```
+
+- [ ] **Step 2: Build the whole reactor up to test-plugin** (confirms discovery wiring + nothing else breaks):
+
+Run: `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10 ./mvnw -pl test-plugin -am package -Danimal.sniffer.skip=true`
+Expected: BUILD SUCCESS, all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/SpigotSchedulerConfiguration.java
+git commit -m "feat(scheduler): register PlatformScheduler bean"
+```
+
+---
+
+## Increment 2: inventory-api region-correctness
+
+> Inject `PlatformScheduler` into the engine, replace the 5 sync scheduler calls and the `isPrimaryThread`/`assertMainThread` guards. Keep these existing tests green throughout: `UpdateFlushTest`, `SharedStateFlowTest`, `PaginationSettleTest`, `ViewEngineOpenOrderingTest`, `BukkitSettleDispatcherTest`, `DeferredOpsTest`, `ViewServiceEndToEndTest`. Run the module test suite after each task: `JAVA_HOME=… ./mvnw -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true`.
+
+### Task 6: Region-aware `ThreadUtils`
+
+**Files:**
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/util/ThreadUtils.java`
+
+`ThreadUtils.assertMainThread` is static with no player. Add a region-aware overload that takes the scheduler + the entity; keep the old method delegating to `isPrimaryThread` semantics for callers without an entity (none after this increment, but harmless).
+
+- [ ] **Step 1: Add `assertOwnsRegion`**
+
+Add to `ThreadUtils` (keep the existing `assertMainThread`):
+```java
+import org.bukkit.entity.Entity;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
+```
+```java
+    /**
+     * Throws when the current thread does not own the entity's region.
+     *
+     * @param scheduler the platform scheduler used for the ownership check
+     * @param entity    the entity whose region must be owned (the viewer)
+     * @param operation the operation name used in the error message
+     * @throws IllegalStateException when the current thread does not own the entity's region
+     */
+    public static void assertOwnsRegion(@NotNull PlatformScheduler scheduler, @NotNull Entity entity, @NotNull String operation) {
+        if (!scheduler.ownsRegion(entity)) {
+            throw new IllegalStateException(operation + " must be called on the thread owning the viewer's region");
+        }
+    }
+```
+
+Note: `inventory-api/api` must depend on `core-spigot`. Verify in `platform-spigot/inventory-api/api/pom.xml`; if absent, add:
+```xml
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-core-spigot</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+```
+
+- [ ] **Step 2: Compile** — `JAVA_HOME=… ./mvnw -pl platform-spigot/inventory-api/api -am compile -Danimal.sniffer.skip=true` → SUCCESS.
+
+- [ ] **Step 3: Commit** — `git commit -am "feat(inventory): add region-aware ThreadUtils.assertOwnsRegion"`
+
+### Task 7: Inject `PlatformScheduler` into `ViewEngine`, `FirstRenderPhase`, `FlushCoordinator`
+
+**Files:**
+- Modify: `ViewEngine.java` (constructor + fields + pass-through to phases)
+- Modify: `FirstRenderPhase.java` (constructor)
+- Modify: `FlushCoordinator.java` (constructor)
+- Modify: `InventoryApiAutoConfiguration.java` if ViewEngine is built there (it is `@Component`; the container injects the `PlatformScheduler` bean automatically once it's a constructor param)
+
+- [ ] **Step 1: Add the field + constructor param to `ViewEngine`**
+
+In `ViewEngine.java` add import `import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;`, add field `private final PlatformScheduler scheduler;`, and extend the constructor:
+```java
+    public ViewEngine(@NotNull Plugin plugin, @NotNull ViewRegistry views, @NotNull SessionRegistry sessions,
+                      @NotNull SlotPainter painter, @NotNull TitleUpdater titleUpdater,
+                      @NotNull PlatformScheduler scheduler) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+        this.views = Objects.requireNonNull(views, "views");
+        this.sessions = Objects.requireNonNull(sessions, "sessions");
+        this.painter = Objects.requireNonNull(painter, "painter");
+        this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+        this.closePhase = new ClosePhase(this, sessions);
+        this.openPhase = new OpenPhase(this, sessions, painter);
+        this.firstRenderPhase = new FirstRenderPhase(this, sessions, painter);
+        this.updatePhase = new UpdatePhase(this, painter);
+        this.clickRoutingPhase = new ClickRoutingPhase(this);
+        this.paginationInitPhase = new PaginationInitPhase(this, sessions);
+        this.flushCoordinator = new FlushCoordinator(plugin, sessions, updatePhase, scheduler);
+    }
+```
+Add an accessor `public @NotNull PlatformScheduler scheduler() { return scheduler; }` next to `plugin()`.
+
+(`@Component` constructor injection resolves the new `PlatformScheduler` param from the bean registered in Increment 1, Task 5.)
+
+- [ ] **Step 2: Add scheduler to `FlushCoordinator`** — add field `private final PlatformScheduler scheduler;`, import it, and add the param to the constructor (assign with `Objects.requireNonNull`).
+
+- [ ] **Step 3: Build reactor + run inventory-api tests** — fix any other `new ViewEngine(...)` / `new FlushCoordinator(...)` call sites the compiler flags (test fixtures included) to pass a scheduler. For tests, pass `new BukkitPlatformScheduler(plugin)` or a Mockito mock.
+
+Run: `JAVA_HOME=… ./mvnw -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true`
+Expected: compile succeeds; tests pass (after updating fixtures).
+
+- [ ] **Step 4: Commit** — `git commit -am "refactor(inventory): inject PlatformScheduler into engine and flush coordinator"`
+
+### Task 8: Replace the `ViewEngine` scheduler calls + region guards
+
+**Files:** `ViewEngine.java`
+
+- [ ] **Step 1: `open` self-defer (line ~139)** — replace `Bukkit.getScheduler().runTask(plugin, () -> open(player, viewType, arguments));` with:
+```java
+                scheduler.runOnEntity(player, () -> open(player, viewType, arguments), null);
+```
+And replace the `ThreadUtils.assertMainThread("ViewEngine.open");` at the top of `open` with `ThreadUtils.assertOwnsRegion(scheduler, player, "ViewEngine.open");`.
+
+- [ ] **Step 2: `defer` drain (line ~345)** — replace `Bukkit.getScheduler().runTask(plugin, () -> drainDeferred(session));` with:
+```java
+        scheduler.runOnEntity(session.player(), () -> drainDeferred(session), null);
+```
+And replace `ThreadUtils.assertMainThread("ViewEngine.defer");` with `ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.defer");`.
+
+- [ ] **Step 3: Convert the remaining session-scoped guards** — in `close`, `updateTitle`, `update`, `paginationSettle`, `click`, `drag`, `bukkitClose`, `flushDirty`, replace `ThreadUtils.assertMainThread("ViewEngine.X")` with `ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.X")` (the `session` parameter is in scope in each).
+
+- [ ] **Step 4: `flushShared(View owner)` (no session in scope)** — this entry point operates on all sessions of a view across regions; a single assert is wrong. Remove its `assertMainThread` call and rely on the per-session dispatch added in Task 9 (the actual repaints will be region-checked there). Leave the method body otherwise unchanged for now.
+
+- [ ] **Step 5: Remove the now-unused `Bukkit` import if the compiler flags it** (only if no other `Bukkit.` use remains in the file).
+
+- [ ] **Step 6: Run inventory-api tests** — expect green. If a test asserted the old "must be called on the main server thread" message, update it to the new "must be called on the thread owning the viewer's region" message (search tests for that string).
+
+- [ ] **Step 7: Commit** — `git commit -am "refactor(inventory): route ViewEngine scheduling and guards through PlatformScheduler"`
+
+### Task 9: `FirstRenderPhase` timer + `ViewSession.updateTask` type
+
+**Files:** `FirstRenderPhase.java`, `ViewSession.java`
+
+- [ ] **Step 1: Change the `ViewSession` task type** — in `ViewSession.java` replace the `import org.bukkit.scheduler.BukkitTask;` with `import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;`, change the field `private BukkitTask updateTask;` to `private PlatformTask updateTask;`, and change both accessor signatures from `BukkitTask` to `PlatformTask`. Find where `updateTask()` is cancelled (search `updateTask()` usages, e.g. in `ClosePhase`/session teardown) — `task.cancel()` still compiles via `PlatformTask.cancel()`.
+
+- [ ] **Step 2: Change the timer in `FirstRenderPhase`** — replace the imports `org.bukkit.Bukkit` and `org.bukkit.scheduler.BukkitTask` (remove if now unused) and rewrite `startScheduledUpdates`:
+```java
+    private void startScheduledUpdates(ViewSession session) {
+        long interval = session.effectiveConfig().updateIntervalTicks();
+        if (interval <= 0) {
+            return;
+        }
+        PlatformTask task = engine.scheduler().runOnEntityAtFixedRate(session.player(),
+                new ViewUpdateTask(engine, session), null, interval, interval);
+        session.updateTask(task);
+    }
+```
+Add import `import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;`.
+
+- [ ] **Step 2b: `ViewUpdateTask`** — it currently implements `Runnable` (legacy timer passed it directly). Confirm it is a `Runnable` (the legacy `runTaskTimer` accepted it). `runOnEntityAtFixedRate` takes a `Runnable`, so no change. If `ViewUpdateTask` instead `extends BukkitRunnable`, change it to `implements Runnable` and keep its `run()` body.
+
+- [ ] **Step 3: Run inventory-api tests** — green (update any test that mocked a `BukkitTask` return to use `PlatformTask`).
+
+- [ ] **Step 4: Commit** — `git commit -am "refactor(inventory): schedule view update timer via PlatformTask"`
+
+### Task 10: `FlushCoordinator` per-session region-correct flush
+
+**Files:** `FlushCoordinator.java`
+
+The shared-state flush must repaint each open session of the owner on that session's region. Replace the `isPrimaryThread()` inline/scheduled split (lines ~162–195) and make `flushShared` dispatch per session.
+
+- [ ] **Step 1: Write/adjust the failing test** — extend `SharedStateFlowTest` (or add `FlushCoordinatorFoliaTest`) to inject a fake `PlatformScheduler` that records `runOnEntity` calls, trigger an off-region shared write, and assert one `runOnEntity(viewerPlayer, …)` is scheduled per active session of the owner (not a single global hop). Use the existing test's view/session setup as the template.
+
+- [ ] **Step 2: Rewrite `flushShared(View owner, Set<Integer> tokenIds)`** to dispatch each session on its own region:
+```java
+    private void flushShared(@NotNull View owner, @Nullable Set<Integer> tokenIds) {
+        // snapshot: an onUpdate handler may close a session and mutate the registry
+        List<ViewSession> snapshot = new ArrayList<>(sessions.all());
+        for (ViewSession session : snapshot) {
+            if (session.registered().instance() == owner && session.isActive()) {
+                final ViewSession target = session;
+                if (scheduler.ownsRegion(target.player())) {
+                    updatePhase.update(target, UpdateTrigger.STATE_CHANGE, tokenIds);
+                } else {
+                    scheduler.runOnEntity(target.player(),
+                            () -> updatePhase.update(target, UpdateTrigger.STATE_CHANGE, tokenIds), null);
+                }
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Replace the flush-hook `isPrimaryThread` branch** (lines ~162–195). The per-tick coalescing map stays (it dedups token ids per owner); the change is that draining no longer hops to one thread but goes through `flushShared`, which now fans out per session. Rewrite the `flushHook` body:
+```java
+            shared.flushHook(() -> {
+                if (scheduler.ownsRegion-any()) { /* see note */ }
+            });
+```
+Note: there is no "owns any region" concept. Replace the inline-vs-scheduled decision with: always coalesce the token id into `sharedFlushScheduled`, and when first-scheduled for the owner this tick, schedule the drain on the **global** region (it only reads the registry and re-dispatches per session — no world state touched), which then calls `flushShared` (Step 2 fans out per session). Concretely:
+```java
+            final int tokenIdFinal = tokenId;
+            shared.flushHook(() -> {
+                boolean[] schedule = {false};
+                sharedFlushScheduled.compute(owner, (key, existing) -> {
+                    if (existing == null) {
+                        Set<Integer> created = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
+                        created.add(tokenIdFinal);
+                        schedule[0] = true;
+                        return created;
+                    }
+                    existing.add(tokenIdFinal);
+                    return existing;
+                });
+                if (schedule[0]) {
+                    scheduler.runGlobal(() -> {
+                        Set<Integer> ids = sharedFlushScheduled.remove(owner);
+                        if (ids != null) {
+                            flushShared(owner, ids);
+                        }
+                    });
+                }
+            });
+```
+This drops the synchronous `sharedFlushPending` re-entrancy path; if `UpdateFlushTest`/`SharedStateFlowTest` depend on synchronous same-tick flush, keep an inline fast-path: `if (scheduler.ownsRegion(<the writing session's player>))` — but the hook has no session handle, so the global-scheduler drain is the uniform correct path. Verify against the tests in Step 4 and adjust their timing expectations (they may need to pump the fake scheduler).
+
+- [ ] **Step 4: Run inventory-api tests** — iterate until green. If `sessions.all()` is not safe to read off the owning region, confine the registry read to the global-region drain (already the case here). Keep `flushDirty` (single-session, called from a region-owning context) unchanged.
+
+- [ ] **Step 5: Commit** — `git commit -am "refactor(inventory): region-correct shared-state flush fan-out"`
+
+### Task 11: `PageRequest` viewer + `BukkitSettleDispatcher`
+
+**Files:** `PageRequest.java`, `BukkitSettleDispatcher.java`, `AsyncPageSource.java` (and any `new PageRequest(...)` call sites)
+
+- [ ] **Step 1: Add a viewer to `PageRequest`** — add `private final Player viewer;` (import `org.bukkit.entity.Player`), add it as the last constructor param, and add accessor:
+```java
+    public @Nullable Player viewer() {
+        return viewer;
+    }
+```
+Update the constructor Javadoc. Then fix every `new PageRequest(...)` call site the compiler flags (search `new PageRequest(`) to pass the viewer (the engine knows `session.player()`; tests may pass `null`).
+
+- [ ] **Step 2: Make `BukkitSettleDispatcher` region-aware** — it must now hop to the viewer's region via a `PlatformScheduler`. Add a constructor taking `PlatformScheduler` (the dispatcher is created by the engine/config — pass the bean). Rewrite `dispatch`:
+```java
+    private final PlatformScheduler scheduler;
+
+    public BukkitSettleDispatcher(@NotNull PlatformScheduler scheduler) {
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+    }
+
+    @Override
+    public void dispatch(PageRequest request, Runnable task) {
+        Player viewer = request.viewer();
+        if (viewer == null) {
+            // engine-external test usage: settle inline on the completing thread
+            task.run();
+            return;
+        }
+        if (scheduler.ownsRegion(viewer)) {
+            task.run();
+            return;
+        }
+        try {
+            scheduler.runOnEntity(viewer, task, null);
+        } catch (IllegalPluginAccessException e) {
+            // legacy: the owning plugin is disabling and the scheduler rejects new tasks
+            LOGGER.log(Level.WARNING, "Dropped a page-load settle: the owning plugin is disabled.", e);
+        }
+    }
+```
+Keep the existing `LOGGER`. Remove the old `request.plugin()`/`isPrimaryThread` logic. Update where `BukkitSettleDispatcher` is instantiated to pass the scheduler.
+
+- [ ] **Step 3: Run inventory-api tests** — update `BukkitSettleDispatcherTest` to construct with a fake/real `PlatformScheduler` and a `PageRequest` carrying a viewer; assert inline when `ownsRegion` is true and `runOnEntity` otherwise. Keep the null-viewer inline path test.
+
+- [ ] **Step 4: Commit** — `git commit -am "refactor(inventory): settle page loads on the viewer's region"`
+
+### Task 12: Increment 2 reactor build
+
+- [ ] **Step 1: Full build + tests** — `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10 ./mvnw -pl test-plugin -am package -Danimal.sniffer.skip=true` → BUILD SUCCESS, all tests pass.
+- [ ] **Step 2: Commit any remaining fixups** — `git commit -am "test(inventory): update fixtures for PlatformScheduler"` (if needed).
+
+---
+
+## Increment 3: Utils redesign
+
+### Task 13: `SoundCompat` cross-version sound resolver
+
+**Files:**
+- Create: `platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java`
+- Test: `platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompatTest.java`
+
+`org.bukkit.Sound` is an enum on paper-api 1.20.1 (compile) and ≤1.21.2 (runtime) but an interface on ≥1.21.3. Provide one resolver usable by both `Utils.playSound` and `SoundSerializer`.
+
+- [ ] **Step 1: Write the failing test** (enum path — the only one exercisable on the 1.20.1 test classpath):
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.utils;
+
+import org.bukkit.Sound;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SoundCompatTest {
+
+    @Test
+    void resolves_enum_sound_by_name() {
+        Sound sound = SoundCompat.resolve("ENTITY_PLAYER_LEVELUP");
+        assertNotNull(sound);
+    }
+
+    @Test
+    void serializes_enum_sound_to_its_name() {
+        Sound sound = SoundCompat.resolve("ENTITY_PLAYER_LEVELUP");
+        assertEquals("ENTITY_PLAYER_LEVELUP", SoundCompat.toKey(sound));
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails** — `JAVA_HOME=… ./mvnw -pl platform-spigot/core-spigot -am test -Dtest=SoundCompatTest -Danimal.sniffer.skip=true` → FAIL (no `SoundCompat`).
+
+- [ ] **Step 3: Implement `SoundCompat`** (reflection; no static refs to `Keyed`/`NamespacedKey`/`Registry` so it loads on 1.8.8):
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.core.spigot.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+
+/**
+ * Cross-version {@link Sound} resolution. {@code Sound} is an enum up to MC 1.21.2 and an
+ * interface (registry type) from 1.21.3 on; this resolves a sound from a config string and
+ * back without a compile-time assumption about its shape.
+ */
+public final class SoundCompat {
+
+    private SoundCompat() {
+    }
+
+    /**
+     * Resolves a sound from a config value — an enum constant name (e.g.
+     * {@code ENTITY_PLAYER_LEVELUP}) or a namespaced key (e.g. {@code minecraft:entity.player.levelup}).
+     *
+     * @param value the config value
+     * @return the resolved sound, or {@code null} if unknown
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static @Nullable Sound resolve(@NotNull String value) {
+        String trimmed = value.trim();
+        if (Sound.class.isEnum()) {
+            String name = trimmed.toUpperCase().replace('.', '_').replace(' ', '_').replace(':', '_');
+            // strip a namespace prefix like MINECRAFT_ if present
+            if (name.startsWith("MINECRAFT_")) {
+                name = name.substring("MINECRAFT_".length());
+            }
+            try {
+                return (Sound) Enum.valueOf((Class) Sound.class, name);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return resolveFromRegistry(trimmed);
+    }
+
+    /**
+     * Serializes a sound back to a stable config string: the enum name on enum builds, else the
+     * namespaced key (e.g. {@code minecraft:entity.player.levelup}).
+     *
+     * @param sound the sound
+     * @return the config string
+     */
+    public static @NotNull String toKey(@NotNull Sound sound) {
+        if (sound instanceof Enum) {
+            return ((Enum<?>) sound).name();
+        }
+        try {
+            Method getKey = sound.getClass().getMethod("getKey");
+            Object key = getKey.invoke(sound); // NamespacedKey
+            return String.valueOf(key);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("cannot read sound key", e);
+        }
+    }
+
+    private static @Nullable Sound resolveFromRegistry(String value) {
+        try {
+            Class<?> namespacedKey = Class.forName("org.bukkit.NamespacedKey");
+            Method fromString = namespacedKey.getMethod("fromString", String.class);
+            Object key = fromString.invoke(null, value.toLowerCase());
+            if (key == null) {
+                return null;
+            }
+            Method getRegistry = Bukkit.class.getMethod("getRegistry", Class.class);
+            Object registry = getRegistry.invoke(null, Sound.class);
+            if (registry == null) {
+                return null;
+            }
+            Method get = registry.getClass().getMethod("get", namespacedKey);
+            get.setAccessible(true);
+            return (Sound) get.invoke(registry, key);
+        } catch (ReflectiveOperationException e) {
+            return null;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run test, verify it passes** — same command as Step 2 → PASS.
+
+- [ ] **Step 5: Commit** — `git add` the two files; `git commit -m "feat(core-spigot): add cross-version SoundCompat resolver"`
+
+### Task 14: Redesign `Utils.sync` / `syncLater` / `playSound`
+
+**Files:** `platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/Utils.java`
+
+- [ ] **Step 1: Replace the three helpers** — remove the no-target `sync(Plugin, Runnable)`, `syncLater(Plugin, Runnable, long)`, and `playSound(Plugin, Player, String)`; add target-aware versions. Remove the now-unused `Bukkit`/`Sound` imports if the compiler flags them; add `PlatformScheduler` import.
+
+```java
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
+// remove: import org.bukkit.Bukkit;  (only if no other Bukkit use remains)
+```
+```java
+    /**
+     * Runs a task on the thread owning the entity's region.
+     *
+     * @param scheduler the platform scheduler
+     * @param entity    the entity whose region owns the task
+     * @param runnable  the work to run
+     */
+    public static void sync(PlatformScheduler scheduler, Entity entity, Runnable runnable) {
+        scheduler.runOnEntity(entity, runnable, null);
+    }
+
+    public static void syncLater(PlatformScheduler scheduler, Entity entity, Runnable runnable, long delayTicks) {
+        scheduler.runOnEntityLater(entity, runnable, null, delayTicks);
+    }
+
+    public static void playSound(PlatformScheduler scheduler, Player player, String name) {
+        scheduler.runOnEntity(player, () -> Utils.tryElsePrint(() -> {
+            Sound sound = SoundCompat.resolve(name);
+            if (sound != null) {
+                player.playSound(player.getEyeLocation(), sound, 1.0f, 1.0f);
+            }
+        }), null);
+    }
+```
+Add imports `org.bukkit.entity.Entity` and (keep) `org.bukkit.entity.Player`, `org.bukkit.Sound`, and `tech.guilhermekaua.spigotboot.core.spigot.utils.SoundCompat` (same package — no import needed).
+
+- [ ] **Step 2: Build core-spigot** — `JAVA_HOME=… ./mvnw -pl platform-spigot/core-spigot -am test -Danimal.sniffer.skip=true` → SUCCESS (no in-repo callers to fix; confirm with `grep -rn "Utils.sync\|Utils.syncLater\|Utils.playSound" --include=*.java platform-spigot core test-plugin`).
+
+- [ ] **Step 3: Commit** — `git commit -am "feat(core-spigot)!: redesign Utils scheduling helpers to require a target"`
+
+---
+
+## Increment 4: cross-version SoundSerializer
+
+### Task 15: Re-enable `SoundSerializer` (cross-version)
+
+**Files:**
+- Modify: `platform-spigot/config-spigot/.../serialization/SoundSerializer.java` (replace the fully-commented body)
+- Modify: `platform-spigot/config-spigot/.../serialization/BukkitSerializers.java` (uncomment registration)
+- Test: `platform-spigot/config-spigot/src/test/java/.../serialization/SoundSerializerTest.java`
+
+- [ ] **Step 1: Write the failing test** (enum path on the 1.20.1 test classpath):
+
+```java
+/* <MIT license header> */
+package tech.guilhermekaua.spigotboot.config.spigot.serialization;
+
+import org.bukkit.Sound;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SoundSerializerTest {
+
+    private final SoundSerializer serializer = new SoundSerializer();
+
+    @Test
+    void deserializes_enum_name() throws Exception {
+        ConfigNode node = Mockito.mock(ConfigNode.class);
+        when(node.get(String.class)).thenReturn("ENTITY_PLAYER_LEVELUP");
+        assertNotNull(serializer.deserialize(node, Sound.class));
+    }
+
+    @Test
+    void serializes_to_stable_key() throws Exception {
+        Sound sound = serializer.deserialize(mockNode("ENTITY_PLAYER_LEVELUP"), Sound.class);
+        MutableConfigNode out = Mockito.mock(MutableConfigNode.class);
+        serializer.serialize(sound, out);
+        verify(out).set("ENTITY_PLAYER_LEVELUP");
+    }
+
+    private ConfigNode mockNode(String value) {
+        ConfigNode node = Mockito.mock(ConfigNode.class);
+        when(node.get(String.class)).thenReturn(value);
+        return node;
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify it fails** — `JAVA_HOME=… ./mvnw -pl platform-spigot/config-spigot -am test -Dtest=SoundSerializerTest -Danimal.sniffer.skip=true` → FAIL (class is commented out).
+
+- [ ] **Step 3: Replace `SoundSerializer.java`** with a cross-version body delegating to `SoundCompat`:
+
+```java
+/* <MIT license header — uncomment/restore> */
+package tech.guilhermekaua.spigotboot.config.spigot.serialization;
+
+import org.bukkit.Sound;
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
+import tech.guilhermekaua.spigotboot.core.spigot.utils.SoundCompat;
+
+/**
+ * Cross-version serializer for {@link Sound}. {@code Sound} is an enum up to MC 1.21.2 and an
+ * interface from 1.21.3 on; resolution is delegated to {@link SoundCompat} so the same config
+ * works on every supported server.
+ */
+public class SoundSerializer implements TypeSerializer<Sound> {
+
+    @Override
+    public Sound deserialize(@NotNull ConfigNode node, @NotNull Class<Sound> type) throws SerializationException {
+        String value = node.get(String.class);
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
+        Sound sound = SoundCompat.resolve(value);
+        if (sound == null) {
+            throw new SerializationException("Unknown sound: " + value);
+        }
+        return sound;
+    }
+
+    @Override
+    public void serialize(@NotNull Sound value, @NotNull MutableConfigNode node) throws SerializationException {
+        node.set(SoundCompat.toKey(value));
+    }
+}
+```
+
+- [ ] **Step 4: Re-register** in `BukkitSerializers.java` — uncomment and add the import:
+```java
+import org.bukkit.Sound;
+```
+```java
+        registry.register(Sound.class, new SoundSerializer());
+```
+
+- [ ] **Step 5: Run test, verify it passes** — same command as Step 2 → PASS. Then run the whole config-spigot suite to confirm no regression.
+
+- [ ] **Step 6: Commit** — `git add` the three files; `git commit -m "feat(config-spigot): re-enable Sound serializer with cross-version resolution"`
+
+---
+
+## Increment 5: Validation
+
+### Task 16: Full reactor build with sniffer (CI parity)
+
+- [ ] **Step 1:** `JAVA_HOME=/c/Users/Guilherme/.jdks/ms-21.0.10 ./mvnw -pl test-plugin -am package` (no `-Danimal.sniffer.skip`) → BUILD SUCCESS (proves the sniffer ignores are correct and nothing leaked a modern `org.bukkit.*` call).
+  - If the spigot-api 1.8 signature artifact is missing, first run `JAVA_HOME=… ./mvnw -pl spigot-api-1_8-signature install`.
+
+### Task 17: Folia runtime validation (real server)
+
+- [ ] **Step 1: Add a Sound field to the test-plugin config** so the interface-Sound deserialize path is exercised on Folia 26.x. In `test-plugin` `MainConfig` add a `Sound` field bound to a config key, and add the key (e.g. `levelup-sound: minecraft:entity.player.levelup`) to its config yml. (See `test-plugin/src/main/.../configuration/MainConfig.java`.)
+- [ ] **Step 2: Rebuild + deploy** — `JAVA_HOME=… ./mvnw -pl test-plugin -am package -Danimal.sniffer.skip=true` then `cp test-plugin/target/test-plugin-3.2.1-SNAPSHOT-shaded.jar "/c/Users/Guilherme/Desktop/spigot/folia 26.1.2/plugins/test-plugin-3.2.1-SNAPSHOT.jar"`.
+- [ ] **Step 3: Boot Folia and capture** (headless, timed stop):
+```bash
+cd "/c/Users/Guilherme/Desktop/spigot/folia 26.1.2"; rm -f after-run2.log; ( sleep 70; printf 'stop\n' ) | java -Xms1G -Xmx2G -jar folia-26.1.2-8.jar nogui > after-run2.log 2>&1
+grep -nE "Enabling TestPlugin|MainConfig|Sound|Error occurred while enabling|Exception|Done \(" after-run2.log
+```
+Expected: `Enabling TestPlugin`, config loads (incl. the Sound value), `Done (`, no exceptions, clean `Disabling` from the stop.
+- [ ] **Step 4 (optional, manual): open a view** — if a test command opens an inventory view, run it from the console/an op and confirm no Folia thread-check error in the log. (Region-correctness of live GUI ops; document the result.)
+
+### Task 18: Finish the branch
+
+- [ ] **Step 1:** Remove scratch logs from the server dir: `rm -f "/c/Users/Guilherme/Desktop/spigot/folia 26.1.2/"*-run*.log`.
+- [ ] **Step 2:** Use `superpowers:finishing-a-development-branch` to decide merge/PR. Suggested PR title: `feat: Folia scheduler abstraction + region-correct inventory views`. Summarize the 5 increments and the before/after Folia validation in the PR body.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 approach A (typed interface, isolated impls, detection) → Tasks 1–4. ✓
+- §4.1 method set → Task 1 interface matches spec exactly. ✓
+- §4.2 PlatformTask → Task 1. ✓
+- §4.3 impls + detection → Tasks 2–4 (Folia uses reflective accessors + typed scheduler calls — a refinement keeping the sniffer net tight, noted in Task 3 rationale; still approach A). ✓
+- §4.4 DI bean → Task 5. ✓
+- §4.5 inventory-api full region-correctness (5 scheduler sites + guards + per-session flush + PageRequest viewer) → Tasks 6–12. ✓
+- §4.6 Utils redesign (require target; fix latent Sound.valueOf via SoundCompat) → Tasks 13–14. ✓
+- §4.7 cross-version SoundSerializer → Tasks 13, 15. ✓
+- §5 testing → unit tests in Tasks 4, 13, 15; existing inventory tests kept green (Increment 2 header); Folia runtime in Task 17. ✓
+- §6 increments order → matches. ✓
+
+**Placeholder scan:** the FlushCoordinator hook rewrite (Task 10, Step 3) is the one area requiring test-driven iteration — concrete code is given, with the existing tests named as the oracle. No "TBD"/"implement later".
+
+**Type consistency:** `PlatformScheduler` method names/signatures are identical across interface (Task 1), impls (Tasks 2–3), callers (Tasks 8–11, 14). `PlatformTask` used consistently for `ViewSession.updateTask` (Task 9). `SoundCompat.resolve`/`toKey` consistent across Tasks 13–15. `PageRequest.viewer()` consistent (Tasks 11). `ThreadUtils.assertOwnsRegion(scheduler, entity, op)` consistent (Tasks 6, 8).
+
+**Open risk:** Task 10 (shared-flush concurrency) is the highest-uncertainty task; if the global-drain approach changes `UpdateFlushTest`/`SharedStateFlowTest` timing, adjust those tests to pump the fake scheduler and keep the per-session-fan-out assertion as the contract.

--- a/docs/superpowers/specs/2026-06-14-folia-scheduler-compat-design.md
+++ b/docs/superpowers/specs/2026-06-14-folia-scheduler-compat-design.md
@@ -1,0 +1,141 @@
+# Folia scheduler & region-correctness — design
+
+- **Date:** 2026-06-14
+- **Status:** Approved (design); pending implementation plan
+- **Modules:** `core-spigot` (new abstraction), `inventory-api/api` (migration), `config-spigot` (Sound)
+- **Related:** load-time Folia fixes already landed this session — `@Plugin(foliaSupported)` + `PluginAnnotationProcessor`, and `InventoryApiNMS.resolveTitleUpdater`. Those make a plugin *boot* on Folia; this spec makes the *runtime* threading correct.
+
+## 1. Problem
+
+Folia (PaperMC's regionized fork) has no single main thread: the world is split into independently-ticked regions, plus a global-region thread and an async pool. Code may only touch a chunk/block/entity/player/inventory from the thread that owns that region.
+
+The framework targets the legacy single-main-thread model directly. A prior audit found two failure classes; this spec addresses the runtime one:
+
+- **8 hard blockers** — legacy synchronous `BukkitScheduler` calls (`runTask`/`runTaskLater`/`runTaskTimer`) that throw `UnsupportedOperationException` on Folia at the call site, on any thread:
+  - `core-spigot` `Utils.java`: `sync` (L129), `syncLater` (L133), `playSound` (L146).
+  - `inventory-api/api`: `FirstRenderPhase` view-update timer (L194), `ViewEngine` click self-defer (L139) and deferred-op drain (L345), `FlushCoordinator` coalesced shared flush (L185), `BukkitSettleDispatcher` async-settle (L57).
+- **Region-ownership hazards** — `Bukkit.isPrimaryThread()` / `ThreadUtils.assertMainThread` used as a "safe to mutate" guard. On Folia this is `true` on *any* tick thread, so it neither proves the viewer's region is owned nor protects the throwing calls behind it. It gates `openInventory`, `setTitle`, slot paint, `closeInventory` across ~11 `ViewEngine` entry points.
+
+Separately, a modern-Paper ABI break: `org.bukkit.Sound` changed from an enum to an interface, so `SoundSerializer`'s `Enum`-upcast bytecode fails class verification (`VerifyError`). It is currently disabled.
+
+## 2. Goals / non-goals
+
+**Goals**
+- One platform-conditional scheduling abstraction that works on Spigot 1.8.8 → modern Paper → Folia from a single code path.
+- inventory-api views open/update/close **region-correctly** on Folia (full correctness, not just "stops throwing").
+- `Utils` scheduling helpers Folia-correct (redesigned to require a target).
+- `SoundSerializer` working cross-version (1.8.8 enum ↔ modern interface) via reflection.
+- Keep working on legacy Spigot/Paper; do not regress existing tests.
+
+**Non-goals**
+- No async-scheduler abstraction (legacy async already works on Folia; the pagination timeout thread stays as-is).
+- No change to event/command/plugin-message registration (already Folia-compatible).
+- No remediation of `pmc`/`placeholder`/`commands-spigot` caller-dependent reads (separate, lower priority).
+
+## 3. Approach
+
+**Chosen: A — platform-detected scheduler with lazily-isolated implementations.** Mirrors the existing `InventoryApiNMS` selector pattern.
+
+- `PlatformScheduler` interface (no version-specific references).
+- `FoliaPlatformScheduler` — references the modern Paper scheduler API (`Bukkit.getRegionScheduler()`, `Entity#getScheduler()`, `Bukkit.getGlobalRegionScheduler()`, `Bukkit.isOwnedByCurrentRegion(...)`). Instantiated only when that API is present, so it works on **modern Paper and Folia** alike.
+- `BukkitPlatformScheduler` — references the legacy `BukkitScheduler` + `Bukkit.isPrimaryThread()`. Used on legacy Spigot / old Paper.
+- `PlatformSchedulers.create(plugin)` detects the modern API via `Class.forName` (e.g. `io.papermc.paper.threadedregions.scheduler.RegionScheduler`) and returns the right impl.
+
+**Isolation constraint (critical):** a class that references the modern scheduler API fails to *load* on 1.8.8. So all such references live only inside `FoliaPlatformScheduler`, which is constructed only when detection passes — legacy servers never link those types (no `NoClassDefFoundError`). `core-spigot` compiles against modern `paper-api`, so the types resolve at compile time; animal-sniffer (1.8.8 signature) `<ignore>` entries cover each modern call (same mechanism as the existing `org.bukkit.UnsafeValues` ignore).
+
+**Rejected:** B reflection-only (slow, untyped, verbose); C drop legacy support (contradicts the framework's 1.8.8 coverage).
+
+## 4. Component design
+
+### 4.1 `PlatformScheduler` (`core-spigot`, package `tech.guilhermekaua.spigotboot.core.spigot.scheduler`)
+
+Only the operations callers need (YAGNI):
+
+```java
+PlatformTask runOnEntity(Entity entity, Runnable task, @Nullable Runnable retired);
+PlatformTask runOnEntityLater(Entity entity, Runnable task, @Nullable Runnable retired, long delayTicks);
+PlatformTask runOnEntityAtFixedRate(Entity entity, Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks);
+PlatformTask runAtRegion(Location location, Runnable task);
+PlatformTask runAtRegionLater(Location location, Runnable task, long delayTicks);
+PlatformTask runGlobal(Runnable task);
+PlatformTask runGlobalLater(Runnable task, long delayTicks);
+boolean ownsRegion(Entity entity);
+boolean ownsRegion(Location location);
+```
+
+- `retired` runs when the target entity is gone before the task fires (Folia Entity scheduler semantics); on legacy it is ignored (or invoked when scheduling is rejected during shutdown), preserving the existing `BukkitSettleDispatcher` drop-on-disable behavior.
+- `delayTicks` / `periodTicks` are in ticks for parity with the legacy API; Folia schedulers also take ticks.
+
+### 4.2 `PlatformTask`
+
+A minimal cancellable handle: `void cancel(); boolean isCancelled();`. Two impls wrapping `org.bukkit.scheduler.BukkitTask` and `io.papermc.paper.threadedregions.scheduler.ScheduledTask` (the Folia type referenced only inside the Folia impl).
+
+### 4.3 Implementations & detection
+
+- `BukkitPlatformScheduler(Plugin)` — entity/region/global all map to `Bukkit.getScheduler().runTask*`; `ownsRegion(...)` → `Bukkit.isPrimaryThread()`.
+- `FoliaPlatformScheduler(Plugin)` — entity → `entity.getScheduler().run/runDelayed/runAtFixedRate`; region → `Bukkit.getRegionScheduler().run/runDelayed`; global → `Bukkit.getGlobalRegionScheduler()`; `ownsRegion(...)` → `Bukkit.isOwnedByCurrentRegion(...)`.
+- `PlatformSchedulers.create(Plugin)` — `Class.forName` detection; documented and unit-tested through a package-private pure selector (parallel to `InventoryApiNMS.resolveTitleUpdater`).
+
+### 4.4 DI wiring
+
+A `@Configuration` in `core-spigot`:
+
+```java
+@Bean
+@ConditionalOnMissingBean(PlatformScheduler.class)
+public PlatformScheduler platformScheduler(Plugin plugin) {
+    return PlatformSchedulers.create(plugin);
+}
+```
+
+`@ConditionalOnMissingBean` lets a downstream plugin substitute its own. (Confirm a `Plugin`/`JavaPlugin` bean is injectable — it is per existing `@Config`/`PersistenceConfig` injection.)
+
+### 4.5 inventory-api migration (full region-correctness)
+
+Inject `PlatformScheduler` into `ViewEngine`; thread the viewer `Player` through entry points.
+
+| Site | Change |
+|---|---|
+| `FirstRenderPhase` L194 (timer) | `runOnEntityAtFixedRate(session.player(), …, interval, interval)`; `Session.updateTask` field type `BukkitTask` → `PlatformTask` |
+| `ViewEngine` L139 (open self-defer) | `runOnEntity(player, () -> open(...), null)` |
+| `ViewEngine` L345 (deferred drain) | `runOnEntity(session.player(), () -> drainDeferred(session), null)` |
+| `FlushCoordinator` L185 (shared flush) | **fan out per session**: for each open session `runOnEntity(session.player(), () -> flushSharedForSession(session, ids), null)` |
+| `BukkitSettleDispatcher` L57 | carry viewer `Player` on `PageRequest`; `runOnEntity(viewer, task, null)` |
+| `ThreadUtils.assertMainThread` (universal guard) | region-aware `assertOwnsRegion(scheduler, player, op)` using `ownsRegion(player)`; viewer threaded into each entry point |
+| `FlushCoordinator` L162, `BukkitSettleDispatcher` L52 (`isPrimaryThread` inline branch) | `ownsRegion(session.player())` / `ownsRegion(viewer)` |
+
+Leaf mutators (`SlotPainter`, `OpenPhase.createInventory`, `ClosePhase`, `OpenFailureHandler`, title update) need no logic change — correctness follows from their callers running on the viewer's region thread via the above.
+
+### 4.6 Utils redesign (breaking change, no in-repo callers)
+
+- `playSound(PlatformScheduler scheduler, Player player, String name)` → `scheduler.runOnEntity(player, () -> player.playSound(player.getEyeLocation(), resolveSound(name), 1f, 1f), null)`, where `resolveSound` is a cross-version Sound lookup using the same reflection technique as §4.7. This also fixes the latent `Sound.valueOf` modern-API break in the current `playSound`. (The plan must place `resolveSound` where both `core-spigot` and `config-spigot` can reach it, or duplicate the small reflective helper per module if the dependency direction does not allow sharing — to be settled in the plan.)
+- `sync`/`syncLater` take an explicit `Entity` (or `Location`) target + `PlatformScheduler` and delegate. The old no-target overloads are **removed**.
+
+### 4.7 Cross-version `SoundSerializer` (`config-spigot`)
+
+Reflection-based, branching at runtime on `Sound.class.isEnum()`:
+
+- **serialize** — enum: `((Enum<?>) value).name()`; interface: reflectively call `getKey()` and `toString()` (no static `Keyed`/`NamespacedKey`/`Registry` references, so the class still loads on 1.8.8).
+- **deserialize** — enum: reflective `Sound.valueOf(String)`; interface: reflective registry lookup by key.
+- Re-register in `BukkitSerializers.registerAll` (uncomment L51).
+
+## 5. Testing
+
+- `PlatformSchedulers` selector: pure-logic unit test (parallel to `InventoryApiNMSTest`); legacy impl exercisable via MockBukkit; Folia impl branches asserted via the detection seam.
+- inventory-api: extend existing engine tests (MockBukkit) to assert tasks route through an injected `PlatformScheduler` (mock/fake) and that entry points consult `ownsRegion`; reuse the `BukkitSettleDispatcherTest` style.
+- `SoundSerializer`: test the modern (interface) path against the real `Sound` on the test classpath + unit-test the key-string parsing; document that the 1.8.8 enum path cannot be co-tested in one JVM.
+- Whole reactor green with JDK 21.
+
+## 6. Delivery (increments — build + tests green between each)
+
+1. `PlatformScheduler` + `PlatformTask` + impls + factory + DI + tests.
+2. inventory-api migration + region-correctness + tests.
+3. `Utils` redesign.
+4. cross-version `SoundSerializer`.
+5. Validation: reactor build (JDK 21) + Folia 26.1.2 boot; if feasible, a runtime GUI smoke test (open a view, confirm no region thread-check error).
+
+## 7. Risks
+
+- Folia `ScheduledTask`/scheduler signatures referenced in the Folia impl must be guarded by detection so legacy servers never load that class — verified by the isolation pattern.
+- Threading the viewer `Player` through ~11 entry points is the largest change; staged in increment 2 with tests at each step.
+- Cross-version Sound reflection cannot be fully co-tested in one JVM; mitigated by testing the live path and isolating parsing logic.

--- a/platform-spigot/annotation-processor/src/main/java/tech/guilhermekaua/spigotboot/spigot/annotationprocessor/annotations/Plugin.java
+++ b/platform-spigot/annotation-processor/src/main/java/tech/guilhermekaua/spigotboot/spigot/annotationprocessor/annotations/Plugin.java
@@ -57,5 +57,15 @@ public @interface Plugin {
     String[] libraries() default {};
 
     String apiVersion() default "";
+
+    /**
+     * Whether the generated {@code plugin.yml} should declare support for Folia's regionized
+     * threading. Folia refuses to enable a plugin that does not opt in via
+     * {@code folia-supported: true}; set this to {@code true} only once the plugin is verified
+     * Folia-safe.
+     *
+     * @return {@code true} to emit {@code folia-supported: true} into {@code plugin.yml}
+     */
+    boolean foliaSupported() default false;
 }
 

--- a/platform-spigot/annotation-processor/src/main/java/tech/guilhermekaua/spigotboot/spigot/annotationprocessor/plugin/PluginAnnotationProcessor.java
+++ b/platform-spigot/annotation-processor/src/main/java/tech/guilhermekaua/spigotboot/spigot/annotationprocessor/plugin/PluginAnnotationProcessor.java
@@ -104,6 +104,9 @@ public class PluginAnnotationProcessor extends AbstractProcessor {
             if (!pluginAnnotation.apiVersion().isEmpty()) {
                 writer.println("api-version: " + pluginAnnotation.apiVersion());
             }
+            if (pluginAnnotation.foliaSupported()) {
+                writer.println("folia-supported: true");
+            }
         }
     }
 }

--- a/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/BukkitSerializers.java
+++ b/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/BukkitSerializers.java
@@ -22,7 +22,9 @@
  */
 package tech.guilhermekaua.spigotboot.config.spigot.serialization;
 
-import org.bukkit.*;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistry;
 
@@ -46,7 +48,7 @@ public final class BukkitSerializers {
         Objects.requireNonNull(registry, "registry cannot be null");
 
         registry.register(Material.class, new MaterialSerializer());
-        registry.register(Sound.class, new SoundSerializer());
+//        registry.register(Sound.class, new SoundSerializer());
         registry.register(World.class, new WorldSerializer());
         registry.register(Location.class, new LocationSerializer());
         registry.register(Duration.class, new DurationSerializer());

--- a/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/BukkitSerializers.java
+++ b/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/BukkitSerializers.java
@@ -24,6 +24,7 @@ package tech.guilhermekaua.spigotboot.config.spigot.serialization;
 
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.Sound;
 import org.bukkit.World;
 import org.jetbrains.annotations.NotNull;
 import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistry;
@@ -48,7 +49,7 @@ public final class BukkitSerializers {
         Objects.requireNonNull(registry, "registry cannot be null");
 
         registry.register(Material.class, new MaterialSerializer());
-//        registry.register(Sound.class, new SoundSerializer());
+        registry.register(Sound.class, new SoundSerializer());
         registry.register(World.class, new WorldSerializer());
         registry.register(Location.class, new LocationSerializer());
         registry.register(Duration.class, new DurationSerializer());

--- a/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/SoundSerializer.java
+++ b/platform-spigot/config-spigot/src/main/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/SoundSerializer.java
@@ -1,58 +1,58 @@
-/*
- * The MIT License
- * Copyright © 2025 Guilherme Kauã da Silva
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-package tech.guilhermekaua.spigotboot.config.spigot.serialization;
-
-import org.bukkit.Sound;
-import org.jetbrains.annotations.NotNull;
-import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
-import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
-import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
-import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
-
-/**
- * Serializer for {@link Sound} enum.
- */
-public class SoundSerializer implements TypeSerializer<Sound> {
-
-    @Override
-    public Sound deserialize(@NotNull ConfigNode node, @NotNull Class<Sound> type) throws SerializationException {
-        String value = node.get(String.class);
-        if (value == null || value.isEmpty()) {
-            return null;
-        }
-
-        try {
-            return Sound.valueOf(value.trim().toUpperCase().replace(" ", "_").replace(".", "_"));
-        } catch (Exception e) {
-            throw new SerializationException("Unknown sound: " + value, e);
-        }
-    }
-
-    @Override
-    public void serialize(@NotNull Sound value, @NotNull MutableConfigNode node) throws SerializationException {
-        // Enum-typed on purpose: the 1.8.8 sniffer signature lacks JDK supertypes, so
-        // name() must resolve via the java.* ignore (see root pom)
-        Enum<?> enumValue = value;
-        node.set(enumValue.name());
-    }
-}
+///*
+// * The MIT License
+// * Copyright © 2025 Guilherme Kauã da Silva
+// *
+// * Permission is hereby granted, free of charge, to any person obtaining a copy
+// * of this software and associated documentation files (the "Software"), to deal
+// * in the Software without restriction, including without limitation the rights
+// * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// * copies of the Software, and to permit persons to whom the Software is
+// * furnished to do so, subject to the following conditions:
+// *
+// * The above copyright notice and this permission notice shall be included in
+// * all copies or substantial portions of the Software.
+// *
+// * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// * THE SOFTWARE.
+// */
+//package tech.guilhermekaua.spigotboot.config.spigot.serialization;
+//
+//import org.bukkit.Sound;
+//import org.jetbrains.annotations.NotNull;
+//import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
+//import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+//import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+//import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
+//
+///**
+// * Serializer for {@link Sound} enum.
+// */
+//public class SoundSerializer implements TypeSerializer<Sound> {
+//
+//    @Override
+//    public Sound deserialize(@NotNull ConfigNode node, @NotNull Class<Sound> type) throws SerializationException {
+//        String value = node.get(String.class);
+//        if (value == null || value.isEmpty()) {
+//            return null;
+//        }
+//
+//        try {
+//            return Sound.valueOf(value.trim().toUpperCase().replace(" ", "_").replace(".", "_"));
+//        } catch (Exception e) {
+//            throw new SerializationException("Unknown sound: " + value, e);
+//        }
+//    }
+//
+//    @Override
+//    public void serialize(@NotNull Sound value, @NotNull MutableConfigNode node) throws SerializationException {
+//        // Enum-typed on purpose: the 1.8.8 sniffer signature lacks JDK supertypes, so
+//        // name() must resolve via the java.* ignore (see root pom)
+//        Enum<?> enumValue = value;
+//        node.set(enumValue.name());
+//    }
+//}

--- a/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/SoundSerializerTest.java
+++ b/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/SoundSerializerTest.java
@@ -25,11 +25,13 @@ package tech.guilhermekaua.spigotboot.config.spigot.serialization;
 import org.bukkit.Sound;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
 import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
 import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -50,6 +52,20 @@ class SoundSerializerTest {
         MutableConfigNode out = Mockito.mock(MutableConfigNode.class);
         serializer.serialize(sound, out);
         verify(out).set("ENTITY_PLAYER_LEVELUP");
+    }
+
+    @Test
+    void deserializes_unknown_sound_throws() {
+        ConfigNode node = Mockito.mock(ConfigNode.class);
+        when(node.get(String.class)).thenReturn("NOT_A_REAL_SOUND_XYZ");
+        assertThrows(SerializationException.class, () -> serializer.deserialize(node, Sound.class));
+    }
+
+    @Test
+    void deserializes_null_input_returns_null() throws Exception {
+        ConfigNode node = Mockito.mock(ConfigNode.class);
+        when(node.get(String.class)).thenReturn(null);
+        assertNull(serializer.deserialize(node, Sound.class));
     }
 
     private ConfigNode mockNode(String value) {

--- a/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/SoundSerializerTest.java
+++ b/platform-spigot/config-spigot/src/test/java/tech/guilhermekaua/spigotboot/config/spigot/serialization/SoundSerializerTest.java
@@ -23,35 +23,38 @@
 package tech.guilhermekaua.spigotboot.config.spigot.serialization;
 
 import org.bukkit.Sound;
-import org.jetbrains.annotations.NotNull;
-import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
 import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
-import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
-import tech.guilhermekaua.spigotboot.core.spigot.utils.SoundCompat;
 
-/**
- * Cross-version serializer for {@link Sound}. {@code Sound} is an enum up to MC 1.21.2 and an
- * interface from 1.21.3 on; resolution is delegated to {@link SoundCompat} so the same config
- * works on every supported server.
- */
-public class SoundSerializer implements TypeSerializer<Sound> {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-    @Override
-    public Sound deserialize(@NotNull ConfigNode node, @NotNull Class<Sound> type) throws SerializationException {
-        String value = node.get(String.class);
-        if (value == null || value.isEmpty()) {
-            return null;
-        }
-        Sound sound = SoundCompat.resolve(value);
-        if (sound == null) {
-            throw new SerializationException("Unknown sound: " + value);
-        }
-        return sound;
+class SoundSerializerTest {
+
+    private final SoundSerializer serializer = new SoundSerializer();
+
+    @Test
+    void deserializes_enum_name() throws Exception {
+        ConfigNode node = Mockito.mock(ConfigNode.class);
+        when(node.get(String.class)).thenReturn("ENTITY_PLAYER_LEVELUP");
+        assertNotNull(serializer.deserialize(node, Sound.class));
     }
 
-    @Override
-    public void serialize(@NotNull Sound value, @NotNull MutableConfigNode node) throws SerializationException {
-        node.set(SoundCompat.toKey(value));
+    @Test
+    void serializes_to_stable_key() throws Exception {
+        Sound sound = serializer.deserialize(mockNode("ENTITY_PLAYER_LEVELUP"), Sound.class);
+        MutableConfigNode out = Mockito.mock(MutableConfigNode.class);
+        serializer.serialize(sound, out);
+        verify(out).set("ENTITY_PLAYER_LEVELUP");
+    }
+
+    private ConfigNode mockNode(String value) {
+        ConfigNode node = Mockito.mock(ConfigNode.class);
+        when(node.get(String.class)).thenReturn(value);
+        return node;
     }
 }

--- a/platform-spigot/core-spigot/pom.xml
+++ b/platform-spigot/core-spigot/pom.xml
@@ -93,6 +93,15 @@
                          instead of replacing them -->
                     <ignores combine.children="append">
                         <ignore>org.bukkit.UnsafeValues</ignore>
+                        <!-- Folia scheduler API; referenced only by FoliaPlatformScheduler/FoliaPlatformTask,
+                             which load only when the API is present at runtime -->
+                        <ignore>io.papermc.paper.threadedregions.scheduler.EntityScheduler</ignore>
+                        <ignore>io.papermc.paper.threadedregions.scheduler.RegionScheduler</ignore>
+                        <ignore>io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler</ignore>
+                        <ignore>io.papermc.paper.threadedregions.scheduler.ScheduledTask</ignore>
+                        <ignore>io.papermc.paper.threadedregions.scheduler.ScheduledTask$CancelledState</ignore>
+                        <!-- BukkitTask#isCancelled() was added after 1.8.8; used only in BukkitPlatformTask -->
+                        <ignore>org.bukkit.scheduler.BukkitTask</ignore>
                     </ignores>
                 </configuration>
             </plugin>

--- a/platform-spigot/core-spigot/pom.xml
+++ b/platform-spigot/core-spigot/pom.xml
@@ -100,8 +100,6 @@
                         <ignore>io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler</ignore>
                         <ignore>io.papermc.paper.threadedregions.scheduler.ScheduledTask</ignore>
                         <ignore>io.papermc.paper.threadedregions.scheduler.ScheduledTask$CancelledState</ignore>
-                        <!-- BukkitTask#isCancelled() was added after 1.8.8; used only in BukkitPlatformTask -->
-                        <ignore>org.bukkit.scheduler.BukkitTask</ignore>
                     </ignores>
                 </configuration>
             </plugin>

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformScheduler.java
@@ -51,12 +51,12 @@ public final class BukkitPlatformScheduler implements PlatformScheduler {
 
     @Override
     public @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks) {
-        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, Math.max(1L, delayTicks)));
     }
 
     @Override
     public @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks) {
-        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks));
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskTimer(plugin, task, Math.max(1L, delayTicks), Math.max(1L, periodTicks)));
     }
 
     @Override
@@ -66,7 +66,7 @@ public final class BukkitPlatformScheduler implements PlatformScheduler {
 
     @Override
     public @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks) {
-        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, Math.max(1L, delayTicks)));
     }
 
     @Override
@@ -76,7 +76,7 @@ public final class BukkitPlatformScheduler implements PlatformScheduler {
 
     @Override
     public @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks) {
-        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, Math.max(1L, delayTicks)));
     }
 
     @Override

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformScheduler.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Legacy {@link PlatformScheduler}: every variant maps to {@link org.bukkit.scheduler.BukkitScheduler}
+ * and runs on the single main thread. {@code retired} callbacks have no legacy equivalent and are
+ * ignored. Selected on Spigot / Paper builds that lack the Folia scheduler API.
+ */
+public final class BukkitPlatformScheduler implements PlatformScheduler {
+
+    private final Plugin plugin;
+
+    public BukkitPlatformScheduler(@NotNull Plugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTask(plugin, task));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskTimer(plugin, task, delayTicks, periodTicks));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTask(plugin, task));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobal(@NotNull Runnable task) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTask(plugin, task));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks) {
+        return new BukkitPlatformTask(Bukkit.getScheduler().runTaskLater(plugin, task, delayTicks));
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Entity entity) {
+        return Bukkit.isPrimaryThread();
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Location location) {
+        return Bukkit.isPrimaryThread();
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformTask.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformTask.java
@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
 final class BukkitPlatformTask implements PlatformTask {
 
     private final BukkitTask task;
+    private volatile boolean cancelled = false;
 
     BukkitPlatformTask(@NotNull BukkitTask task) {
         this.task = task;
@@ -36,11 +37,12 @@ final class BukkitPlatformTask implements PlatformTask {
 
     @Override
     public void cancel() {
+        cancelled = true;
         task.cancel();
     }
 
     @Override
     public boolean isCancelled() {
-        return task.isCancelled();
+        return cancelled;
     }
 }

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformTask.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformTask.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+
+/** {@link PlatformTask} backed by a legacy {@link BukkitTask}. */
+final class BukkitPlatformTask implements PlatformTask {
+
+    private final BukkitTask task;
+
+    BukkitPlatformTask(@NotNull BukkitTask task) {
+        this.task = task;
+    }
+
+    @Override
+    public void cancel() {
+        task.cancel();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return task.isCancelled();
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformTask.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/BukkitPlatformTask.java
@@ -41,6 +41,13 @@ final class BukkitPlatformTask implements PlatformTask {
         task.cancel();
     }
 
+    /**
+     * Returns whether this handle has been cancelled via {@link #cancel()}. External cancellation
+     * (e.g. {@code BukkitScheduler#cancelTasks}) is not observed here because {@code BukkitTask}
+     * does not expose {@code isCancelled()} on 1.8.8.
+     *
+     * @return {@code true} if {@link #cancel()} was called on this handle
+     */
     @Override
     public boolean isCancelled() {
         return cancelled;

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/CancelledPlatformTask.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/CancelledPlatformTask.java
@@ -22,26 +22,25 @@
  */
 package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
 
-import org.bukkit.plugin.Plugin;
-import tech.guilhermekaua.spigotboot.core.context.annotations.Bean;
-import tech.guilhermekaua.spigotboot.core.context.annotations.ConditionalOnMissingBean;
-import tech.guilhermekaua.spigotboot.core.context.annotations.Configuration;
-
 /**
- * Registers the platform {@link PlatformScheduler}. Guarded by {@code @ConditionalOnMissingBean}
- * so a plugin may register its own implementation.
+ * A {@link PlatformTask} representing work that was never scheduled — returned when the Folia
+ * entity scheduler reports the target entity was already removed (its {@code retired} callback
+ * is or will be invoked by the platform). Cancelling it is a no-op.
  */
-@Configuration
-public class SpigotSchedulerConfiguration {
+final class CancelledPlatformTask implements PlatformTask {
 
-    /**
-     * @param plugin the host plugin
-     * @return the {@link PlatformScheduler} for the running server — Folia-aware when the modern
-     *         scheduler API is present, otherwise a legacy Bukkit-backed implementation
-     */
-    @Bean
-    @ConditionalOnMissingBean(PlatformScheduler.class)
-    public PlatformScheduler platformScheduler(Plugin plugin) {
-        return PlatformSchedulers.create(plugin);
+    static final CancelledPlatformTask INSTANCE = new CancelledPlatformTask();
+
+    private CancelledPlatformTask() {
+    }
+
+    @Override
+    public void cancel() {
+        // nothing was scheduled
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return true;
     }
 }

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformScheduler.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * Folia / modern-Paper {@link PlatformScheduler}. Region/entity/global tasks land on the owning
+ * region thread. The scheduler accessors on {@link Bukkit}/{@link Entity} are invoked reflectively
+ * (so the 1.8.8 animal-sniffer net over {@code org.bukkit.*} stays intact); the scheduler
+ * interfaces themselves are used with normal typed calls. Instantiated only when the Folia
+ * scheduler API is present (see {@code PlatformSchedulers}).
+ */
+public final class FoliaPlatformScheduler implements PlatformScheduler {
+
+    private static final Method GET_REGION_SCHEDULER;
+    private static final Method GET_GLOBAL_SCHEDULER;
+    private static final Method IS_OWNED_ENTITY;
+    private static final Method IS_OWNED_LOCATION;
+    private static final Method ENTITY_GET_SCHEDULER;
+
+    static {
+        try {
+            GET_REGION_SCHEDULER = Bukkit.class.getMethod("getRegionScheduler");
+            GET_GLOBAL_SCHEDULER = Bukkit.class.getMethod("getGlobalRegionScheduler");
+            IS_OWNED_ENTITY = Bukkit.class.getMethod("isOwnedByCurrentRegion", Entity.class);
+            IS_OWNED_LOCATION = Bukkit.class.getMethod("isOwnedByCurrentRegion", Location.class);
+            ENTITY_GET_SCHEDULER = Entity.class.getMethod("getScheduler");
+        } catch (NoSuchMethodException e) {
+            throw new IllegalStateException("Folia scheduler API expected but not found", e);
+        }
+    }
+
+    private final Plugin plugin;
+
+    public FoliaPlatformScheduler(@NotNull Plugin plugin) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin");
+    }
+
+    private EntityScheduler entityScheduler(Entity entity) {
+        try {
+            return (EntityScheduler) ENTITY_GET_SCHEDULER.invoke(entity);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private RegionScheduler regionScheduler() {
+        try {
+            return (RegionScheduler) GET_REGION_SCHEDULER.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private GlobalRegionScheduler globalScheduler() {
+        try {
+            return (GlobalRegionScheduler) GET_GLOBAL_SCHEDULER.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired) {
+        return new FoliaPlatformTask(entityScheduler(entity).run(plugin, scheduled -> task.run(), retired));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks) {
+        return new FoliaPlatformTask(entityScheduler(entity).runDelayed(plugin, scheduled -> task.run(), retired, Math.max(1L, delayTicks)));
+    }
+
+    @Override
+    public @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks) {
+        return new FoliaPlatformTask(entityScheduler(entity).runAtFixedRate(plugin, scheduled -> task.run(), retired, Math.max(1L, delayTicks), Math.max(1L, periodTicks)));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task) {
+        return new FoliaPlatformTask(regionScheduler().run(plugin, location, scheduled -> task.run()));
+    }
+
+    @Override
+    public @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks) {
+        return new FoliaPlatformTask(regionScheduler().runDelayed(plugin, location, scheduled -> task.run(), Math.max(1L, delayTicks)));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobal(@NotNull Runnable task) {
+        return new FoliaPlatformTask(globalScheduler().run(plugin, scheduled -> task.run()));
+    }
+
+    @Override
+    public @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks) {
+        return new FoliaPlatformTask(globalScheduler().runDelayed(plugin, scheduled -> task.run(), Math.max(1L, delayTicks)));
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Entity entity) {
+        try {
+            return (boolean) IS_OWNED_ENTITY.invoke(null, entity);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public boolean ownsRegion(@NotNull Location location) {
+        try {
+            return (boolean) IS_OWNED_LOCATION.invoke(null, location);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformScheduler.java
@@ -25,6 +25,7 @@ package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
 import io.papermc.paper.threadedregions.scheduler.EntityScheduler;
 import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
 import io.papermc.paper.threadedregions.scheduler.RegionScheduler;
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
@@ -94,17 +95,20 @@ public final class FoliaPlatformScheduler implements PlatformScheduler {
 
     @Override
     public @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired) {
-        return new FoliaPlatformTask(entityScheduler(entity).run(plugin, scheduled -> task.run(), retired));
+        ScheduledTask scheduled = entityScheduler(entity).run(plugin, st -> task.run(), retired);
+        return scheduled == null ? CancelledPlatformTask.INSTANCE : new FoliaPlatformTask(scheduled);
     }
 
     @Override
     public @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks) {
-        return new FoliaPlatformTask(entityScheduler(entity).runDelayed(plugin, scheduled -> task.run(), retired, Math.max(1L, delayTicks)));
+        ScheduledTask scheduled = entityScheduler(entity).runDelayed(plugin, st -> task.run(), retired, Math.max(1L, delayTicks));
+        return scheduled == null ? CancelledPlatformTask.INSTANCE : new FoliaPlatformTask(scheduled);
     }
 
     @Override
     public @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks) {
-        return new FoliaPlatformTask(entityScheduler(entity).runAtFixedRate(plugin, scheduled -> task.run(), retired, Math.max(1L, delayTicks), Math.max(1L, periodTicks)));
+        ScheduledTask scheduled = entityScheduler(entity).runAtFixedRate(plugin, st -> task.run(), retired, Math.max(1L, delayTicks), Math.max(1L, periodTicks));
+        return scheduled == null ? CancelledPlatformTask.INSTANCE : new FoliaPlatformTask(scheduled);
     }
 
     @Override

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformScheduler.java
@@ -40,7 +40,7 @@ import java.util.Objects;
  * region thread. The scheduler accessors on {@link Bukkit}/{@link Entity} are invoked reflectively
  * (so the 1.8.8 animal-sniffer net over {@code org.bukkit.*} stays intact); the scheduler
  * interfaces themselves are used with normal typed calls. Instantiated only when the Folia
- * scheduler API is present (see {@code PlatformSchedulers}).
+ * scheduler API is present (see {@link PlatformSchedulers}).
  */
 public final class FoliaPlatformScheduler implements PlatformScheduler {
 

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformTask.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/FoliaPlatformTask.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+import org.jetbrains.annotations.NotNull;
+
+/** {@link PlatformTask} backed by a Folia {@link ScheduledTask}. */
+final class FoliaPlatformTask implements PlatformTask {
+
+    private final ScheduledTask task;
+
+    FoliaPlatformTask(@NotNull ScheduledTask task) {
+        this.task = task;
+    }
+
+    @Override
+    public void cancel() {
+        task.cancel();
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return task.isCancelled();
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Platform-neutral scheduling. On Folia every task is bound to a region (an entity's, a
+ * location's, or the global region); on legacy Spigot/Paper all variants fall back to the
+ * single main thread. Obtain the configured instance by injecting this type.
+ *
+ * <p>Times are in server ticks (20 per second), matching the legacy scheduler.
+ */
+public interface PlatformScheduler {
+
+    /**
+     * Runs a task on the thread owning the entity's region (Folia) or the main thread (legacy).
+     *
+     * @param entity  the entity whose region owns the task
+     * @param task    the work to run
+     * @param retired run instead of {@code task} if the entity is removed before it fires
+     *                (Folia only); ignored on legacy
+     * @return a cancellable handle
+     */
+    @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired);
+
+    @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks);
+
+    @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks);
+
+    @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task);
+
+    @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks);
+
+    @NotNull PlatformTask runGlobal(@NotNull Runnable task);
+
+    @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks);
+
+    /**
+     * @return {@code true} if the current thread owns the entity's region (Folia) or is the
+     * main thread (legacy) — i.e. it is safe to touch the entity now.
+     */
+    boolean ownsRegion(@NotNull Entity entity);
+
+    boolean ownsRegion(@NotNull Location location);
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java
@@ -113,6 +113,7 @@ public interface PlatformScheduler {
     @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks);
 
     /**
+     * @param entity the entity to check
      * @return {@code true} if the current thread owns the entity's region (Folia) or is the
      * main thread (legacy) — i.e. it is safe to touch the entity now.
      */

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformScheduler.java
@@ -47,16 +47,69 @@ public interface PlatformScheduler {
      */
     @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired);
 
+    /**
+     * Runs a task on the thread owning the entity's region (Folia) or the main thread (legacy),
+     * after a delay.
+     *
+     * @param entity      the entity whose region owns the task
+     * @param task        the work to run
+     * @param retired     run instead of {@code task} if the entity is removed before it fires
+     *                    (Folia only); ignored on legacy
+     * @param delayTicks  delay in ticks before the task fires; clamped to at least 1
+     * @return a cancellable handle
+     */
     @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks);
 
+    /**
+     * Runs a task repeatedly on the thread owning the entity's region (Folia) or the main thread
+     * (legacy).
+     *
+     * @param entity      the entity whose region owns the task
+     * @param task        the work to run each period
+     * @param retired     run instead of {@code task} if the entity is removed before it fires
+     *                    (Folia only); ignored on legacy
+     * @param delayTicks  delay in ticks before the first execution; clamped to at least 1
+     * @param periodTicks interval in ticks between subsequent executions; clamped to at least 1
+     * @return a cancellable handle
+     */
     @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks);
 
+    /**
+     * Runs a task on the thread owning the given location's region (Folia) or the main thread
+     * (legacy).
+     *
+     * @param location the location whose region owns the task
+     * @param task     the work to run
+     * @return a cancellable handle
+     */
     @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task);
 
+    /**
+     * Runs a task on the thread owning the given location's region (Folia) or the main thread
+     * (legacy), after a delay.
+     *
+     * @param location   the location whose region owns the task
+     * @param task       the work to run
+     * @param delayTicks delay in ticks before the task fires; clamped to at least 1
+     * @return a cancellable handle
+     */
     @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks);
 
+    /**
+     * Runs a task on the global region thread (Folia) or the main thread (legacy).
+     *
+     * @param task the work to run
+     * @return a cancellable handle
+     */
     @NotNull PlatformTask runGlobal(@NotNull Runnable task);
 
+    /**
+     * Runs a task on the global region thread (Folia) or the main thread (legacy), after a delay.
+     *
+     * @param task       the work to run
+     * @param delayTicks delay in ticks before the task fires; clamped to at least 1
+     * @return a cancellable handle
+     */
     @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks);
 
     /**
@@ -65,5 +118,10 @@ public interface PlatformScheduler {
      */
     boolean ownsRegion(@NotNull Entity entity);
 
+    /**
+     * @param location the location to check
+     * @return {@code true} if the current thread owns the given location's region (Folia) or is
+     * the main thread (legacy) — i.e. it is safe to touch that location now.
+     */
     boolean ownsRegion(@NotNull Location location);
 }

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulers.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulers.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Objects;
+
+/** Detects the platform and builds the matching {@link PlatformScheduler}. */
+public final class PlatformSchedulers {
+
+    private static final String FOLIA_SCHEDULER_CLASS = "io.papermc.paper.threadedregions.scheduler.RegionScheduler";
+
+    private PlatformSchedulers() {
+    }
+
+    /**
+     * Builds the scheduler for the running server.
+     *
+     * @param plugin the owning plugin
+     * @return a Folia scheduler when the modern scheduler API is present, else a legacy one
+     */
+    public static @NotNull PlatformScheduler create(@NotNull Plugin plugin) {
+        return create(plugin, isFoliaSchedulerApiPresent());
+    }
+
+    // package-private seam so the branch is unit-testable without a live server
+    static @NotNull PlatformScheduler create(@NotNull Plugin plugin, boolean foliaApiPresent) {
+        Objects.requireNonNull(plugin, "plugin");
+        return foliaApiPresent ? new FoliaPlatformScheduler(plugin) : new BukkitPlatformScheduler(plugin);
+    }
+
+    static boolean isFoliaSchedulerApiPresent() {
+        try {
+            Class.forName(FOLIA_SCHEDULER_CLASS, false, PlatformSchedulers.class.getClassLoader());
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulers.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulers.java
@@ -51,6 +51,7 @@ public final class PlatformSchedulers {
         return foliaApiPresent ? new FoliaPlatformScheduler(plugin) : new BukkitPlatformScheduler(plugin);
     }
 
+    // RegionScheduler is probed as the representative class of the Folia scheduler API
     static boolean isFoliaSchedulerApiPresent() {
         try {
             Class.forName(FOLIA_SCHEDULER_CLASS, false, PlatformSchedulers.class.getClassLoader());

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformTask.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformTask.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+/**
+ * A cancellable handle to a task scheduled through a {@link PlatformScheduler}. Abstracts over
+ * the legacy {@code BukkitTask} and the Folia {@code ScheduledTask} so callers can cancel a
+ * repeating task without referencing a platform-specific type.
+ */
+public interface PlatformTask {
+
+    /** Cancels the task; a no-op if it has already run or been cancelled. */
+    void cancel();
+
+    /**
+     * @return {@code true} if this task has been cancelled.
+     */
+    boolean isCancelled();
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/SpigotSchedulerConfiguration.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/SpigotSchedulerConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Bean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.ConditionalOnMissingBean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Configuration;
+
+/**
+ * Registers the platform {@link PlatformScheduler}. Guarded by {@code @ConditionalOnMissingBean}
+ * so a plugin may register its own implementation.
+ */
+@Configuration
+public class SpigotSchedulerConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(PlatformScheduler.class)
+    public PlatformScheduler platformScheduler(Plugin plugin) {
+        return PlatformSchedulers.create(plugin);
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.reflect.Method;
+import java.util.Locale;
 
 /**
  * Cross-version {@link Sound} resolution. {@code Sound} is an enum up to MC 1.21.2 and an
@@ -55,7 +56,7 @@ public final class SoundCompat {
     public static @Nullable Sound resolve(@NotNull String value) {
         String trimmed = value.trim();
         if (Sound.class.isEnum()) {
-            String name = trimmed.toUpperCase().replace('.', '_').replace(' ', '_').replace(':', '_');
+            String name = trimmed.toUpperCase(Locale.ROOT).replace('.', '_').replace(' ', '_').replace(':', '_');
             // strip a namespace prefix like MINECRAFT_ if present
             if (name.startsWith("MINECRAFT_")) {
                 name = name.substring("MINECRAFT_".length());
@@ -97,7 +98,7 @@ public final class SoundCompat {
         try {
             Class<?> namespacedKey = Class.forName("org.bukkit.NamespacedKey");
             Method fromString = namespacedKey.getMethod("fromString", String.class);
-            Object key = fromString.invoke(null, value.toLowerCase());
+            Object key = fromString.invoke(null, value.toLowerCase(Locale.ROOT));
             if (key == null) {
                 return null;
             }

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
@@ -98,10 +98,6 @@ public final class SoundCompat {
         try {
             Class<?> namespacedKey = Class.forName("org.bukkit.NamespacedKey");
             Method fromString = namespacedKey.getMethod("fromString", String.class);
-            Object key = fromString.invoke(null, value.toLowerCase(Locale.ROOT));
-            if (key == null) {
-                return null;
-            }
             Method getRegistry = Bukkit.class.getMethod("getRegistry", Class.class);
             Object registry = getRegistry.invoke(null, Sound.class);
             if (registry == null) {
@@ -109,9 +105,29 @@ public final class SoundCompat {
             }
             Class<?> registryInterface = Class.forName("org.bukkit.Registry");
             Method get = registryInterface.getMethod("get", namespacedKey);
-            return (Sound) get.invoke(registry, key);
+
+            String lower = value.toLowerCase(Locale.ROOT);
+            // try the value as given first — this resolves namespaced keys and registry keys that
+            // legitimately contain underscores (e.g. block.note_block.harp) — then fall back to
+            // translating a bare enum-constant name (ENTITY_PLAYER_LEVELUP) to its dotted key form
+            // (entity.player.levelup), so configs written for enum-Sound servers keep working here.
+            Sound resolved = lookupRegistry(fromString, get, registry, lower);
+            if (resolved == null && lower.indexOf('_') >= 0) {
+                resolved = lookupRegistry(fromString, get, registry, lower.replace('_', '.'));
+            }
+            return resolved;
         } catch (ReflectiveOperationException e) {
             return null;
         }
+    }
+
+    private static @Nullable Sound lookupRegistry(@NotNull Method fromString, @NotNull Method get,
+                                                  @NotNull Object registry, @NotNull String key)
+            throws ReflectiveOperationException {
+        Object namespaced = fromString.invoke(null, key);
+        if (namespaced == null) {
+            return null;
+        }
+        return (Sound) get.invoke(registry, namespaced);
     }
 }

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
@@ -44,6 +44,10 @@ public final class SoundCompat {
      * {@code ENTITY_PLAYER_LEVELUP}) or a namespaced key (e.g.
      * {@code minecraft:entity.player.levelup}).
      *
+     * <p>Note: bare enum-constant names (e.g. {@code ENTITY_PLAYER_LEVELUP}) are only accepted on
+     * enum-{@code Sound} servers (MC &lt;= 1.21.2); on interface-{@code Sound} servers (&gt;= 1.21.3)
+     * supply a namespaced key (e.g. {@code minecraft:entity.player.levelup}).
+     *
      * @param value the config value
      * @return the resolved sound, or {@code null} if unknown
      */
@@ -98,8 +102,8 @@ public final class SoundCompat {
             if (registry == null) {
                 return null;
             }
-            Method get = registry.getClass().getMethod("get", namespacedKey);
-            get.setAccessible(true);
+            Class<?> registryInterface = Class.forName("org.bukkit.Registry");
+            Method get = registryInterface.getMethod("get", namespacedKey);
             return (Sound) get.invoke(registry, key);
         } catch (ReflectiveOperationException e) {
             return null;

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
@@ -78,7 +78,11 @@ public final class SoundCompat {
      */
     public static @NotNull String toKey(@NotNull Sound sound) {
         if (sound instanceof Enum) {
-            return ((Enum<?>) sound).name();
+            // cast via Object so the compiler emits a checkcast: Sound is an enum on the compile
+            // classpath, so a direct (Enum) cast would be a no-op upcast and the bytecode would
+            // invokevirtual Enum.name() on a Sound operand — a VerifyError on servers (>=1.21.3)
+            // where Sound is an interface, even though this branch never runs there.
+            return ((Enum<?>) (Object) sound).name();
         }
         try {
             Method getKey = sound.getClass().getMethod("getKey");

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompat.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.utils;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Sound;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+
+/**
+ * Cross-version {@link Sound} resolution. {@code Sound} is an enum up to MC 1.21.2 and an
+ * interface (registry type) from 1.21.3 on; this resolves a sound from a config string and
+ * back without a compile-time assumption about its shape.
+ */
+public final class SoundCompat {
+
+    private SoundCompat() {
+    }
+
+    /**
+     * Resolves a sound from a config value — an enum constant name (e.g.
+     * {@code ENTITY_PLAYER_LEVELUP}) or a namespaced key (e.g.
+     * {@code minecraft:entity.player.levelup}).
+     *
+     * @param value the config value
+     * @return the resolved sound, or {@code null} if unknown
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static @Nullable Sound resolve(@NotNull String value) {
+        String trimmed = value.trim();
+        if (Sound.class.isEnum()) {
+            String name = trimmed.toUpperCase().replace('.', '_').replace(' ', '_').replace(':', '_');
+            // strip a namespace prefix like MINECRAFT_ if present
+            if (name.startsWith("MINECRAFT_")) {
+                name = name.substring("MINECRAFT_".length());
+            }
+            try {
+                return (Sound) Enum.valueOf((Class) Sound.class, name);
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+        return resolveFromRegistry(trimmed);
+    }
+
+    /**
+     * Serializes a sound back to a stable config string: the enum name on enum builds, else the
+     * namespaced key (e.g. {@code minecraft:entity.player.levelup}).
+     *
+     * @param sound the sound
+     * @return the config string
+     */
+    public static @NotNull String toKey(@NotNull Sound sound) {
+        if (sound instanceof Enum) {
+            return ((Enum<?>) sound).name();
+        }
+        try {
+            Method getKey = sound.getClass().getMethod("getKey");
+            Object key = getKey.invoke(sound); // NamespacedKey
+            return String.valueOf(key);
+        } catch (ReflectiveOperationException e) {
+            throw new IllegalStateException("cannot read sound key", e);
+        }
+    }
+
+    private static @Nullable Sound resolveFromRegistry(String value) {
+        try {
+            Class<?> namespacedKey = Class.forName("org.bukkit.NamespacedKey");
+            Method fromString = namespacedKey.getMethod("fromString", String.class);
+            Object key = fromString.invoke(null, value.toLowerCase());
+            if (key == null) {
+                return null;
+            }
+            Method getRegistry = Bukkit.class.getMethod("getRegistry", Class.class);
+            Object registry = getRegistry.invoke(null, Sound.class);
+            if (registry == null) {
+                return null;
+            }
+            Method get = registry.getClass().getMethod("get", namespacedKey);
+            get.setAccessible(true);
+            return (Sound) get.invoke(registry, key);
+        } catch (ReflectiveOperationException e) {
+            return null;
+        }
+    }
+}

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/Utils.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/Utils.java
@@ -22,13 +22,13 @@
  */
 package tech.guilhermekaua.spigotboot.core.spigot.utils;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -125,12 +125,27 @@ public class Utils {
         }
     }
 
-    public static void sync(Plugin plugin, Runnable runnable) {
-        Bukkit.getServer().getScheduler().runTask(plugin, runnable);
+    /**
+     * Runs a task on the thread owning the entity's region.
+     *
+     * @param scheduler the platform scheduler
+     * @param entity    the entity whose region owns the task
+     * @param runnable  the work to run
+     */
+    public static void sync(PlatformScheduler scheduler, Entity entity, Runnable runnable) {
+        scheduler.runOnEntity(entity, runnable, null);
     }
 
-    public static void syncLater(Plugin plugin, Runnable runnable, long delay) {
-        Bukkit.getServer().getScheduler().runTaskLater(plugin, runnable, delay);
+    /**
+     * Runs a task on the thread owning the entity's region after a delay.
+     *
+     * @param scheduler  the platform scheduler
+     * @param entity     the entity whose region owns the task
+     * @param runnable   the work to run
+     * @param delayTicks the delay in server ticks
+     */
+    public static void syncLater(PlatformScheduler scheduler, Entity entity, Runnable runnable, long delayTicks) {
+        scheduler.runOnEntityLater(entity, runnable, null, delayTicks);
     }
 
     public static <T> T find(Collection<T> collection, Predicate<T> predicate) {
@@ -142,13 +157,22 @@ public class Utils {
         return null;
     }
 
-    public static void playSound(Plugin plugin, Player player, String name) {
-        Bukkit.getServer().getScheduler().runTask(plugin, () -> {
-            Utils.tryElsePrint(() -> {
-                final Sound sound = Sound.valueOf(name);
+    /**
+     * Plays a sound for the player on the thread owning the player's region. The sound name is
+     * resolved via {@link SoundCompat} so this works on both enum (≤ 1.21.2) and interface
+     * (≥ 1.21.3) server builds.
+     *
+     * @param scheduler the platform scheduler
+     * @param player    the target player
+     * @param name      the sound name (enum constant or namespaced key)
+     */
+    public static void playSound(PlatformScheduler scheduler, Player player, String name) {
+        scheduler.runOnEntity(player, () -> Utils.tryElsePrint(() -> {
+            Sound sound = SoundCompat.resolve(name);
+            if (sound != null) {
                 player.playSound(player.getEyeLocation(), sound, 1.0f, 1.0f);
-            });
-        });
+            }
+        }), null);
     }
 
     public static long millisToTicks(long millis) {

--- a/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulersTest.java
+++ b/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/scheduler/PlatformSchedulersTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.scheduler;
+
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class PlatformSchedulersTest {
+
+    @Test
+    void selects_folia_scheduler_when_api_present() {
+        Plugin plugin = Mockito.mock(Plugin.class);
+        assertInstanceOf(FoliaPlatformScheduler.class, PlatformSchedulers.create(plugin, true));
+    }
+
+    @Test
+    void selects_bukkit_scheduler_when_api_absent() {
+        Plugin plugin = Mockito.mock(Plugin.class);
+        assertInstanceOf(BukkitPlatformScheduler.class, PlatformSchedulers.create(plugin, false));
+    }
+}

--- a/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompatTest.java
+++ b/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompatTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class SoundCompatTest {
 
@@ -40,5 +41,18 @@ class SoundCompatTest {
     void serializes_enum_sound_to_its_name() {
         Sound sound = SoundCompat.resolve("ENTITY_PLAYER_LEVELUP");
         assertEquals("ENTITY_PLAYER_LEVELUP", SoundCompat.toKey(sound));
+    }
+
+    @Test
+    void resolves_namespaced_key_on_enum_server() {
+        // the enum branch upper-cases, replaces separators, and strips a MINECRAFT_ prefix
+        Sound sound = SoundCompat.resolve("minecraft:entity.player.levelup");
+        assertNotNull(sound);
+        assertEquals("ENTITY_PLAYER_LEVELUP", SoundCompat.toKey(sound));
+    }
+
+    @Test
+    void returns_null_for_unknown_sound() {
+        assertNull(SoundCompat.resolve("not_a_real_sound_xyz"));
     }
 }

--- a/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompatTest.java
+++ b/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/SoundCompatTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.spigot.utils;
+
+import org.bukkit.Sound;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class SoundCompatTest {
+
+    @Test
+    void resolves_enum_sound_by_name() {
+        Sound sound = SoundCompat.resolve("ENTITY_PLAYER_LEVELUP");
+        assertNotNull(sound);
+    }
+
+    @Test
+    void serializes_enum_sound_to_its_name() {
+        Sound sound = SoundCompat.resolve("ENTITY_PLAYER_LEVELUP");
+        assertEquals("ENTITY_PLAYER_LEVELUP", SoundCompat.toKey(sound));
+    }
+}

--- a/platform-spigot/inventory-api/api/pom.xml
+++ b/platform-spigot/inventory-api/api/pom.xml
@@ -90,6 +90,12 @@
         </dependency>
 
         <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-core-spigot</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.20</artifactId>
         </dependency>

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinator.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinator.java
@@ -22,8 +22,6 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine;
 
-import org.bukkit.Bukkit;
-import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
@@ -38,7 +36,6 @@ import tech.guilhermekaua.spigotboot.inventoryapi.state.StateToken;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -59,29 +56,24 @@ final class FlushCoordinator {
     private static final Logger LOGGER = Logger.getLogger(ViewEngine.class.getName());
     static final int CASCADE_CAP = 8;
 
-    private final Plugin plugin;
     private final SessionRegistry sessions;
     private final UpdatePhase updatePhase;
     private final PlatformScheduler scheduler;
 
-    // re-entrancy guard for main-thread shared flushes: a renderer writing shared state
-    // while its view is being flushed must not recurse; main thread only
-    private final Set<View> sharedFlushPending = new HashSet<>();
-    // per-tick coalescing of off-main shared writes: maps each owner to the accumulated set
-    // of dirty token ids; touched from any thread; drained atomically when the scheduled task runs
+    // per-tick coalescing of shared writes: maps each owner to the accumulated set of dirty
+    // token ids; touched from any thread (and any region); drained atomically on the global
+    // region when the scheduled task runs, which then fans the repaint out per session
     private final ConcurrentHashMap<View, Set<Integer>> sharedFlushScheduled = new ConcurrentHashMap<>();
 
     /**
      * Creates the coordinator.
      *
-     * @param plugin      the plugin owning the inventory-api runtime
      * @param sessions    the per-player session registry
      * @param updatePhase the update phase running the repaint passes
      * @param scheduler   the platform scheduler
      */
-    FlushCoordinator(@NotNull Plugin plugin, @NotNull SessionRegistry sessions,
+    FlushCoordinator(@NotNull SessionRegistry sessions,
                      @NotNull UpdatePhase updatePhase, @NotNull PlatformScheduler scheduler) {
-        this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.sessions = Objects.requireNonNull(sessions, "sessions");
         this.updatePhase = Objects.requireNonNull(updatePhase, "updatePhase");
         this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
@@ -127,6 +119,12 @@ final class FlushCoordinator {
      * the repaint to watchers of the supplied token id set. Passing {@code null} for
      * {@code tokenIds} triggers a full repaint (same as the no-arg overload).
      *
+     * <p>The owner's sessions can live in different regions, so each session is repainted on
+     * its own region: inline when the current thread already owns the viewer's region,
+     * otherwise hopped to that region via {@link PlatformScheduler#runOnEntity}. On legacy
+     * Spigot/Paper every session shares the single main thread, so the inline path is always
+     * taken.
+     *
      * @param owner    the view singleton whose sessions should flush
      * @param tokenIds the dirty token ids to pass to the update phase, or {@code null} for a full pass
      */
@@ -134,20 +132,31 @@ final class FlushCoordinator {
         // snapshot: an onUpdate handler may close a session and mutate the registry
         List<ViewSession> snapshot = new ArrayList<>(sessions.all());
         for (ViewSession session : snapshot) {
-            if (session.registered().instance() == owner && session.isActive()) {
-                updatePhase.update(session, UpdateTrigger.STATE_CHANGE, tokenIds);
+            if (session.registered().instance() != owner || !session.isActive()) {
+                continue;
+            }
+            final ViewSession target = session;
+            if (scheduler.ownsRegion(target.player())) {
+                updatePhase.update(target, UpdateTrigger.STATE_CHANGE, tokenIds);
+            } else {
+                // no retired callback: a viewer logging out before this runs leaves the
+                // session inactive, so the deferred repaint is a harmless no-op
+                scheduler.runOnEntity(target.player(),
+                        () -> updatePhase.update(target, UpdateTrigger.STATE_CHANGE, tokenIds), null);
             }
         }
     }
 
     /**
      * Wires the flush hook of every {@code SharedState} token of the view so writes fan out
-     * to all of the view's open sessions: main-thread writes flush immediately (re-entrancy
-     * guarded), off-main writes coalesce into one scheduled flush per view per tick. Already
-     * wired tokens are skipped to avoid redundant re-wiring. The flush is watcher-scoped: each
-     * hook captures its token id and passes it as a singleton dirty set so only components
-     * watching that token are repainted. Called on the main thread via {@code ViewEngine.open};
-     * no separate assertion here.
+     * to all of the view's open sessions. A view's sessions can span regions, so a write from
+     * any thread (and any region) coalesces the dirty token id into the per-owner set and, when
+     * first scheduled for that owner this tick, schedules a single drain on the global region.
+     * The drain only reads the session registry and re-dispatches the repaint per session via
+     * {@link #flushShared} — it never touches world state off-region. Already wired tokens are
+     * skipped to avoid redundant re-wiring. The flush is watcher-scoped: each hook captures its
+     * token id and passes it as a singleton dirty set so only components watching that token are
+     * repainted. Called on the main thread via {@code ViewEngine.open}; no separate assertion here.
      *
      * @param registered the registration whose view instance is being opened
      */
@@ -163,36 +172,28 @@ final class FlushCoordinator {
             }
             final int tokenId = shared.id();
             shared.flushHook(() -> {
-                if (Bukkit.isPrimaryThread()) {
-                    if (sharedFlushPending.add(owner)) {
-                        try {
-                            flushShared(owner, Collections.singleton(tokenId));
-                        } finally {
-                            sharedFlushPending.remove(owner);
-                        }
+                // compute is atomic vs the drain's remove on the same key, so an id can
+                // never land in an already-drained set
+                boolean[] schedule = {false};
+                sharedFlushScheduled.compute(owner, (key, existing) -> {
+                    if (existing == null) {
+                        Set<Integer> created = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
+                        created.add(tokenId);
+                        schedule[0] = true;
+                        return created;
                     }
-                } else {
-                    // compute is atomic vs the drain's remove on the same key, so an id can
-                    // never land in an already-drained set
-                    boolean[] schedule = {false};
-                    sharedFlushScheduled.compute(owner, (key, existing) -> {
-                        if (existing == null) {
-                            Set<Integer> created = Collections.newSetFromMap(new ConcurrentHashMap<Integer, Boolean>());
-                            created.add(tokenId);
-                            schedule[0] = true;
-                            return created;
+                    existing.add(tokenId);
+                    return existing;
+                });
+                if (schedule[0]) {
+                    // drain on the global region: it only reads the registry and re-dispatches
+                    // per session, so it is the one region-safe place to fan out across regions
+                    scheduler.runGlobal(() -> {
+                        Set<Integer> ids = sharedFlushScheduled.remove(owner);
+                        if (ids != null) {
+                            flushShared(owner, ids);
                         }
-                        existing.add(tokenId);
-                        return existing;
                     });
-                    if (schedule[0]) {
-                        Bukkit.getScheduler().runTask(plugin, () -> {
-                            Set<Integer> ids = sharedFlushScheduled.remove(owner);
-                            if (ids != null) {
-                                flushShared(owner, ids);
-                            }
-                        });
-                    }
                 }
             });
         }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinator.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinator.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
  * Flush machinery extracted from {@link ViewEngine}: the dirty-token cascade loop, the
  * shared-state fan-out flush with its re-entrancy guard and per-tick coalescing, and the
  * shared flush-hook wiring. Behavior-preserving extraction — {@link ViewEngine} keeps the
- * public entry points (and their main-thread asserts) and delegates here.
+ * public entry points (and their region-ownership asserts) and delegates here.
  */
 final class FlushCoordinator {
 
@@ -91,8 +91,8 @@ final class FlushCoordinator {
      * Flushes dirty state tokens of a session: each pass drains the dirty set and runs a
      * STATE_CHANGE update over the watchers; passes repeat while handlers re-dirty tokens,
      * capped at {@value #CASCADE_CAP} cascades per flush, after which the remaining dirty
-     * tokens are dropped with a WARNING. Main thread only; the {@link ViewEngine} entry
-     * point asserts it.
+     * tokens are dropped with a WARNING. The {@link ViewEngine} entry point asserts
+     * the calling thread owns the viewer's region.
      *
      * @param session the session to flush
      */
@@ -113,8 +113,8 @@ final class FlushCoordinator {
 
     /**
      * Runs a full STATE_CHANGE repaint pass on every active session of the given view; full-pass
-     * fallback — the wired hooks use the watcher-scoped overload. Main thread only; the
-     * {@link ViewEngine} entry point asserts it.
+     * fallback — the wired hooks use the watcher-scoped overload. The {@link ViewEngine}
+     * entry point asserts the calling thread owns the viewer's region.
      *
      * @param owner the view singleton whose sessions should flush
      */

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinator.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinator.java
@@ -26,6 +26,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.UpdateTrigger;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.engine.phase.UpdatePhase;
@@ -61,6 +62,7 @@ final class FlushCoordinator {
     private final Plugin plugin;
     private final SessionRegistry sessions;
     private final UpdatePhase updatePhase;
+    private final PlatformScheduler scheduler;
 
     // re-entrancy guard for main-thread shared flushes: a renderer writing shared state
     // while its view is being flushed must not recurse; main thread only
@@ -75,12 +77,14 @@ final class FlushCoordinator {
      * @param plugin      the plugin owning the inventory-api runtime
      * @param sessions    the per-player session registry
      * @param updatePhase the update phase running the repaint passes
+     * @param scheduler   the platform scheduler
      */
     FlushCoordinator(@NotNull Plugin plugin, @NotNull SessionRegistry sessions,
-                     @NotNull UpdatePhase updatePhase) {
+                     @NotNull UpdatePhase updatePhase, @NotNull PlatformScheduler scheduler) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.sessions = Objects.requireNonNull(sessions, "sessions");
         this.updatePhase = Objects.requireNonNull(updatePhase, "updatePhase");
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
     }
 
     /**

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
@@ -58,7 +58,7 @@ import java.util.Objects;
 
 /**
  * Orchestrator of the view lifecycle: composes the fixed-order phase handlers and is the
- * sole mutator of sessions. All entry points assert the main thread.
+ * sole mutator of sessions. All entry points assert that the calling thread owns the viewer's region.
  */
 @Component
 @ApiStatus.Internal
@@ -82,7 +82,7 @@ public final class ViewEngine {
     final PaginationInitPhase paginationInitPhase;
 
     // flush machinery extracted behind a dedicated coordinator (single responsibility);
-    // the flush entry points below delegate to it after asserting the main thread
+    // the flush entry points below delegate to it after asserting region ownership
     private final FlushCoordinator flushCoordinator;
 
     /**
@@ -125,7 +125,7 @@ public final class ViewEngine {
      * @throws UnknownViewException     when the view class is not registered
      * @throws IllegalArgumentException when an {@code initialState} argument has a
      *                                  mismatching type
-     * @throws IllegalStateException    when called off the main thread
+     * @throws IllegalStateException    when called off the thread owning the viewer's region
      */
     public void open(@NotNull Player player, @NotNull Class<? extends View> viewType,
                      @NotNull ViewArguments arguments) {
@@ -140,6 +140,7 @@ public final class ViewEngine {
             if (current != null) {
                 defer(current, () -> open(player, viewType, arguments));
             } else {
+                // no retired callback: a player logging out before this runs leaves nothing to clean up (no session yet)
                 scheduler.runOnEntity(player, () -> open(player, viewType, arguments), null);
             }
             return;
@@ -185,7 +186,7 @@ public final class ViewEngine {
      *
      * @param session the session whose container title is updated
      * @param title   the new title, legacy color codes supported
-     * @throws IllegalStateException when called off the main thread
+     * @throws IllegalStateException when called off the thread owning the viewer's region
      */
     public void updateTitle(@NotNull ViewSession session, @NotNull String title) {
         ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.updateTitle");
@@ -215,7 +216,7 @@ public final class ViewEngine {
      *
      * @param session the session whose pagination token settled
      * @param tokenId the token id of the settled pagination declaration
-     * @throws IllegalStateException when called off the main thread
+     * @throws IllegalStateException when called off the thread owning the viewer's region
      */
     public void paginationSettle(@NotNull ViewSession session, int tokenId) {
         ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.paginationSettle");

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
@@ -71,7 +71,9 @@ public final class ViewEngine {
     private final TitleUpdater titleUpdater;
     private final PlatformScheduler scheduler;
 
-    private boolean inClickDispatch;
+    // per-thread: under Folia region concurrency one ViewEngine instance serves multiple region
+    // threads at once, so a shared flag would leak click-dispatch state across concurrent sessions.
+    private final ThreadLocal<Boolean> inClickDispatch = ThreadLocal.withInitial(() -> Boolean.FALSE);
 
     // fixed-order phase handlers, engine-owned
     final OpenPhase openPhase;
@@ -367,7 +369,7 @@ public final class ViewEngine {
      * @return {@code true} while a click is being dispatched
      */
     public boolean isInClickDispatch() {
-        return inClickDispatch;
+        return inClickDispatch.get();
     }
 
     /**
@@ -378,7 +380,11 @@ public final class ViewEngine {
      */
     @ApiStatus.Internal
     public void clickDispatch(boolean active) {
-        this.inClickDispatch = active;
+        if (active) {
+            inClickDispatch.set(Boolean.TRUE);
+        } else {
+            inClickDispatch.remove();
+        }
     }
 
     /**

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
@@ -110,7 +110,7 @@ public final class ViewEngine {
         this.updatePhase = new UpdatePhase(this, painter);
         this.clickRoutingPhase = new ClickRoutingPhase(this);
         this.paginationInitPhase = new PaginationInitPhase(this, sessions);
-        this.flushCoordinator = new FlushCoordinator(plugin, sessions, updatePhase, scheduler);
+        this.flushCoordinator = new FlushCoordinator(sessions, updatePhase, scheduler);
     }
 
     /**

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
@@ -33,6 +33,7 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseReason;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.UpdateTrigger;
@@ -69,6 +70,7 @@ public final class ViewEngine {
     private final SessionRegistry sessions;
     private final SlotPainter painter;
     private final TitleUpdater titleUpdater;
+    private final PlatformScheduler scheduler;
 
     private boolean inClickDispatch;
 
@@ -92,21 +94,24 @@ public final class ViewEngine {
      * @param sessions     the per-player session registry
      * @param painter      the slot painter used by the rendering phases
      * @param titleUpdater the in-place title update strategy
+     * @param scheduler    the platform scheduler
      */
     public ViewEngine(@NotNull Plugin plugin, @NotNull ViewRegistry views, @NotNull SessionRegistry sessions,
-                      @NotNull SlotPainter painter, @NotNull TitleUpdater titleUpdater) {
+                      @NotNull SlotPainter painter, @NotNull TitleUpdater titleUpdater,
+                      @NotNull PlatformScheduler scheduler) {
         this.plugin = Objects.requireNonNull(plugin, "plugin");
         this.views = Objects.requireNonNull(views, "views");
         this.sessions = Objects.requireNonNull(sessions, "sessions");
         this.painter = Objects.requireNonNull(painter, "painter");
         this.titleUpdater = Objects.requireNonNull(titleUpdater, "titleUpdater");
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
         this.closePhase = new ClosePhase(this, sessions);
         this.openPhase = new OpenPhase(this, sessions, painter);
         this.firstRenderPhase = new FirstRenderPhase(this, sessions, painter);
         this.updatePhase = new UpdatePhase(this, painter);
         this.clickRoutingPhase = new ClickRoutingPhase(this);
         this.paginationInitPhase = new PaginationInitPhase(this, sessions);
-        this.flushCoordinator = new FlushCoordinator(plugin, sessions, updatePhase);
+        this.flushCoordinator = new FlushCoordinator(plugin, sessions, updatePhase, scheduler);
     }
 
     /**
@@ -394,6 +399,15 @@ public final class ViewEngine {
      */
     public @NotNull Plugin plugin() {
         return plugin;
+    }
+
+    /**
+     * Returns the platform scheduler used by this engine.
+     *
+     * @return the platform scheduler
+     */
+    public @NotNull PlatformScheduler scheduler() {
+        return scheduler;
     }
 
     /**

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngine.java
@@ -22,7 +22,6 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine;
 
-import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -130,7 +129,7 @@ public final class ViewEngine {
      */
     public void open(@NotNull Player player, @NotNull Class<? extends View> viewType,
                      @NotNull ViewArguments arguments) {
-        ThreadUtils.assertMainThread("ViewEngine.open");
+        ThreadUtils.assertOwnsRegion(scheduler, player, "ViewEngine.open");
         Objects.requireNonNull(player, "player");
         Objects.requireNonNull(arguments, "arguments");
         if (isInClickDispatch()) {
@@ -141,7 +140,7 @@ public final class ViewEngine {
             if (current != null) {
                 defer(current, () -> open(player, viewType, arguments));
             } else {
-                Bukkit.getScheduler().runTask(plugin, () -> open(player, viewType, arguments));
+                scheduler.runOnEntity(player, () -> open(player, viewType, arguments), null);
             }
             return;
         }
@@ -169,7 +168,7 @@ public final class ViewEngine {
      * @param reason  the close reason
      */
     public void close(@NotNull ViewSession session, @NotNull CloseReason reason) {
-        ThreadUtils.assertMainThread("ViewEngine.close");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.close");
         if (isInClickDispatch()) {
             // self-defer: the deferred op runs at end of tick, when click dispatch is
             // over, so it cannot re-defer
@@ -189,7 +188,7 @@ public final class ViewEngine {
      * @throws IllegalStateException when called off the main thread
      */
     public void updateTitle(@NotNull ViewSession session, @NotNull String title) {
-        ThreadUtils.assertMainThread("ViewEngine.updateTitle");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.updateTitle");
         // placeholders first, then color codes: PAPI output may itself contain '&' codes
         String resolved = ChatColor.translateAlternateColorCodes('&',
                 painter.applyText(session.player(), title, session.effectiveConfig().applyPlaceholders()));
@@ -203,7 +202,7 @@ public final class ViewEngine {
      * @param trigger the cause of the update
      */
     public void update(@NotNull ViewSession session, @NotNull UpdateTrigger trigger) {
-        ThreadUtils.assertMainThread("ViewEngine.update");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.update");
         updatePhase.update(session, trigger, null);
         flushDirty(session);
     }
@@ -219,7 +218,7 @@ public final class ViewEngine {
      * @throws IllegalStateException when called off the main thread
      */
     public void paginationSettle(@NotNull ViewSession session, int tokenId) {
-        ThreadUtils.assertMainThread("ViewEngine.paginationSettle");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.paginationSettle");
         ViewSession.Status status = session.status();
         if (status == ViewSession.Status.CLOSED || status == ViewSession.Status.OPENING) {
             return;
@@ -238,7 +237,7 @@ public final class ViewEngine {
      * @param event   the Bukkit event
      */
     public void click(@NotNull ViewSession session, @NotNull InventoryClickEvent event) {
-        ThreadUtils.assertMainThread("ViewEngine.click");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.click");
         clickDispatch(true);
         try {
             clickRoutingPhase.route(session, event);
@@ -258,7 +257,7 @@ public final class ViewEngine {
      * @param event   the Bukkit event
      */
     public void drag(@NotNull ViewSession session, @NotNull InventoryDragEvent event) {
-        ThreadUtils.assertMainThread("ViewEngine.drag");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.drag");
         if (!session.effectiveConfig().cancelOnDrag()) {
             return;
         }
@@ -284,7 +283,7 @@ public final class ViewEngine {
      * @param event   the Bukkit event
      */
     public void bukkitClose(@NotNull ViewSession session, @NotNull InventoryCloseEvent event) {
-        ThreadUtils.assertMainThread("ViewEngine.bukkitClose");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.bukkitClose");
         if (event.getInventory() != session.inventory()) {
             return;
         }
@@ -300,7 +299,7 @@ public final class ViewEngine {
      * @param session the session to flush
      */
     public void flushDirty(@NotNull ViewSession session) {
-        ThreadUtils.assertMainThread("ViewEngine.flushDirty");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.flushDirty");
         flushCoordinator.flushDirty(session);
     }
 
@@ -311,7 +310,6 @@ public final class ViewEngine {
      * @param owner the view singleton whose sessions should flush
      */
     public void flushShared(@NotNull View owner) {
-        ThreadUtils.assertMainThread("ViewEngine.flushShared");
         flushCoordinator.flushShared(owner);
     }
 
@@ -337,7 +335,7 @@ public final class ViewEngine {
      * @param op      the operation to run at end of tick
      */
     public void defer(@NotNull ViewSession session, @NotNull Runnable op) {
-        ThreadUtils.assertMainThread("ViewEngine.defer");
+        ThreadUtils.assertOwnsRegion(scheduler, session.player(), "ViewEngine.defer");
         if (session.status() == ViewSession.Status.ACTIVE) {
             session.status(ViewSession.Status.TRANSITIONING);
         }
@@ -347,7 +345,7 @@ public final class ViewEngine {
                 op.run();
             }
         });
-        Bukkit.getScheduler().runTask(plugin, () -> drainDeferred(session));
+        scheduler.runOnEntity(session.player(), () -> drainDeferred(session), null);
     }
 
     private void drainDeferred(ViewSession session) {

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/ClosePhase.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/ClosePhase.java
@@ -22,8 +22,8 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine.phase;
 
-import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.ApiStatus;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import org.jetbrains.annotations.NotNull;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseReason;
@@ -73,7 +73,7 @@ public final class ClosePhase {
         if (session.status() == ViewSession.Status.CLOSED) {
             return;
         }
-        BukkitTask updateTask = session.updateTask();
+        PlatformTask updateTask = session.updateTask();
         if (updateTask != null) {
             updateTask.cancel();
             session.updateTask(null);

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/ClosePhase.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/ClosePhase.java
@@ -23,8 +23,8 @@
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine.phase;
 
 import org.jetbrains.annotations.ApiStatus;
-import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseReason;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.HandlerInvoker;

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
@@ -24,9 +24,9 @@ package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine.phase;
 
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.exception.ViewConfigurationException;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.HandlerInvoker;

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
@@ -22,10 +22,9 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine.phase;
 
-import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitTask;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
@@ -191,8 +190,8 @@ public final class FirstRenderPhase {
         if (interval <= 0) {
             return;
         }
-        BukkitTask task = Bukkit.getScheduler().runTaskTimer(engine.plugin(),
-                new ViewUpdateTask(engine, session), interval, interval);
+        PlatformTask task = engine.scheduler().runOnEntityAtFixedRate(session.player(),
+                new ViewUpdateTask(engine, session), null, interval, interval);
         session.updateTask(task);
     }
 }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
@@ -384,7 +384,7 @@ public final class PaginationBinding implements PaginationHost {
 
     @Override
     public @Nullable UUID playerId() {
-        return session.player().getUniqueId();
+        return player().getUniqueId();
     }
 
     @Override

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
@@ -22,6 +22,7 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -198,7 +199,7 @@ public final class PaginationBinding implements PaginationHost {
         this.targetSlots = resolveTargetSlots(fillLayout, patterns);
 
         this.plainContext = new PlainViewContextImpl(session, engine);
-        PageSource<Object> source = spec.source().createSource(plainContext, spec);
+        PageSource<Object> source = spec.source().createSource(plainContext, spec, engine.scheduler());
         this.fallbackSupplier = frameSupplier(spec.fallbackItem(), "fallback item");
         this.loadingSupplier = frameSupplier(spec.loadingItem(), "loading item");
         PageItemFactory<Object> factory = elementFactory();
@@ -384,6 +385,11 @@ public final class PaginationBinding implements PaginationHost {
     @Override
     public @Nullable UUID playerId() {
         return session.player().getUniqueId();
+    }
+
+    @Override
+    public @NotNull Player player() {
+        return session.player();
     }
 
     @Override

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationHost.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationHost.java
@@ -22,6 +22,7 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination;
 
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
@@ -67,6 +68,15 @@ public interface PaginationHost {
      * @return the viewing player's id; production hosts never return null (test fixtures may)
      */
     @Nullable UUID playerId();
+
+    /**
+     * Returns the live viewer the settle dispatcher uses to route the settle to the correct
+     * region thread. Production hosts always return the session's player; test fixtures may
+     * return {@code null} to trigger the inline-settle path.
+     *
+     * @return the viewing player, or {@code null} for test fixtures
+     */
+    @Nullable Player player();
 
     /**
      * Returns the plugin that owns the view; asynchronously completed settles are scheduled

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpec.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpec.java
@@ -25,6 +25,7 @@ package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.ViewContext;
 import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.AsyncPageSource;
 import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.AsyncPageSupplier;
@@ -200,21 +201,26 @@ public final class PaginationSourceSpec<T> {
      *       defensive copy).</li>
      *   <li>{@link Kind#ASYNC}: constructs a fresh {@link AsyncPageSource} from the supplier
      *       and the spec's async options, dispatching settles through a
-     *       {@link BukkitSettleDispatcher}.</li>
+     *       {@link BukkitSettleDispatcher} backed by the given scheduler.</li>
      *   <li>{@link Kind#CUSTOM}: invokes the factory with {@code context} and returns its
      *       result as-is.</li>
      * </ul>
      *
-     * @param context the context the source will serve
-     * @param spec    the owning spec, read for the async options
+     * @param context   the context the source will serve
+     * @param spec      the owning spec, read for the async options
+     * @param scheduler the platform scheduler used to route async settles to the viewer's
+     *                  region thread; passed through to the {@link BukkitSettleDispatcher}
+     *                  for {@link Kind#ASYNC} sources
      * @return the page source for this context
      * @throws NullPointerException if the lazy function returns null
      *         ("lazy pagination source function returned null"), or the custom factory
      *         returns null ("paginateSource factory returned null"), or an argument is null
      */
-    public @NotNull PageSource<T> createSource(@NotNull ViewContext context, @NotNull PaginationSpec<T> spec) {
+    public @NotNull PageSource<T> createSource(@NotNull ViewContext context, @NotNull PaginationSpec<T> spec,
+                                               @NotNull PlatformScheduler scheduler) {
         Objects.requireNonNull(context, "context is required.");
         Objects.requireNonNull(spec, "spec is required.");
+        Objects.requireNonNull(scheduler, "scheduler is required.");
         switch (kind) {
             case EAGER_STATIC:
                 return sharedEagerSource;
@@ -223,7 +229,7 @@ public final class PaginationSourceSpec<T> {
                         "lazy pagination source function returned null"));
             case ASYNC:
                 return new AsyncPageSource<>(asyncSupplier, spec.errorCallback(), spec.requestTimeout(),
-                        spec.cacheTtl(), spec.cacheMaxPages(), new BukkitSettleDispatcher());
+                        spec.cacheTtl(), spec.cacheMaxPages(), new BukkitSettleDispatcher(scheduler));
             case CUSTOM:
                 return Objects.requireNonNull(customFactory.apply(context),
                         "paginateSource factory returned null");

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSpec.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSpec.java
@@ -41,7 +41,7 @@ import java.util.function.Function;
 /**
  * Immutable pagination declaration built by {@code PaginationBuilderImpl.build()}: geometry,
  * paint target, renderer and frame items, the source declaration, and the async plumbing
- * consumed by {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec)}. All
+ * consumed by {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec, tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler)}. All
  * combination validation happens in the builder before a spec is constructed; the spec only
  * carries the validated values.
  *
@@ -237,7 +237,7 @@ public final class PaginationSpec<T> {
 
     /**
      * Returns the async error callback, consumed by
-     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec)}.
+     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec, tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler)}.
      *
      * @return the callback, or null
      */
@@ -247,7 +247,7 @@ public final class PaginationSpec<T> {
 
     /**
      * Returns the async per-request timeout, consumed by
-     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec)}.
+     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec, tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler)}.
      *
      * @return the timeout, or null when disabled
      */
@@ -257,7 +257,7 @@ public final class PaginationSpec<T> {
 
     /**
      * Returns the async cache TTL, consumed by
-     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec)}.
+     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec, tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler)}.
      *
      * @return the TTL, or null when caching is disabled
      */
@@ -267,7 +267,7 @@ public final class PaginationSpec<T> {
 
     /**
      * Returns the async cache LRU bound, consumed by
-     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec)}.
+     * {@link PaginationSourceSpec#createSource(ViewContext, PaginationSpec, tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler)}.
      *
      * @return the bound; 128 unless overridden (the 2.x {@code DEFAULT_CACHE_MAX_PAGES})
      */

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AbstractPageSourcePagination.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AbstractPageSourcePagination.java
@@ -222,7 +222,7 @@ abstract class AbstractPageSourcePagination<T, S> implements Paginator<T> {
     private void dispatch(S rollback, boolean render) {
         // the host is always bound here: bind dispatches after setting it, and changePageInternal records-only when unbound
         PageRequest request = new PageRequest(this.currentPage, this.itemPageLimit,
-                requestOffset(), this.host.playerId(), this.host.plugin());
+                requestOffset(), this.host.playerId(), this.host.plugin(), this.host.player());
         this.dispatchingThread = Thread.currentThread();
         try {
             this.pageSource.request(request, (result, error) -> onSettle(rollback, result, error));

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/session/ViewSession.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/session/ViewSession.java
@@ -24,10 +24,10 @@ package tech.guilhermekaua.spigotboot.inventoryapi.internal.session;
 
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfig;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.component.ComponentTable;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.layout.ResolvedLayout;
@@ -78,7 +78,7 @@ public final class ViewSession {
     private Inventory inventory;
     private ViewConfig effectiveConfig;
     private ResolvedLayout layout;
-    private BukkitTask updateTask;
+    private PlatformTask updateTask;
 
     /**
      * Creates a session in {@link Status#OPENING}.
@@ -221,7 +221,7 @@ public final class ViewSession {
      *
      * @return the task, or {@code null} when scheduling is disabled or not started
      */
-    public @Nullable BukkitTask updateTask() {
+    public @Nullable PlatformTask updateTask() {
         return updateTask;
     }
 
@@ -230,7 +230,7 @@ public final class ViewSession {
      *
      * @param t the task, or {@code null} to clear it
      */
-    public void updateTask(@Nullable BukkitTask t) {
+    public void updateTask(@Nullable PlatformTask t) {
         this.updateTask = t;
     }
 

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/util/ThreadUtils.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/util/ThreadUtils.java
@@ -23,8 +23,10 @@
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.util;
 
 import org.bukkit.Bukkit;
+import org.bukkit.entity.Entity;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 
 /**
  * Shared threading assertions for the inventory-api internals.
@@ -45,6 +47,20 @@ public final class ThreadUtils {
     public static void assertMainThread(@NotNull String operation) {
         if (Bukkit.getServer() != null && !Bukkit.isPrimaryThread()) {
             throw new IllegalStateException(operation + " must be called on the main server thread");
+        }
+    }
+
+    /**
+     * Throws when the current thread does not own the entity's region.
+     *
+     * @param scheduler the platform scheduler used for the ownership check
+     * @param entity    the entity whose region must be owned (the viewer)
+     * @param operation the operation name used in the error message
+     * @throws IllegalStateException when the current thread does not own the entity's region
+     */
+    public static void assertOwnsRegion(@NotNull PlatformScheduler scheduler, @NotNull Entity entity, @NotNull String operation) {
+        if (!scheduler.ownsRegion(entity)) {
+            throw new IllegalStateException(operation + " must be called on the thread owning the viewer's region");
         }
     }
 }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/BukkitSettleDispatcher.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/BukkitSettleDispatcher.java
@@ -22,42 +22,67 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.pagination.source;
 
-import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.IllegalPluginAccessException;
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Default {@link SettleDispatcher}: settles always route to the main server thread — inline
- * when the load already completed there, otherwise through the Bukkit scheduler on behalf of
- * the request's owning plugin. A request without a plugin (engine-external test usage only)
- * settles inline on the completing thread.
+ * Default {@link SettleDispatcher}: settles route to the viewer's region thread (Folia) or
+ * the main thread (legacy Spigot/Paper) via the injected {@link PlatformScheduler}.
  *
- * <p>Dispatch order is FIFO: inline settles run immediately and the Bukkit scheduler runs
- * same-tick tasks in submission order. {@link AsyncPageSource} relies on this — a request's
- * timeout settle must reach the dispatcher before the cancellation settle it triggers, so the
- * at-most-once check discards the latter.
+ * <p>Routing rules:
+ * <ol>
+ *   <li>No viewer ({@link PageRequest#viewer()} is {@code null}) — engine-external test
+ *       usage: settle runs inline on the completing thread.</li>
+ *   <li>The calling thread already owns the viewer's region — settle runs inline.</li>
+ *   <li>Otherwise — the settle is dispatched to the viewer's entity scheduler.</li>
+ * </ol>
  *
- * <p>A settle completing while the owning plugin is disabling is dropped with a warning: the
- * scheduler rejects new tasks at that point and the inventory is about to be closed by the
- * shutdown anyway.
+ * <p>Dispatch order is FIFO: inline settles run immediately; the scheduler runs same-tick
+ * tasks in submission order. {@link AsyncPageSource} relies on this — a request's timeout
+ * settle must reach the dispatcher before the cancellation settle it triggers.
+ *
+ * <p>A settle that is rejected because the owning plugin is disabling
+ * ({@link IllegalPluginAccessException}) is dropped with a warning: the scheduler will not
+ * accept new tasks at that point and the inventory is about to be closed anyway.
  */
 public final class BukkitSettleDispatcher implements SettleDispatcher {
 
     private static final Logger LOGGER = Logger.getLogger(BukkitSettleDispatcher.class.getName());
 
+    private final PlatformScheduler scheduler;
+
+    /**
+     * Creates the dispatcher.
+     *
+     * @param scheduler the platform scheduler used to route settles to the viewer's region
+     */
+    public BukkitSettleDispatcher(@NotNull PlatformScheduler scheduler) {
+        this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+    }
+
     @Override
     public void dispatch(PageRequest request, Runnable task) {
-        if (request.plugin() == null || Bukkit.isPrimaryThread()) {
+        Player viewer = request.viewer();
+        if (viewer == null) {
+            // engine-external test usage: settle inline on the completing thread
+            task.run();
+            return;
+        }
+        if (scheduler.ownsRegion(viewer)) {
             task.run();
             return;
         }
         try {
-            Bukkit.getScheduler().runTask(request.plugin(), task);
+            scheduler.runOnEntity(viewer, task, null);
         } catch (IllegalPluginAccessException e) {
-            // thrown inside whenComplete or a timeout task this would otherwise vanish into
-            // an unobserved future
+            // thrown inside whenComplete or a timeout task; swallow so the completing thread
+            // does not blow up — the session is about to be closed during plugin disable
             LOGGER.log(Level.WARNING, "Dropped a page-load settle: the owning plugin is disabled.", e);
         }
     }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/PageRequest.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/PageRequest.java
@@ -115,8 +115,9 @@ public final class PageRequest {
     }
 
     /**
-     * Returns the plugin owning the load; the settle dispatcher schedules onto the main
-     * thread on its behalf.
+     * Returns the plugin that owns the load. Informational: the built-in
+     * {@link BukkitSettleDispatcher} routes settles by {@link #viewer()} via the platform
+     * scheduler and does not use this; a custom {@link SettleDispatcher} may use it.
      *
      * @return the owning plugin, or {@code null} only for engine-external test usage
      */

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/PageRequest.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/PageRequest.java
@@ -22,6 +22,7 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.pagination.source;
 
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
@@ -35,8 +36,9 @@ import java.util.UUID;
  * {@code page} is informational only: scroll paginators advance one element per page, so
  * deriving the offset as {@code (page - 1) * pageSize} is wrong for them.
  *
- * <p>{@code playerId} identifies who the page is loaded for and {@code plugin} owns the load
- * (the settle dispatcher schedules onto the main thread on its behalf). Both are {@code null}
+ * <p>{@code playerId} identifies who the page is loaded for and {@code plugin} owns the load.
+ * {@code viewer} is the live {@link Player} the settle dispatcher uses to route the settle to
+ * the viewer's region thread (Folia) or the main thread (legacy). All three are {@code null}
  * only for engine-external test usage — requests dispatched by the built-in paginators always
  * populate them.
  */
@@ -47,6 +49,7 @@ public final class PageRequest {
     private final int offset;
     private final UUID playerId;
     private final Plugin plugin;
+    private final Player viewer;
 
     /**
      * Creates a page request.
@@ -58,13 +61,18 @@ public final class PageRequest {
      *                 engine-external test usage
      * @param plugin   the plugin owning the load, or {@code null} only for engine-external
      *                 test usage
+     * @param viewer   the live {@link Player} the settle dispatcher routes the settle for;
+     *                 {@code null} only for engine-external test usage, in which case the
+     *                 settle runs inline on the completing thread
      */
-    public PageRequest(int page, int pageSize, int offset, @Nullable UUID playerId, @Nullable Plugin plugin) {
+    public PageRequest(int page, int pageSize, int offset, @Nullable UUID playerId,
+                       @Nullable Plugin plugin, @Nullable Player viewer) {
         this.page = page;
         this.pageSize = pageSize;
         this.offset = offset;
         this.playerId = playerId;
         this.plugin = plugin;
+        this.viewer = viewer;
     }
 
     /**
@@ -114,5 +122,18 @@ public final class PageRequest {
      */
     public @Nullable Plugin plugin() {
         return plugin;
+    }
+
+    /**
+     * Returns the live viewer the settle dispatcher uses to route the settle to the correct
+     * region thread. On Folia each player's inventory is owned by the region containing the
+     * player; the settle must run on that region's thread. On legacy Spigot/Paper the
+     * dispatcher falls back to the main thread.
+     *
+     * @return the viewing player, or {@code null} only for engine-external test usage
+     *         (in which case the settle runs inline on the completing thread)
+     */
+    public @Nullable Player viewer() {
+        return viewer;
     }
 }

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/ViewTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/ViewTest.java
@@ -23,6 +23,7 @@
 package tech.guilhermekaua.spigotboot.inventoryapi;
 
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.ViewContext;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination.PaginationImpl;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination.PaginationSourceSpec;
@@ -185,8 +186,9 @@ class ViewTest {
 
         PaginationImpl<String> token = (PaginationImpl<String>) builder.itemRenderer(noopRenderer()).build();
         ViewContext context = mock(ViewContext.class);
-        PageSource<String> first = token.spec().source().createSource(context, token.spec());
-        PageSource<String> second = token.spec().source().createSource(context, token.spec());
+        PlatformScheduler scheduler = mock(PlatformScheduler.class);
+        PageSource<String> first = token.spec().source().createSource(context, token.spec(), scheduler);
+        PageSource<String> second = token.spec().source().createSource(context, token.spec(), scheduler);
 
         assertEquals(Arrays.asList("a", "b"), first.elements());
         // EAGER_STATIC serves the one shared immutable source to every context

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/context/ContextPhaseValidityTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/context/ContextPhaseValidityTest.java
@@ -27,6 +27,7 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.entity.Entity;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -53,6 +54,7 @@ import tech.guilhermekaua.spigotboot.inventoryapi.internal.render.SlotPainter;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.SessionRegistry;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.ViewSession;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.state.StateStore;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.util.ThreadUtils;
 import tech.guilhermekaua.spigotboot.inventoryapi.placeholder.NoopPlaceholderApplier;
 import tech.guilhermekaua.spigotboot.inventoryapi.service.ViewArguments;
@@ -75,6 +77,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -102,8 +105,10 @@ class ContextPhaseValidityTest {
         server = MockBukkit.mock();
         plugin = mock(Plugin.class);
         titleUpdater = mock(TitleUpdater.class);
+        PlatformScheduler scheduler = mock(PlatformScheduler.class);
+        when(scheduler.ownsRegion(any(Entity.class))).thenReturn(true);
         engine = new ViewEngine(plugin, new ViewRegistry(), new SessionRegistry(),
-                new SlotPainter(new NoopPlaceholderApplier()), titleUpdater);
+                new SlotPainter(new NoopPlaceholderApplier()), titleUpdater, scheduler);
         player = server.addPlayer("tester");
     }
 
@@ -230,8 +235,10 @@ class ContextPhaseValidityTest {
     @Test
     void updateTitle_appliesPlaceholdersAndColorCodesBeforeTheTitleUpdater() {
         List<String> received = new ArrayList<>();
+        PlatformScheduler recordingScheduler = mock(PlatformScheduler.class);
+        when(recordingScheduler.ownsRegion(any(Entity.class))).thenReturn(true);
         ViewEngine recordingEngine = new ViewEngine(plugin, new ViewRegistry(), new SessionRegistry(),
-                new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> received.add(title));
+                new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> received.add(title), recordingScheduler);
         ViewSession session = sessionFor(new ProbeView(), config());
         session.status(ViewSession.Status.ACTIVE);
         PlainViewContextImpl context = new PlainViewContextImpl(session, recordingEngine);

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ClickRoutingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ClickRoutingTest.java
@@ -47,6 +47,7 @@ import tech.guilhermekaua.spigotboot.inventoryapi.internal.registry.ViewRegistry
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.render.SlotPainter;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.SessionRegistry;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.ViewSession;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.placeholder.NoopPlaceholderApplier;
 import tech.guilhermekaua.spigotboot.inventoryapi.service.ViewArguments;
 
@@ -185,7 +186,7 @@ class ClickRoutingTest {
         views.register(new ErrorThrowingView());
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, t) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/DeferredOpsTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/DeferredOpsTest.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
@@ -177,7 +178,7 @@ class DeferredOpsTest {
         views.register(closeNavView);
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, t) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinatorRegionTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/FlushCoordinatorRegionTest.java
@@ -1,0 +1,220 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.MockPlugin;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.Entity;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
+import tech.guilhermekaua.spigotboot.inventoryapi.View;
+import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.RenderContext;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.registry.ViewRegistry;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.render.SlotPainter;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.SessionRegistry;
+import tech.guilhermekaua.spigotboot.inventoryapi.placeholder.NoopPlaceholderApplier;
+import tech.guilhermekaua.spigotboot.inventoryapi.service.ViewArguments;
+import tech.guilhermekaua.spigotboot.inventoryapi.service.ViewService;
+import tech.guilhermekaua.spigotboot.inventoryapi.state.SharedState;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Region-correctness of the shared-state flush fan-out. An off-region shared write must repaint
+ * each open session of the owning view on that session's own region — one {@code runOnEntity(viewer)}
+ * dispatch per active session — rather than a single global hop that touches every viewer from one
+ * thread. Drives a real {@link ViewEngine} with a recording {@link PlatformScheduler} stand-in for
+ * Folia, where no single thread owns more than one viewer's region.
+ */
+class FlushCoordinatorRegionTest {
+
+    private ServerMock server;
+    private MockPlugin plugin;
+    private ViewService service;
+    private SessionRegistry sessions;
+    private RecordingScheduler scheduler;
+    private SharedFanOutView view;
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.createMockPlugin();
+        sessions = new SessionRegistry();
+        ViewRegistry views = new ViewRegistry();
+        view = new SharedFanOutView();
+        views.register(view);
+        scheduler = new RecordingScheduler();
+        ViewEngine engine = new ViewEngine(plugin, views, sessions,
+                new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
+        }, scheduler);
+        service = new ViewService(engine, sessions);
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.getScheduler().cancelTasks(plugin);
+        MockBukkit.unmock();
+    }
+
+    @Test
+    void offRegionSharedWrite_dispatchesOneRunOnEntityPerActiveSession() {
+        PlayerMock a = server.addPlayer("a");
+        PlayerMock b = server.addPlayer("b");
+        service.open(a, SharedFanOutView.class, ViewArguments.empty());
+        service.open(b, SharedFanOutView.class, ViewArguments.empty());
+        assertEquals(2, view.renders.get(), "first render paints both sessions once");
+
+        // simulate Folia: a write from a thread that owns no viewer's region. the flush-hook
+        // coalesces and schedules a global-region drain, which re-dispatches per session.
+        scheduler.ownsRegion = false;
+        view.shared.set("changed");
+
+        // exactly one global-region drain was scheduled (the coalesced flush entry point)
+        assertEquals(1, scheduler.globalDispatches.get(),
+                "off-region shared write coalesces into a single global-region drain");
+
+        // the drain fanned the repaint out per session: one runOnEntity per active session,
+        // each targeting that session's own viewer (not a single global hop painting both)
+        assertEquals(2, scheduler.entityDispatches.size(),
+                "each open session must be repainted on its own region");
+        assertTrue(scheduler.entityDispatches.contains(a), "session a must be dispatched on a's region");
+        assertTrue(scheduler.entityDispatches.contains(b), "session b must be dispatched on b's region");
+
+        // and the per-region repaints actually ran, updating both inventories
+        assertEquals(4, view.renders.get(), "both sessions repaint exactly once after the fan-out");
+    }
+
+    static final class SharedFanOutView extends View {
+        final SharedState<String> shared = sharedState("initial");
+        final AtomicInteger renders = new AtomicInteger();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("SharedFanOut").rows(1);
+        }
+
+        @Override
+        protected void onFirstRender(@NotNull RenderContext render) {
+            render.slot(0)
+                    .item(ctx -> {
+                        renders.incrementAndGet();
+                        return new ItemStack(Material.PAPER);
+                    })
+                    .updateOnStateChange(shared);
+        }
+    }
+
+    /**
+     * Records scheduling calls and runs every task inline so the fan-out completes within the test.
+     * {@code ownsRegion} is flipped to {@code false} to drive the off-region dispatch paths.
+     */
+    private static final class RecordingScheduler implements PlatformScheduler {
+        private final AtomicInteger globalDispatches = new AtomicInteger();
+        private final List<Entity> entityDispatches = new ArrayList<>();
+        private volatile boolean ownsRegion = true;
+
+        @Override
+        public @NotNull PlatformTask runOnEntity(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired) {
+            entityDispatches.add(entity);
+            task.run();
+            return NoopTask.INSTANCE;
+        }
+
+        @Override
+        public @NotNull PlatformTask runOnEntityLater(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks) {
+            entityDispatches.add(entity);
+            task.run();
+            return NoopTask.INSTANCE;
+        }
+
+        @Override
+        public @NotNull PlatformTask runOnEntityAtFixedRate(@NotNull Entity entity, @NotNull Runnable task, @Nullable Runnable retired, long delayTicks, long periodTicks) {
+            return NoopTask.INSTANCE;
+        }
+
+        @Override
+        public @NotNull PlatformTask runAtRegion(@NotNull Location location, @NotNull Runnable task) {
+            task.run();
+            return NoopTask.INSTANCE;
+        }
+
+        @Override
+        public @NotNull PlatformTask runAtRegionLater(@NotNull Location location, @NotNull Runnable task, long delayTicks) {
+            task.run();
+            return NoopTask.INSTANCE;
+        }
+
+        @Override
+        public @NotNull PlatformTask runGlobal(@NotNull Runnable task) {
+            globalDispatches.incrementAndGet();
+            task.run();
+            return NoopTask.INSTANCE;
+        }
+
+        @Override
+        public @NotNull PlatformTask runGlobalLater(@NotNull Runnable task, long delayTicks) {
+            globalDispatches.incrementAndGet();
+            task.run();
+            return NoopTask.INSTANCE;
+        }
+
+        @Override
+        public boolean ownsRegion(@NotNull Entity entity) {
+            return ownsRegion;
+        }
+
+        @Override
+        public boolean ownsRegion(@NotNull Location location) {
+            return ownsRegion;
+        }
+    }
+
+    private enum NoopTask implements PlatformTask {
+        INSTANCE;
+
+        @Override
+        public void cancel() {
+        }
+
+        @Override
+        public boolean isCancelled() {
+            return false;
+        }
+    }
+}

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/NavigationPairFlowTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/NavigationPairFlowTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.RenderContext;
@@ -76,7 +77,7 @@ class NavigationPairFlowTest {
         views.register(new ConfirmFlowView());
         ViewEngine engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
         service = new ViewService(engine, sessions);
         listener = new ViewListener(sessions, engine);
     }

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationClickRoutingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationClickRoutingTest.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
@@ -326,7 +327,7 @@ class PaginationClickRoutingTest {
         views.register(new BoundCharsView());
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, t) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationOpenWiringTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationOpenWiringTest.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
@@ -119,7 +120,7 @@ class PaginationOpenWiringTest {
         views.register(outOfBoundsLayoutView);
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationSampleFlowsTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationSampleFlowsTest.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.RenderContext;
@@ -113,7 +114,7 @@ class PaginationSampleFlowsTest {
         sessions = new SessionRegistry();
         engine = new ViewEngine(plugin, registry, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, t) -> {
-                });
+                }, new BukkitPlatformScheduler(plugin));
         service = new ViewService(engine, sessions);
         listener = new ViewListener(sessions, engine);
         scrollView = new ScrollFlowView();

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationSettleTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationSettleTest.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseReason;
@@ -109,7 +110,7 @@ class PaginationSettleTest {
         views.register(rollbackView);
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/SharedStateFlowTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/SharedStateFlowTest.java
@@ -87,8 +87,10 @@ class SharedStateFlowTest {
         assertEquals("nobody".length(), invA.getItem(0).getAmount());
         assertEquals("nobody".length(), invB.getItem(0).getAmount());
 
-        // a single shared write must repaint the watching component of BOTH open sessions
+        // a single shared write must repaint the watching component of BOTH open sessions;
+        // the flush coalesces and drains on the global region (next tick), then fans out per session
         leaderboard.topName.set("champion");
+        server.getScheduler().performTicks(1);
 
         assertEquals("champion".length(), invA.getItem(0).getAmount());
         assertEquals("champion".length(), invB.getItem(0).getAmount());

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/SharedStateFlowTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/SharedStateFlowTest.java
@@ -33,6 +33,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.RenderContext;
@@ -63,7 +64,7 @@ class SharedStateFlowTest {
         views.register(leaderboard);
         ViewEngine engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
         service = new ViewService(engine, sessions);
     }
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/UpdateFlushTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/UpdateFlushTest.java
@@ -223,6 +223,8 @@ class UpdateFlushTest {
         assertEquals(2, sharedView.renders.get());
 
         sharedView.shared.set("changed");
+        // the flush coalesces and drains on the global region (next tick), then fans out per session
+        server.getScheduler().performTicks(1);
 
         assertEquals(4, sharedView.renders.get(),
                 "both sessions of the owning view must repaint exactly once");
@@ -274,6 +276,8 @@ class UpdateFlushTest {
         assertEquals(1, twoSlotSharedView.unwatchedRenders.get());
 
         twoSlotSharedView.shared.set("changed");
+        // the flush coalesces and drains on the global region (next tick), then fans out per session
+        server.getScheduler().performTicks(1);
 
         assertEquals(2, twoSlotSharedView.watchedRenders.get(),
                 "slot 0 watches the shared token and must repaint");

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/UpdateFlushTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/UpdateFlushTest.java
@@ -38,6 +38,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.RenderContext;
@@ -103,7 +104,7 @@ class UpdateFlushTest {
         views.register(twoSlotSharedView);
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, t) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
         player = server.addPlayer("first");
         second = server.addPlayer("second");
     }

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngineOpenCloseTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngineOpenCloseTest.java
@@ -30,6 +30,8 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -183,7 +185,7 @@ class ViewEngineOpenCloseTest {
         views.register(new ColoredTitleView());
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngineOpenCloseTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngineOpenCloseTest.java
@@ -29,7 +29,6 @@ import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitTask;
 import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import org.jetbrains.annotations.NotNull;
@@ -298,7 +297,7 @@ class ViewEngineOpenCloseTest {
     void scheduledUpdates_taskStartsOnOpenAndIsCancelledOnClose() {
         engine.open(player, ScheduledView.class, ViewArguments.empty());
         ViewSession session = session();
-        BukkitTask task = session.updateTask();
+        PlatformTask task = session.updateTask();
         assertNotNull(task);
         assertFalse(task.isCancelled());
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngineOpenOrderingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/ViewEngineOpenOrderingTest.java
@@ -34,6 +34,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
@@ -197,7 +198,7 @@ class ViewEngineOpenOrderingTest {
         views.register(new RenderFailView());
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/listener/ViewListenerTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/listener/ViewListenerTest.java
@@ -43,6 +43,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
@@ -113,7 +114,7 @@ class ViewListenerTest {
         views.register(listenerView);
         engine = new ViewEngine(plugin, views, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, t) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
         listener = new ViewListener(sessions, engine);
     }
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfig;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
@@ -162,7 +163,7 @@ class PaginationBindingTest {
         player = server.addPlayer("tester");
         engine = new ViewEngine(plugin, new ViewRegistry(), new SessionRegistry(),
                 new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
-        });
+        }, new BukkitPlatformScheduler(plugin));
     }
 
     @AfterEach

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationImplTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationImplTest.java
@@ -25,10 +25,12 @@ package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfig;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
@@ -60,7 +62,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class PaginationImplTest {
 
@@ -98,8 +102,10 @@ class PaginationImplTest {
     void setUp() {
         server = MockBukkit.mock();
         plugin = mock(Plugin.class);
+        PlatformScheduler scheduler = mock(PlatformScheduler.class);
+        when(scheduler.ownsRegion(any(Entity.class))).thenReturn(true);
         engine = new ViewEngine(plugin, new ViewRegistry(), new SessionRegistry(),
-                new SlotPainter(new NoopPlaceholderApplier()), mock(TitleUpdater.class));
+                new SlotPainter(new NoopPlaceholderApplier()), mock(TitleUpdater.class), scheduler);
         player = server.addPlayer("paginator");
     }
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpecTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpecTest.java
@@ -23,6 +23,7 @@
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination;
 
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.ViewContext;
 import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.AsyncPageSource;
 import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.EagerPageSource;
@@ -50,6 +51,7 @@ import static org.mockito.Mockito.mock;
 class PaginationSourceSpecTest {
 
     private final ViewContext context = mock(ViewContext.class);
+    private final PlatformScheduler scheduler = mock(PlatformScheduler.class);
 
     // pins the package-private PaginationSpec constructor order Task 8's builder must use:
     // (geometry, target, layoutChar, explicitLayout, patterns, renderer, fallbackItem,
@@ -66,8 +68,8 @@ class PaginationSourceSpecTest {
         PaginationSourceSpec<Integer> sourceSpec = PaginationSourceSpec.eager(Arrays.asList(1, 2, 3));
         PaginationSpec<Integer> spec = specOf(sourceSpec);
 
-        PageSource<Integer> first = sourceSpec.createSource(context, spec);
-        PageSource<Integer> second = sourceSpec.createSource(mock(ViewContext.class), spec);
+        PageSource<Integer> first = sourceSpec.createSource(context, spec, scheduler);
+        PageSource<Integer> second = sourceSpec.createSource(mock(ViewContext.class), spec, scheduler);
 
         assertTrue(first instanceof EagerPageSource);
         assertSame(first, second);
@@ -80,7 +82,7 @@ class PaginationSourceSpecTest {
 
         backing.add(4);
 
-        PageSource<Integer> source = sourceSpec.createSource(context, specOf(sourceSpec));
+        PageSource<Integer> source = sourceSpec.createSource(context, specOf(sourceSpec), scheduler);
         assertEquals(Arrays.asList(1, 2, 3), source.elements());
     }
 
@@ -102,8 +104,8 @@ class PaginationSourceSpecTest {
         });
         PaginationSpec<Integer> spec = specOf(sourceSpec);
 
-        PageSource<Integer> first = sourceSpec.createSource(context, spec);
-        PageSource<Integer> second = sourceSpec.createSource(context, spec);
+        PageSource<Integer> first = sourceSpec.createSource(context, spec, scheduler);
+        PageSource<Integer> second = sourceSpec.createSource(context, spec, scheduler);
 
         assertTrue(first instanceof EagerPageSource);
         assertNotSame(first, second);
@@ -117,7 +119,7 @@ class PaginationSourceSpecTest {
         PaginationSpec<Integer> spec = specOf(sourceSpec);
 
         NullPointerException error = assertThrows(NullPointerException.class,
-                () -> sourceSpec.createSource(context, spec));
+                () -> sourceSpec.createSource(context, spec, scheduler));
 
         assertEquals("lazy pagination source function returned null", error.getMessage());
     }
@@ -144,8 +146,8 @@ class PaginationSourceSpecTest {
                 (ctx, item, index, value) -> { }, null, null, sourceSpec,
                 (request, error) -> { }, Duration.ofSeconds(5), Duration.ofSeconds(30), 64);
 
-        PageSource<Integer> first = sourceSpec.createSource(context, spec);
-        PageSource<Integer> second = sourceSpec.createSource(context, spec);
+        PageSource<Integer> first = sourceSpec.createSource(context, spec, scheduler);
+        PageSource<Integer> second = sourceSpec.createSource(context, spec, scheduler);
 
         assertTrue(first instanceof AsyncPageSource);
         assertNotSame(first, second);
@@ -162,7 +164,7 @@ class PaginationSourceSpecTest {
             return made;
         });
 
-        PageSource<Integer> created = sourceSpec.createSource(context, specOf(sourceSpec));
+        PageSource<Integer> created = sourceSpec.createSource(context, specOf(sourceSpec), scheduler);
 
         assertSame(made, created);
         assertSame(context, seen.get());
@@ -175,7 +177,7 @@ class PaginationSourceSpecTest {
         PaginationSourceSpec<Integer> sourceSpec = PaginationSourceSpec.custom(ctx -> null);
 
         NullPointerException error = assertThrows(NullPointerException.class,
-                () -> sourceSpec.createSource(context, specOf(sourceSpec)));
+                () -> sourceSpec.createSource(context, specOf(sourceSpec), scheduler));
 
         assertEquals("paginateSource factory returned null", error.getMessage());
     }

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AsyncPaginationEngineTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AsyncPaginationEngineTest.java
@@ -25,11 +25,14 @@ package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination.engine;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.MockPlugin;
 import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination.RenderedItem;
 import tech.guilhermekaua.spigotboot.inventoryapi.layout.Layout;
 import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.AsyncPageSource;
@@ -58,11 +61,15 @@ class AsyncPaginationEngineTest {
 
     private ServerMock server;
     private MockPlugin plugin;
+    private BukkitPlatformScheduler scheduler;
+    private PlayerMock player;
 
     @BeforeEach
     void setUp() {
         server = MockBukkit.mock();
         plugin = MockBukkit.createMockPlugin("TestPlugin");
+        scheduler = new BukkitPlatformScheduler(plugin);
+        player = server.addPlayer();
     }
 
     @AfterEach
@@ -90,20 +97,20 @@ class AsyncPaginationEngineTest {
     }
 
     private FakePaginationHost newHost() {
-        return new FakePaginationHost(UUID.randomUUID(), plugin);
+        return new FakePaginationHost(player.getUniqueId(), plugin, player);
     }
 
     private static Layout threeSlots() {
         return Layout.ofSlots(0, 1, 2);
     }
 
-    private static NormalPagination<Integer> asyncNormal(CapturingSupplier supplier) {
+    private NormalPagination<Integer> asyncNormal(CapturingSupplier supplier) {
         return new NormalPagination<>(
                 null,
                 ITEM_FACTORY,
                 threeSlots(),
                 () -> RenderedItem.ofItem(new ItemStack(Material.CLOCK)),
-                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher()));
+                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher(scheduler)));
     }
 
     @Test
@@ -158,7 +165,7 @@ class AsyncPaginationEngineTest {
                 threeSlots(),
                 null,
                 new AsyncPageSource<>(supplier, (request, error) -> callbackError.set(error),
-                        null, null, 128, new BukkitSettleDispatcher()));
+                        null, null, 128, new BukkitSettleDispatcher(scheduler)));
 
         pagination.bind(newHost());
         supplier.futures.get(0).complete(PageResult.of(List.of(1, 2, 3), 9)); // page 1 ok
@@ -219,7 +226,7 @@ class AsyncPaginationEngineTest {
                 threeSlots(),
                 null,
                 new AsyncPageSource<>(supplier, null, null, Duration.ofMinutes(5), 128,
-                        new BukkitSettleDispatcher()));
+                        new BukkitSettleDispatcher(scheduler)));
 
         pagination.bind(newHost());
         supplier.futures.get(0).complete(PageResult.of(List.of(1, 2, 3), 9)); // page 1 now cached
@@ -242,7 +249,7 @@ class AsyncPaginationEngineTest {
                 ITEM_FACTORY,
                 List.of(five, two),
                 null,
-                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher()));
+                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher(scheduler)));
         FakePaginationHost host = newHost();
 
         pagination.bind(host);
@@ -274,7 +281,7 @@ class AsyncPaginationEngineTest {
                 ITEM_FACTORY,
                 threeSlots(),
                 null,
-                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher()));
+                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher(scheduler)));
 
         pagination.bind(newHost());
         supplier.futures.get(0).complete(PageResult.of(List.of(1, 2, 3), 10));
@@ -295,7 +302,7 @@ class AsyncPaginationEngineTest {
                 List.of(Layout.ofSlots(0, 1, 2, 3, 4),      // 5 slots
                         Layout.ofSlots(9, 10)),              // 2 slots
                 null,
-                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher()));
+                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher(scheduler)));
 
         pagination.bind(newHost());
         supplier.futures.get(0).complete(PageResult.of(List.of(1, 2, 3, 4, 5), 9));
@@ -338,7 +345,7 @@ class AsyncPaginationEngineTest {
                 List.of(Layout.ofSlots(0, 1, 2, 3, 4),      // 5 slots
                         Layout.ofSlots(9, 10)),              // 2 slots
                 null,
-                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher()));
+                new AsyncPageSource<>(supplier, null, null, null, 128, new BukkitSettleDispatcher(scheduler)));
 
         pagination.changePage(2);
         pagination.changePage(3); // 2.x regression: NPE'd clearing the last pattern unbound

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/FakePaginationHost.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/FakePaginationHost.java
@@ -22,6 +22,7 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination.engine;
 
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -56,12 +57,23 @@ final class FakePaginationHost implements PaginationHost {
     private final List<FillPageCall> fillPageCalls = new ArrayList<>();
     private final UUID playerId;
     private final Plugin plugin;
+    private final Player player;
     private boolean active = true;
     private int requestRenderCount;
 
+    /** Creates a host with no live {@code Player} — settles run inline on the completing thread. */
     FakePaginationHost(UUID playerId, Plugin plugin) {
+        this(playerId, plugin, null);
+    }
+
+    /**
+     * Creates a host with a live {@code Player}; the settle dispatcher will route off-thread
+     * settles to the player's entity scheduler (or the mock Bukkit scheduler in legacy mode).
+     */
+    FakePaginationHost(UUID playerId, Plugin plugin, @Nullable Player player) {
         this.playerId = playerId;
         this.plugin = plugin;
+        this.player = player;
     }
 
     @Override
@@ -82,6 +94,11 @@ final class FakePaginationHost implements PaginationHost {
     @Override
     public @Nullable UUID playerId() {
         return playerId;
+    }
+
+    @Override
+    public @Nullable Player player() {
+        return player;
     }
 
     @Override

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/session/ViewSessionTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/session/ViewSessionTest.java
@@ -27,8 +27,8 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import org.bukkit.Bukkit;
 import org.bukkit.inventory.Inventory;
-import org.bukkit.scheduler.BukkitTask;
 import org.junit.jupiter.api.AfterEach;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
@@ -184,7 +184,7 @@ class ViewSessionTest {
         ViewSession session = newSession();
         assertNull(session.updateTask());
 
-        BukkitTask task = mock(BukkitTask.class);
+        PlatformTask task = mock(PlatformTask.class);
         session.updateTask(task);
         assertSame(task, session.updateTask());
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/AsyncPageSourceTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/AsyncPageSourceTest.java
@@ -51,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AsyncPageSourceTest {
 
     private static PageRequest request(int page) {
-        return new PageRequest(page, 3, (page - 1) * 3, null, null);
+        return new PageRequest(page, 3, (page - 1) * 3, null, null, null);
     }
 
     private static <T> AsyncPageSource<T> source(AsyncPageSupplier<T> supplier) {

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/BukkitSettleDispatcherTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/BukkitSettleDispatcherTest.java
@@ -22,14 +22,13 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.pagination.source;
 
-import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.plugin.IllegalPluginAccessException;
-import org.bukkit.plugin.Plugin;
-import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.mockito.MockedStatic;
 import org.mockito.Mockito;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformScheduler;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.PlatformTask;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -38,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -45,86 +45,76 @@ import static org.mockito.Mockito.when;
 
 class BukkitSettleDispatcherTest {
 
-    private static PageRequest requestWith(Plugin plugin) {
-        return new PageRequest(1, 3, 0, null, plugin);
+    // request with a viewer
+    private static PageRequest requestWithViewer(Player viewer) {
+        return new PageRequest(1, 3, 0, null, null, viewer);
+    }
+
+    // request without a viewer (engine-external test usage)
+    private static PageRequest requestNullViewer() {
+        return new PageRequest(1, 3, 0, null, null, null);
     }
 
     @Test
-    void dispatch_onPrimaryThread_runsInline() {
-        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher();
+    void dispatch_nullViewer_runsInline() {
+        PlatformScheduler scheduler = mock(PlatformScheduler.class);
+        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher(scheduler);
         AtomicBoolean ran = new AtomicBoolean();
 
-        try (MockedStatic<Bukkit> bukkit = Mockito.mockStatic(Bukkit.class)) {
-            bukkit.when(Bukkit::isPrimaryThread).thenReturn(true);
+        dispatcher.dispatch(requestNullViewer(), () -> ran.set(true));
 
-            dispatcher.dispatch(requestWith(mock(Plugin.class)), () -> ran.set(true));
-
-            bukkit.verify(Bukkit::getScheduler, never());
-        }
-
-        assertTrue(ran.get(), "a settle completing on the main thread must run inline");
+        assertTrue(ran.get(), "a request with no viewer must settle inline on the calling thread");
+        verify(scheduler, never()).ownsRegion(any(Player.class));
+        verify(scheduler, never()).runOnEntity(any(), any(), any());
     }
 
     @Test
-    void dispatch_nullPluginOffThread_runsInline() {
-        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher();
+    void dispatch_ownsRegion_runsInline() {
+        Player viewer = mock(Player.class);
+        PlatformScheduler scheduler = mock(PlatformScheduler.class);
+        when(scheduler.ownsRegion(viewer)).thenReturn(true);
+
+        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher(scheduler);
         AtomicBoolean ran = new AtomicBoolean();
 
-        try (MockedStatic<Bukkit> bukkit = Mockito.mockStatic(Bukkit.class)) {
-            bukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
+        dispatcher.dispatch(requestWithViewer(viewer), () -> ran.set(true));
 
-            dispatcher.dispatch(requestWith(null), () -> ran.set(true));
-
-            bukkit.verify(Bukkit::getScheduler, never());
-        }
-
-        assertTrue(ran.get(), "engine-external requests without a plugin must settle on the calling thread");
+        assertTrue(ran.get(), "a settle on the owning region must run inline");
+        verify(scheduler, never()).runOnEntity(any(), any(), any());
     }
 
     @Test
-    void dispatch_offMainWithPlugin_schedulesOntoMainThread() {
-        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher();
-        Plugin plugin = mock(Plugin.class);
-        BukkitScheduler scheduler = mock(BukkitScheduler.class);
+    void dispatch_offRegion_schedulesOnViewerEntity() {
+        Player viewer = mock(Player.class);
+        PlatformScheduler scheduler = mock(PlatformScheduler.class);
+        when(scheduler.ownsRegion(viewer)).thenReturn(false);
+        when(scheduler.runOnEntity(eq(viewer), any(), isNull())).thenReturn(mock(PlatformTask.class));
+
+        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher(scheduler);
         AtomicBoolean ran = new AtomicBoolean();
 
-        try (MockedStatic<Bukkit> bukkit = Mockito.mockStatic(Bukkit.class)) {
-            bukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
-            bukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+        dispatcher.dispatch(requestWithViewer(viewer), () -> ran.set(true));
 
-            dispatcher.dispatch(requestWith(plugin), () -> ran.set(true));
-
-            assertFalse(ran.get(), "the settle must not run inline on the completing thread");
-            ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
-            verify(scheduler).runTask(eq(plugin), task.capture());
-            task.getValue().run();
-        }
-
-        assertTrue(ran.get(), "the scheduled task must carry the settle onto the main thread");
+        assertFalse(ran.get(), "the settle must not run inline when the current thread does not own the region");
+        ArgumentCaptor<Runnable> task = ArgumentCaptor.forClass(Runnable.class);
+        verify(scheduler).runOnEntity(eq(viewer), task.capture(), isNull());
+        task.getValue().run();
+        assertTrue(ran.get(), "the scheduled task must carry the settle onto the region thread");
     }
 
     @Test
     void dispatch_whilePluginDisabling_dropsSettleInsteadOfThrowing() {
-        // the real scheduler rejects tasks registered by a disabling plugin with
-        // IllegalPluginAccessException; the dispatcher must swallow it (a throw inside
-        // whenComplete or a timeout task would vanish into an unobserved future) and the
-        // settle is dropped
-        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher();
-        Plugin plugin = mock(Plugin.class);
-        BukkitScheduler scheduler = mock(BukkitScheduler.class);
-        AtomicBoolean ran = new AtomicBoolean();
-
-        when(scheduler.runTask(any(Plugin.class), any(Runnable.class)))
+        Player viewer = mock(Player.class);
+        PlatformScheduler scheduler = mock(PlatformScheduler.class);
+        when(scheduler.ownsRegion(viewer)).thenReturn(false);
+        when(scheduler.runOnEntity(any(), any(), any()))
                 .thenThrow(new IllegalPluginAccessException("Plugin attempted to register task while disabled"));
 
-        try (MockedStatic<Bukkit> bukkit = Mockito.mockStatic(Bukkit.class)) {
-            bukkit.when(Bukkit::isPrimaryThread).thenReturn(false);
-            bukkit.when(Bukkit::getScheduler).thenReturn(scheduler);
+        BukkitSettleDispatcher dispatcher = new BukkitSettleDispatcher(scheduler);
+        AtomicBoolean ran = new AtomicBoolean();
 
-            assertDoesNotThrow(() -> dispatcher.dispatch(requestWith(plugin), () -> ran.set(true)),
-                    "a disabling plugin must not blow up the completing thread");
-        }
-
+        assertDoesNotThrow(() -> dispatcher.dispatch(requestWithViewer(viewer), () -> ran.set(true)),
+                "a disabling plugin must not blow up the completing thread");
         assertFalse(ran.get(), "the scheduler rejected the task; the settle is dropped");
     }
 }

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/EagerPageSourceTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/source/EagerPageSourceTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class EagerPageSourceTest {
 
     private static PageRequest request(int page, int pageSize, int offset) {
-        return new PageRequest(page, pageSize, offset, null, null);
+        return new PageRequest(page, pageSize, offset, null, null, null);
     }
 
     private static <T> PageResult<T> settleOf(EagerPageSource<T> source, PageRequest request) {

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/service/ViewServiceEndToEndTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/service/ViewServiceEndToEndTest.java
@@ -39,6 +39,7 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
 import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
 import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
@@ -86,7 +87,7 @@ class ViewServiceEndToEndTest {
         sessions = new SessionRegistry();
         engine = new ViewEngine(plugin, registry, sessions,
                 new SlotPainter(new NoopPlaceholderApplier()), (p, t) -> {
-                });
+                }, new BukkitPlatformScheduler(plugin));
         service = new ViewService(engine, sessions);
         listener = new ViewListener(sessions, engine);
         view = new SampleView();

--- a/platform-spigot/inventory-api/nms/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/nms/InventoryApiNMS.java
+++ b/platform-spigot/inventory-api/nms/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/nms/InventoryApiNMS.java
@@ -39,9 +39,11 @@ import java.util.regex.Pattern;
  * Picks the right {@link InventoryTitleUpdater} for the running server. The strategy is:
  *
  * <ol>
- *     <li>If the Bukkit minor version is 20 or newer (1.20+), return {@link BukkitInventoryTitleUpdater}
- *         which uses the public Bukkit API ({@code InventoryView#setTitle}) added in 1.20.</li>
- *     <li>Otherwise, look up the CraftBukkit package suffix (e.g. {@code v1_19_R3}) and
+ *     <li>If the server exposes the modern public Bukkit API — the parsed minor version is 20 or
+ *         newer (1.20+), or the CraftBukkit package is un-versioned (Paper 1.20.5+, where no
+ *         {@code vX_Y_RZ} suffix is present) — return {@link BukkitInventoryTitleUpdater}, which
+ *         uses {@code InventoryView#setTitle} (added in 1.20).</li>
+ *     <li>Otherwise, look up the legacy CraftBukkit package suffix (e.g. {@code v1_19_R3}) and
  *         instantiate the matching per-version NMS class.</li>
  * </ol>
  *
@@ -68,21 +70,34 @@ public final class InventoryApiNMS {
      *                               classpath
      */
     public static InventoryTitleUpdater getTitleUpdater() {
-        int minor = detectMinorVersion();
-        if (minor >= 20) {
-            return new BukkitInventoryTitleUpdater();
-        }
+        return resolveTitleUpdater(detectMinorVersion(), detectPackageSuffix());
+    }
 
-        String suffix = detectPackageSuffix();
-        if (suffix == null) {
-            // Object-typed on purpose: the 1.8.8 sniffer signature lacks JDK supertypes, so
-            // getClass() must resolve via the java.* ignore (see root pom)
-            Object server = Bukkit.getServer();
-            throw new IllegalStateException(
-                    "Unable to detect CraftBukkit package suffix (server.class=" +
-                            server.getClass().getName() +
-                            "); register a custom TitleUpdater bean to bypass the selector"
-            );
+    /**
+     * Selects the title updater from the detected server coordinates. Package-private so the
+     * branch logic can be exercised without a live server.
+     *
+     * <p>Modern servers (Minecraft 1.20+) expose {@code InventoryView#setTitle} and, since Paper
+     * 1.20.5, no longer relocate CraftBukkit into a versioned {@code org.bukkit.craftbukkit.vX_Y_RZ}
+     * package — {@link #detectPackageSuffix()} returns {@code null} there. The public Bukkit API is
+     * therefore selected whenever the parsed minor version is &ge; 20 <em>or</em> the versioned NMS
+     * package is absent. This keeps working on renumbered version schemes (e.g. Paper/Folia
+     * {@code "26.x"}) whose version string makes the {@code 1.MINOR} heuristic parse a misleading
+     * minor of {@code 1}, which would otherwise fall through to the dead NMS branch.
+     *
+     * @param minor  the detected Bukkit minor version, or {@code -1} if it could not be parsed
+     * @param suffix the detected CraftBukkit package suffix (e.g. {@code v1_19_R3}), or
+     *               {@code null} on un-versioned modern servers
+     * @return the resolved updater
+     * @throws IllegalStateException when a legacy versioned server reports a package suffix that
+     *                               has no matching per-version implementation
+     */
+    static InventoryTitleUpdater resolveTitleUpdater(int minor, String suffix) {
+        // prefer the public Bukkit API on any modern server: either the version parses as 1.20+,
+        // or the versioned CraftBukkit package is absent (Paper 1.20.5+, including renumbered
+        // schemes whose version string defeats the minor-version parse).
+        if (minor >= 20 || suffix == null) {
+            return new BukkitInventoryTitleUpdater();
         }
 
         // dispatch via static references so shade's minimizer keeps these classes in the

--- a/platform-spigot/inventory-api/nms/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/nms/InventoryApiNMSTest.java
+++ b/platform-spigot/inventory-api/nms/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/nms/InventoryApiNMSTest.java
@@ -1,0 +1,68 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.inventoryapi.nms;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.inventoryapi.nms.title.BukkitInventoryTitleUpdater;
+import tech.guilhermekaua.spigotboot.inventoryapi.nms.title.InventoryTitleUpdater;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Covers the title-updater selection logic in {@link InventoryApiNMS#resolveTitleUpdater(int, String)}.
+ *
+ * <p>The legacy per-version branches (e.g. {@code v1_8_R3}) are intentionally not asserted here:
+ * instantiating them links {@code net.minecraft.server.vX_Y_RZ} types that are absent from a plain
+ * test JVM. The cases below exercise only the modern Bukkit-API branch and the unknown-suffix
+ * failure, which is where the behavior change lives.
+ */
+class InventoryApiNMSTest {
+
+    @Test
+    void unversioned_modern_package_selects_bukkit_api_even_when_minor_parses_low() {
+        // regression: Paper/Folia "26.x" reports an un-versioned org.bukkit.craftbukkit package
+        // (suffix null) and a version string whose minor parses as 1. The old selector threw
+        // "Unable to detect CraftBukkit package suffix"; it must now pick the public Bukkit API.
+        InventoryTitleUpdater updater = InventoryApiNMS.resolveTitleUpdater(1, null);
+
+        assertInstanceOf(BukkitInventoryTitleUpdater.class, updater);
+    }
+
+    @Test
+    void unparseable_version_with_unversioned_package_selects_bukkit_api() {
+        assertInstanceOf(BukkitInventoryTitleUpdater.class, InventoryApiNMS.resolveTitleUpdater(-1, null));
+    }
+
+    @Test
+    void modern_minor_selects_bukkit_api() {
+        assertInstanceOf(BukkitInventoryTitleUpdater.class, InventoryApiNMS.resolveTitleUpdater(21, null));
+        // even if a versioned suffix is somehow still reported, minor >= 20 wins
+        assertInstanceOf(BukkitInventoryTitleUpdater.class, InventoryApiNMS.resolveTitleUpdater(20, "v1_20_R1"));
+    }
+
+    @Test
+    void legacy_versioned_package_without_mapping_throws() {
+        assertThrows(IllegalStateException.class, () -> InventoryApiNMS.resolveTitleUpdater(15, "v1_15_R1"));
+    }
+}

--- a/test-plugin/src/main/java/tech/guilhermekaua/spigotboot/testPlugin/Main.java
+++ b/test-plugin/src/main/java/tech/guilhermekaua/spigotboot/testPlugin/Main.java
@@ -36,7 +36,8 @@ import tech.guilhermekaua.spigotboot.testPlugin.configuration.MainConfig;
         version = "1.0.0",
         description = "A test plugin for ApxPlugin framework.",
         authors = {"Approximations"},
-        apiVersion = "1.13"
+        apiVersion = "1.13",
+        foliaSupported = true
 )
 public class Main extends JavaPlugin {
     private SpigotBootPlugin bootPlugin;

--- a/test-plugin/src/main/java/tech/guilhermekaua/spigotboot/testPlugin/Main.java
+++ b/test-plugin/src/main/java/tech/guilhermekaua/spigotboot/testPlugin/Main.java
@@ -48,7 +48,7 @@ public class Main extends JavaPlugin {
         Context ctx = SpigotBoot.initialize(bootPlugin);
 
         MainConfig mainConfig = ctx.getBean(MainConfig.class);
-        getLogger().info("MainConfig - Server name: " + mainConfig.getServerName() + ". Max players: " + mainConfig.getMaxPlayers());
+        getLogger().info("MainConfig - Server name: " + mainConfig.getServerName() + ". Max players: " + mainConfig.getMaxPlayers() + ". Level-up sound: " + mainConfig.getLevelUpSound());
     }
 
     @Override

--- a/test-plugin/src/main/java/tech/guilhermekaua/spigotboot/testPlugin/configuration/MainConfig.java
+++ b/test-plugin/src/main/java/tech/guilhermekaua/spigotboot/testPlugin/configuration/MainConfig.java
@@ -1,6 +1,7 @@
 package tech.guilhermekaua.spigotboot.testPlugin.configuration;
 
 import lombok.Data;
+import org.bukkit.Sound;
 import tech.guilhermekaua.spigotboot.config.annotation.Comment;
 import tech.guilhermekaua.spigotboot.config.annotation.Config;
 import tech.guilhermekaua.spigotboot.core.validation.annotation.Range;
@@ -14,6 +15,9 @@ public class MainConfig {
     @Comment("Maximum players allowed on the server")
     @Range(min = 1, max = 1000)
     private int maxPlayers = 100;
+
+    @Comment("Sound played on level up; accepts an enum name or a namespaced key (cross-version)")
+    private Sound levelUpSound = Sound.ENTITY_PLAYER_LEVELUP;
 
     @Comment("Database connection settings")
     private DatabaseConfig database = new DatabaseConfig();


### PR DESCRIPTION
## Summary
- **New `PlatformScheduler` abstraction** (`core-spigot`): legacy Bukkit ↔ Folia region/entity/global schedulers, auto-detected and DI-injected (`@ConditionalOnMissingBean`). The Folia impl reaches the `Bukkit`/`Entity` accessors via reflection so the 1.8.8 animal-sniffer net over `org.bukkit.*` stays intact — only `io.papermc.paper.threadedregions.scheduler.*` is sniffer-ignored. Loaded only when the Folia API is present (mirrors `InventoryApiNMS`).
- **inventory-api made region-correct on Folia**: the 5 legacy sync-scheduler blockers (`ViewEngine` open self-defer + deferred drain, `FirstRenderPhase` update timer, `FlushCoordinator` shared flush, `BukkitSettleDispatcher` async settle) now run on the **viewer's region**; `isPrimaryThread`/`assertMainThread` entry-point guards replaced with `isOwnedByCurrentRegion`/`assertOwnsRegion`; shared-state flush **fans out per session**; the viewer `Player` is threaded onto `PageRequest` → `BukkitSettleDispatcher`.
- **`Utils.sync`/`syncLater`/`playSound`** redesigned to require an entity/location target and route through `PlatformScheduler` (breaking; no in-repo callers).
- **Cross-version `Sound`**: new `SoundCompat` resolver + re-enabled `SoundSerializer` — works whether `org.bukkit.Sound` is an enum (MC ≤ 1.21.2) or an interface (≥ 1.21.3).
- **Load-time fixes**: `@Plugin(foliaSupported = true)` emitted by the annotation processor; `InventoryApiNMS` title-updater selector handles un-versioned modern CraftBukkit packages and renumbered versions (e.g. Folia `26.x`).

## Validation
- Full reactor green with **animal-sniffer enabled** (1110 tests, 0 failures/errors).
- Booted the test-plugin on a real **Folia 26.1.2** server: clean enable, cross-version `Sound` deserialized from config on the interface-`Sound` server, 0 errors. The boot caught a runtime-only `VerifyError` in `SoundCompat.toKey` (a no-op enum upcast — invisible to the enum-`Sound` test JVM), fixed with a cast-via-`Object` so javac emits a real `checkcast`.

## Design / plan
- Spec: `docs/superpowers/specs/2026-06-14-folia-scheduler-compat-design.md`
- Plan: `docs/superpowers/plans/2026-06-14-folia-scheduler-compat.md`

## Known follow-up (non-blocking, out of this spec's scope)
- A few non-throwing `assertMainThread` guards on `ViewService`/`PaginationImpl`/`MutableStateImpl`/`InitialStateImpl` (safe on Folia — they don't throw on a correct region thread) could be migrated to region-aware checks later.

## Test Plan
- [ ] CI green (reactor build + animal-sniffer)
- [ ] Boot on Folia (modern, interface-`Sound`) → plugin enables, `Sound` config resolves
- [ ] Boot on legacy Spigot/Paper (≤ 1.20) → `BukkitPlatformScheduler` selected, no regression
- [ ] Open an inventory view on Folia (place a trigger block) → no region thread-check error

🤖 Generated with [Claude Code](https://claude.com/claude-code)