### PR TITLE
feat(bungee): generate bungee.yml descriptor from @BungeePlugin

### DIFF
--- a/docs/superpowers/plans/2026-06-15-bungeecord-yml-generation.md
+++ b/docs/superpowers/plans/2026-06-15-bungeecord-yml-generation.md
@@ -1,0 +1,630 @@
+# BungeeCord bungee.yml Generation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `platform-bungee/annotation-processor-bungee` module that generates a valid BungeeCord `bungee.yml` descriptor at build time from a new `@BungeePlugin` annotation, mirroring how the Spigot annotation processor generates `plugin.yml`.
+
+**Architecture:** A new, isolated annotation-processor module under the existing `platform-bungee` tree (parent `spigot-boot-platform-bungee`). It defines the `@BungeePlugin` annotation (Bungee-only descriptor elements) and `BungeePluginAnnotationProcessor`, a near-mechanical mirror of the Spigot `PluginAnnotationProcessor`: the annotated class becomes `main`, and the YAML is hand-written into `StandardLocation.CLASS_OUTPUT` (`bungee.yml` at the jar root). The module is independent of `core-bungee`, the Spigot processor, and the Bungee API — it uses only `javax.annotation.processing`/`javax.lang.model`. This isolation keeps the high-blast-radius shared Spigot processor untouched and lets the work proceed concurrently with the sibling `commands-bungee`/`config-bungee` slices.
+
+**Tech Stack:** Java 8 bytecode (tests Java 17), Maven, `com.google.testing.compile:compile-testing:0.21.0` (test scope, real in-memory annotation-processor TDD), JUnit 5 (inherited from the root pom). No BungeeCord API dependency. Spec: `docs/superpowers/specs/2026-06-15-bungeecord-yml-generation-design.md`.
+
+**Build/JDK notes (read once):**
+- Build with **JDK 21** (`JAVA_HOME` must point at JDK 21, e.g. `C:/Users/Guilherme/.jdks/ms-21.0.10`, **not** 25 — Lombok 1.18.36 crashes on 25). This module does not use Lombok, but the reactor build does.
+- All commands run from the worktree root: `C:\Users\Guilherme\IdeaProjects\spigot-boot\.claude\worktrees\bungeecord-yml`.
+- Every command passes `-Danimal.sniffer.skip=true` defensively (this module declares no animal-sniffer check, but the reactor has the 1.8.8 signature plugin and a stale signature must never block the build).
+- Filtered runs (`-pl … -am -Dtest=…`) **must** add `-Dsurefire.failIfNoSpecifiedTests=false`: `-am` also builds the upstream reactor modules (`core`, `utils`, …), none of which contain the named test class, so without this flag surefire fails them with "No tests were executed".
+- Every new `.java` file MUST begin with the project's MIT license header (the full block is shown in Task 2, `Copyright © 2025`, to match existing files and the root `license-maven-plugin`). XML and SPI resource files do not take the header.
+- `platform-bungee` is **already** registered in the root `pom.xml` `<modules>` (from the core-bungee v1 slice), so the root pom is **not** modified by this plan — only `platform-bungee/pom.xml`.
+
+---
+
+## File Structure
+
+**Created:**
+- `platform-bungee/annotation-processor-bungee/pom.xml` — the new processor module; Java 8 main / Java 17 tests, `<proc>none</proc>`, one test-scoped dep (`compile-testing`). No Bungee API, no shade, no animal-sniffer.
+- `platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/annotations/BungeePlugin.java` — the `@BungeePlugin` source annotation.
+- `platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessor.java` — the descriptor writer.
+- `platform-bungee/annotation-processor-bungee/src/main/resources/META-INF/services/javax.annotation.processing.Processor` — SPI registration so `javac` auto-discovers the processor.
+- `platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessorTest.java` — generation tests (compile-testing).
+- `platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginProcessorRegistrationTest.java` — SPI registration test.
+
+**Modified:**
+- `platform-bungee/pom.xml` — add `<module>annotation-processor-bungee</module>` to `<modules>` (**the merge-conflict point** shared with the sibling `commands-bungee`/`config-bungee` slices).
+
+---
+
+## Task 1: Scaffold the `annotation-processor-bungee` Maven module
+
+**Files:**
+- Create: `platform-bungee/annotation-processor-bungee/pom.xml`
+- Modify: `platform-bungee/pom.xml`
+
+- [ ] **Step 1: Create the module pom `platform-bungee/annotation-processor-bungee/pom.xml`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>tech.guilhermekaua.spigot-boot</groupId>
+        <artifactId>spigot-boot-platform-bungee</artifactId>
+        <version>3.2.1-SNAPSHOT</version>
+    </parent>
+
+    <name>${project.artifactId}</name>
+    <description>Annotation processor that generates the BungeeCord bungee.yml descriptor from @BungeePlugin.</description>
+    <url>https://github.com/guikaua12/spigot-boot</url>
+    <artifactId>spigot-boot-annotation-processor-bungee</artifactId>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
+                    <!-- disable annotation processing while compiling this module so javac does not try to
+                         run our own (not-yet-compiled) processor on itself, mirroring the Spigot processor pom. -->
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+            <version>0.21.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+Note: JUnit 5 (junit-jupiter) is declared `test`-scoped in the **root** pom `<dependencies>`, so it is inherited — do not redeclare it. `compile-testing` transitively brings Truth + Guava (all test scope); `com.google.testing.compile.CompilationSubject` and `Compiler.javac()` come from it.
+
+- [ ] **Step 2: Register the module in `platform-bungee/pom.xml`**
+
+In `platform-bungee/pom.xml`, change the `<modules>` block from:
+
+```xml
+    <modules>
+        <module>core-bungee</module>
+    </modules>
+```
+
+to (add the new module immediately after `core-bungee` to minimize conflict churn with the sibling slices):
+
+```xml
+    <modules>
+        <module>core-bungee</module>
+        <module>annotation-processor-bungee</module>
+    </modules>
+```
+
+- [ ] **Step 3: Verify the scaffolding resolves and the reactor wiring is correct**
+
+Run: `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true compile`
+Expected: `BUILD SUCCESS`. The module has no sources yet, so the compiler reports "No sources to compile" — that is fine. This proves the parent resolves, the module is wired into the reactor, and the pom is valid. (`compile` is used deliberately so the `package`-bound javadoc/source jars are not invoked on an empty module. The `compile-testing` test dependency is exercised in Task 3.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add platform-bungee/pom.xml platform-bungee/annotation-processor-bungee/pom.xml
+git commit -m "build(bungee): scaffold annotation-processor-bungee module"
+```
+
+---
+
+## Task 2: `@BungeePlugin` descriptor annotation
+
+**Files:**
+- Create: `platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/annotations/BungeePlugin.java`
+
+There is no behavior to unit-test in a pure annotation declaration; it is verified by compilation here and exercised end-to-end by the processor tests in Task 3.
+
+- [ ] **Step 1: Write the annotation**
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the BungeeCord plugin descriptor on the plugin's main class (the class that extends
+ * {@code net.md_5.bungee.api.plugin.Plugin}). {@code BungeePluginAnnotationProcessor} reads this
+ * annotation at compile time and emits a {@code bungee.yml} into the jar root, mirroring how the
+ * Spigot {@code @Plugin} annotation drives {@code plugin.yml}.
+ *
+ * <p>The annotated class itself becomes the descriptor's {@code main} entry. {@code name} and
+ * {@code version} are required; every other element is optional and is omitted from the generated
+ * descriptor when left at its blank/empty default.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface BungeePlugin {
+    /**
+     * The plugin name BungeeCord registers the plugin under.
+     *
+     * @return the plugin name (required)
+     */
+    String name();
+
+    /**
+     * The plugin version.
+     *
+     * @return the plugin version (required)
+     */
+    String version();
+
+    /**
+     * The single plugin author. BungeeCord's descriptor has no plural {@code authors} key, unlike
+     * Spigot's.
+     *
+     * @return the author, or an empty string to omit the key
+     */
+    String author() default "";
+
+    /**
+     * Hard dependencies that must be present and load before this plugin. Emitted under the
+     * BungeeCord {@code depends} key (camelCase, distinct from Spigot's {@code depend}).
+     *
+     * @return the hard-dependency plugin names
+     */
+    String[] depends() default {};
+
+    /**
+     * Soft dependencies loaded before this plugin when present. Emitted under the BungeeCord
+     * {@code softDepends} key (camelCase, distinct from Spigot's {@code softdepend}).
+     *
+     * @return the soft-dependency plugin names
+     */
+    String[] softDepends() default {};
+
+    /**
+     * A human-readable description.
+     *
+     * @return the description, or an empty string to omit the key
+     */
+    String description() default "";
+
+    /**
+     * Runtime Maven library coordinates ({@code group:artifact:version}) that BungeeCord 1.21+
+     * downloads via its library loader. Emitted under the {@code libraries} key.
+     *
+     * @return the library coordinates
+     */
+    String[] libraries() default {};
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true compile`
+Expected: `BUILD SUCCESS` (one source file compiled to Java 8 bytecode).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/annotations/BungeePlugin.java
+git commit -m "feat(bungee): add @BungeePlugin descriptor annotation"
+```
+
+---
+
+## Task 3: `BungeePluginAnnotationProcessor` (bungee.yml writer)
+
+**Files:**
+- Create: `platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessor.java`
+- Test: `platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessorTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.StandardLocation;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeePluginAnnotationProcessorTest {
+
+    private Compilation compile(String source) {
+        return javac()
+                .withProcessors(new BungeePluginAnnotationProcessor())
+                .compile(JavaFileObjects.forSourceString("com.example.Main", source));
+    }
+
+    @Test
+    void generatesFullDescriptorWithAllFields() {
+        Compilation compilation = compile(
+                "package com.example;\n" +
+                "import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;\n" +
+                "@BungeePlugin(\n" +
+                "        name = \"MyProxyPlugin\",\n" +
+                "        version = \"1.0.0\",\n" +
+                "        author = \"Approximations\",\n" +
+                "        depends = {\"SomeOther\"},\n" +
+                "        softDepends = {\"Optional\"},\n" +
+                "        description = \"A proxy plugin.\",\n" +
+                "        libraries = {\"com.squareup.okhttp3:okhttp:4.12.0\"}\n" +
+                ")\n" +
+                "public class Main {}\n");
+
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+                .contentsAsUtf8String()
+                .isEqualTo(
+                        "name: MyProxyPlugin\n" +
+                        "main: com.example.Main\n" +
+                        "version: 1.0.0\n" +
+                        "author: Approximations\n" +
+                        "depends: [SomeOther]\n" +
+                        "softDepends: [Optional]\n" +
+                        "description: A proxy plugin.\n" +
+                        "libraries: ['com.squareup.okhttp3:okhttp:4.12.0']\n");
+    }
+
+    @Test
+    void generatesOnlyRequiredFieldsWhenOptionalsAbsent() {
+        Compilation compilation = compile(
+                "package com.example;\n" +
+                "import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;\n" +
+                "@BungeePlugin(name = \"MyProxyPlugin\", version = \"1.0.0\")\n" +
+                "public class Main {}\n");
+
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+                .contentsAsUtf8String()
+                .isEqualTo(
+                        "name: MyProxyPlugin\n" +
+                        "main: com.example.Main\n" +
+                        "version: 1.0.0\n");
+    }
+
+    @Test
+    void usesBungeeCamelCaseDependencyKeysNotSpigotKeys() throws Exception {
+        Compilation compilation = compile(
+                "package com.example;\n" +
+                "import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;\n" +
+                "@BungeePlugin(name = \"MyProxyPlugin\", version = \"1.0.0\",\n" +
+                "        depends = {\"A\", \"B\"}, softDepends = {\"C\"})\n" +
+                "public class Main {}\n");
+
+        assertThat(compilation).succeeded();
+        String yml = compilation
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+                .orElseThrow(() -> new AssertionError("bungee.yml was not generated"))
+                .getCharContent(true)
+                .toString();
+
+        assertTrue(yml.contains("depends: [A, B]"), "should emit camelCase depends as a flow list");
+        assertTrue(yml.contains("softDepends: [C]"), "should emit camelCase softDepends as a flow list");
+        assertFalse(yml.contains("depend:"), "must not emit the Spigot-style 'depend' key");
+        assertFalse(yml.contains("softdepend:"), "must not emit the Spigot-style 'softdepend' key");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true test -Dtest=BungeePluginAnnotationProcessorTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — `BungeePluginAnnotationProcessor` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin;
+
+import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Generates a BungeeCord {@code bungee.yml} descriptor at compile time from {@link BungeePlugin}.
+ * Mirrors the Spigot {@code PluginAnnotationProcessor}: the annotated type is taken as the descriptor
+ * {@code main} class, and the YAML is hand-written into {@link StandardLocation#CLASS_OUTPUT} so it
+ * lands at the jar root, where BungeeCord's {@code PluginManager} reads it (preferring {@code bungee.yml}
+ * over {@code plugin.yml}).
+ */
+@SupportedAnnotationTypes("tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class BungeePluginAnnotationProcessor extends AbstractProcessor {
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (TypeElement annotation : annotations) {
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                BungeePlugin pluginAnnotation = element.getAnnotation(BungeePlugin.class);
+
+                if (pluginAnnotation == null) {
+                    continue;
+                }
+
+                try {
+                    generateBungeeYml(pluginAnnotation, element);
+                } catch (IOException e) {
+                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Could not generate bungee.yml: " + e.getMessage(), element);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void generateBungeeYml(BungeePlugin pluginAnnotation, Element element) throws IOException {
+        Filer filer = processingEnv.getFiler();
+        FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "bungee.yml", element);
+
+        try (PrintWriter writer = new PrintWriter(fileObject.openWriter())) {
+            // explicit '\n' (not println) keeps the generated descriptor byte-identical regardless of the
+            // build OS, which the byte-exact tests depend on. the annotated class is assumed to be the main class.
+            writer.print("name: " + pluginAnnotation.name() + "\n");
+            writer.print("main: " + ((TypeElement) element).getQualifiedName().toString() + "\n");
+            writer.print("version: " + pluginAnnotation.version() + "\n");
+
+            if (!pluginAnnotation.author().isEmpty()) {
+                writer.print("author: " + pluginAnnotation.author() + "\n");
+            }
+            if (pluginAnnotation.depends().length > 0) {
+                writer.print("depends: [" + String.join(", ", pluginAnnotation.depends()) + "]\n");
+            }
+            if (pluginAnnotation.softDepends().length > 0) {
+                writer.print("softDepends: [" + String.join(", ", pluginAnnotation.softDepends()) + "]\n");
+            }
+            if (!pluginAnnotation.description().isEmpty()) {
+                writer.print("description: " + pluginAnnotation.description() + "\n");
+            }
+            if (pluginAnnotation.libraries().length > 0) {
+                writer.print("libraries: [" + Arrays.stream(pluginAnnotation.libraries()).map(lib -> "'" + lib + "'").collect(Collectors.joining(", ")) + "]\n");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true test -Dtest=BungeePluginAnnotationProcessorTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS (3 tests). A benign note may appear — "Supported source version 'RELEASE_8' … less than -source '21'" — because the processor targets Java 8 while the JDK-21 in-test compiler defaults to source 21. It is a note, not an error, so `succeeded()` still holds. (The processor uses only public `javax.*` APIs, so compile-testing needs no `--add-exports`; if a future change touches `com.sun.source.*` internals and triggers an access error, add the standard `--add-exports jdk.compiler/...=ALL-UNNAMED` flags via a surefire `argLine`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessor.java platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessorTest.java
+git commit -m "feat(bungee): generate bungee.yml from @BungeePlugin"
+```
+
+---
+
+## Task 4: Register the processor via SPI
+
+**Files:**
+- Create: `platform-bungee/annotation-processor-bungee/src/main/resources/META-INF/services/javax.annotation.processing.Processor`
+- Test: `platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginProcessorRegistrationTest.java`
+
+The Task 3 tests instantiate the processor directly, so they pass without SPI. This task adds the registration that lets `javac` auto-discover the processor when a downstream plugin puts the module on its `annotationProcessorPaths`, and guards it with a test.
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeePluginProcessorRegistrationTest {
+
+    // proves the SPI service file is present and names the processor, so javac auto-discovers it from a
+    // downstream plugin's annotationProcessorPaths exactly as it does the Spigot PluginAnnotationProcessor.
+    @Test
+    void processorIsRegisteredAsAnnotationProcessorService() throws IOException {
+        try (InputStream in = getClass().getClassLoader()
+                .getResourceAsStream("META-INF/services/javax.annotation.processing.Processor")) {
+            assertNotNull(in, "the SPI registration file must be present on the classpath");
+            String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(content.contains(BungeePluginAnnotationProcessor.class.getName()),
+                    "META-INF/services/javax.annotation.processing.Processor must register "
+                            + "BungeePluginAnnotationProcessor so javac auto-discovers it");
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true test -Dtest=BungeePluginProcessorRegistrationTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: FAIL — `assertNotNull` fails because the SPI resource does not exist yet (`getResourceAsStream` returns `null`).
+
+- [ ] **Step 3: Create the SPI registration resource**
+
+File: `platform-bungee/annotation-processor-bungee/src/main/resources/META-INF/services/javax.annotation.processing.Processor`
+
+Content (single line, the processor FQCN, no license header — this is a service file, not Java):
+
+```
+tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin.BungeePluginAnnotationProcessor
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true test -Dtest=BungeePluginProcessorRegistrationTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS (1 test). If it still fails, confirm the file landed in `target/classes/META-INF/services/` after the build (Maven copies `src/main/resources` during `process-resources`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "platform-bungee/annotation-processor-bungee/src/main/resources/META-INF/services/javax.annotation.processing.Processor" platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginProcessorRegistrationTest.java
+git commit -m "feat(bungee): register bungee.yml processor via SPI"
+```
+
+---
+
+## Task 5: Full-module and reactor verification
+
+**Files:** none (verification only — no new commit).
+
+- [ ] **Step 1: Run the full module test suite**
+
+Run: `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true test`
+Expected: PASS — all tests across `BungeePluginAnnotationProcessorTest` (3) and `BungeePluginProcessorRegistrationTest` (1) = **4 tests, 0 failures**.
+
+- [ ] **Step 2: Verify the whole reactor still builds**
+
+Run: `mvnw.cmd -Danimal.sniffer.skip=true install -DskipTests`
+Expected: `BUILD SUCCESS` for every module including `spigot-boot-platform-bungee` and the new `spigot-boot-annotation-processor-bungee`. This confirms adding the module did not disturb the existing reactor and that the license-header check passes on the new `.java` files.
+
+- [ ] **Step 3: Confirm the working tree is clean**
+
+Run: `git status`
+Expected: clean (all changes committed across Tasks 1–4). If `target/` artifacts appear, they are build output and are already git-ignored.
+
+---
+
+## Done criteria
+
+- `mvnw.cmd -pl platform-bungee/annotation-processor-bungee -am -Danimal.sniffer.skip=true test` is green (4 tests).
+- `mvnw.cmd -Danimal.sniffer.skip=true install -DskipTests` builds the full reactor including the new module.
+- A Bungee plugin author can annotate a `net.md_5.bungee.api.plugin.Plugin` subclass with `@BungeePlugin(name = …, version = …, …)`, add `spigot-boot-annotation-processor-bungee` to their `annotationProcessorPaths`, and a correct `bungee.yml` (using `depends`/`softDepends`/`author`/`libraries`) is emitted to the jar root at build time — no hand-written descriptor.
+- `@BungeePlugin` is `SOURCE`-retained and the processor module carries no runtime dependency, so nothing new ships inside the downstream plugin jar.
+
+## Out of scope (later slices, separate plans)
+
+- `commands-bungee`, `config-bungee` (concurrent sibling slices).
+- `${project.version}` / Maven-property interpolation in descriptor metadata (hardcoded literals, matching `test-plugin`'s `@Plugin`).
+- Main-class subtype validation (the processor does not verify the annotated class extends Bungee's `Plugin`, mirroring the Spigot processor).
+- A runnable BungeeCord sample/test plugin and on-server end-to-end validation that loads a generated `bungee.yml`.

--- a/docs/superpowers/specs/2026-06-15-bungeecord-yml-generation-design.md
+++ b/docs/superpowers/specs/2026-06-15-bungeecord-yml-generation-design.md
@@ -1,0 +1,341 @@
+# BungeeCord Descriptor Generator: bungee.yml Generation Design
+
+Date: 2026-06-15
+Status: Approved design, pending spec review
+Target module: `platform-bungee/annotation-processor-bungee` (new), artifactId `spigot-boot-annotation-processor-bungee`
+
+## Background
+
+Spigot Boot generates the Spigot plugin descriptor (`plugin.yml`) at **build time** from a
+source annotation, so a Spigot author never hand-writes or hand-maintains the descriptor.
+The generator lives in `platform-spigot/annotation-processor`
+(artifactId `spigot-boot-annotation-processor-spigot`): the `@Plugin` annotation
+(`.../annotations/Plugin.java`) carries the metadata, and `PluginAnnotationProcessor`
+(`.../plugin/PluginAnnotationProcessor.java`) hand-rolls the YAML with a `PrintWriter` into
+`StandardLocation.CLASS_OUTPUT` (`target/classes/plugin.yml`). The annotated class itself is
+taken as the `main` class (`PluginAnnotationProcessor.java:72`: "Assumes the annotated class
+is the main class"). The processor is registered via SPI in
+`META-INF/services/javax.annotation.processing.Processor` (which also lists the unrelated
+`DiscoveryIndexProcessor`).
+
+The BungeeCord adapter slice ("core-bungee v1",
+`docs/superpowers/specs/2026-06-15-bungeecord-core-bungee-design.md`) deliberately deferred
+descriptor generation: its user-facing example notes "the plugin still needs a `bungee.yml`
+descriptor to load… the test plugin hand-writes one", and its Roadmap item #1 frames the
+exact decision this spec resolves:
+
+> **Descriptor generator** — emit `bungee.yml` (decision: reuse `@Plugin` with a
+> Bungee-targeted writer vs. a new `@BungeePlugin` annotation/module).
+
+**This spec covers that slice.** It adds a build-time generator that emits a valid
+`bungee.yml` from a new `@BungeePlugin` annotation, mirroring the Spigot mechanism so a
+Bungee author declares descriptor metadata on the main class and the file is produced during
+compilation.
+
+## Goals
+
+- A Bungee plugin author annotates the main class with `@BungeePlugin(...)` and a valid
+  `bungee.yml` is emitted to the jar root at build time — no hand-written descriptor.
+- The generated descriptor uses the exact BungeeCord schema (`depends`/`softDepends`
+  camelCase, single `author`, `libraries`), distinct from Spigot's schema.
+- The mechanism mirrors the Spigot generator (annotation on the main class → hand-rolled
+  YAML → `CLASS_OUTPUT`), so the two platforms stay structurally consistent.
+- The work is isolated in its own module so it can be built and reviewed concurrently with
+  the sibling `commands-bungee` and `config-bungee` slices.
+
+## Non-goals
+
+- **No reuse of the Spigot `@Plugin` annotation.** Its Spigot-only elements (`load`,
+  `apiVersion`, `foliaSupported`, `prefix`, `loadbefore`, `website`, plural `authors`) are
+  meaningless on a proxy and its dependency keys (`depend`/`softdepend`) do not match
+  Bungee's (`depends`/`softDepends`).
+- **No Maven property interpolation** (`${project.version}`). Metadata is hardcoded
+  annotation literals, exactly as `test-plugin`'s `@Plugin(version = "1.0.0", ...)` does
+  today (`test-plugin/.../Main.java:34-41`).
+- **No main-class subtype validation.** The processor does not verify the annotated class
+  extends `net.md_5.bungee.api.plugin.Plugin`, mirroring Spigot's no-validation approach
+  (and keeping the processor free of any Bungee-API dependency).
+- **No changes to `test-plugin`.** It is Spigot-only and stays so; the generator is verified
+  by self-contained unit tests (see Testing strategy).
+- **No on-server end-to-end validation** or runnable Bungee sample plugin (a later slice,
+  consistent with core-bungee v1's deferral).
+- No touching `commands-bungee`, `config-bungee`, or the shared Spigot processor.
+
+## Descriptor schema (grounding)
+
+Verified directly against the pinned `net.md-5:bungeecord-api:1.21-R0.3` jar (`javap` on
+`net.md_5.bungee.api.plugin.PluginDescription`) and BungeeCord's `PluginManager`:
+
+- BungeeCord's `PluginManager.detectPlugins(File)` reads **`bungee.yml`** from the jar root
+  first, falling back to `plugin.yml` if absent, and loads it via SnakeYAML
+  `yaml.loadAs(in, PluginDescription.class)` — i.e. YAML keys map to the JavaBean property
+  names of `PluginDescription` (case-sensitive). `setSkipMissingProperties(true)` means
+  unknown keys are silently ignored.
+- `PluginDescription` fields → YAML keys:
+
+| Key | Type | Required | Notes |
+|---|---|---|---|
+| `name` | String | **yes** (`checkNotNull`) | |
+| `main` | String | **yes** (`checkNotNull`) | the main class FQCN |
+| `version` | String | no (defaults `null`) | required by `@BungeePlugin` by convention, to avoid a Bungee console warning |
+| `author` | String | no | **single** author — there is no plural `authors` key (unlike Spigot) |
+| `depends` | Set\<String\> | no (default empty) | **camelCase**; *not* Spigot's `depend` |
+| `softDepends` | Set\<String\> | no (default empty) | **camelCase**; *not* Spigot's `softdepend` |
+| `description` | String | no | |
+| `libraries` | List\<String\> | no (default empty) | BungeeCord 1.21 runtime Maven loader; `group:artifact:version` coordinates |
+
+`file` exists on the POJO but is set at runtime, never a YAML key. Scalars
+(`name`/`main`/`version`/`author`/`description`) must be single strings; `depends`,
+`softDepends`, and `libraries` must be YAML sequences (SnakeYAML does not coerce a scalar
+into a Set/List).
+
+## Design decision: a new isolated module
+
+We add a **new module** `platform-bungee/annotation-processor-bungee`
+(artifactId `spigot-boot-annotation-processor-bungee`) rather than extending the shared
+`platform-spigot/annotation-processor`.
+
+**Why a new module (recommended and chosen):**
+
+1. **Blast radius.** The shared Spigot processor drives the entire Spigot platform — both
+   `plugin.yml` generation **and** the runtime discovery index (`DiscoveryIndexProcessor`,
+   registered in the same SPI file). Editing it to add Bungee logic risks the Spigot build
+   and tests, which is unacceptable while two sibling Bungee efforts run concurrently.
+2. **Single Responsibility / Interface Segregation.** A Bungee-specific annotation and writer
+   belong with the Bungee platform tree. A Bungee author should not depend on `@Plugin`
+   (whose surface is Folia/`api-version`/`load`/`prefix`/plural-`authors`) to emit a proxy
+   descriptor; `@BungeePlugin` exposes only Bungee-relevant elements.
+3. **Dependency hygiene & symmetry.** Like the Spigot processor, the Bungee module ships no
+   runtime dependencies and carries its own SPI registration. It mirrors how
+   `platform-spigot` keeps its processor as a standalone module under the platform tree; a
+   future `platform-velocity` would slot in the same way.
+4. **Parallelizability.** Keeping the work in its own files limits contention with the
+   sibling slices to a single shared line in `platform-bungee/pom.xml` (see Architecture).
+
+**Alternative considered — reuse `@Plugin` with a second Bungee-targeted writer:** rejected.
+It forces edits to the high-blast-radius shared module, and `@Plugin`'s semantics do not map
+cleanly onto Bungee (it would have to ignore six Spigot-only elements and remap
+`depend`→`depends`, `softdepend`→`softDepends`, and collapse plural `authors` into a single
+`author`). The mismatch is large enough that a dedicated annotation is both safer and
+clearer.
+
+## Architecture
+
+### Module & Maven structure (mirror `platform-spigot/annotation-processor`)
+
+```
+platform-bungee/                          packaging: pom (already exists)
+  pom.xml                                  <modules> gains: annotation-processor-bungee
+  core-bungee/                             (existing, v1)
+  annotation-processor-bungee/            artifactId: spigot-boot-annotation-processor-bungee
+    pom.xml
+    src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/
+      annotations/BungeePlugin.java
+      plugin/BungeePluginAnnotationProcessor.java
+    src/main/resources/META-INF/services/javax.annotation.processing.Processor
+    src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/
+      plugin/BungeePluginAnnotationProcessorTest.java
+```
+
+`annotation-processor-bungee` pom (modeled on `core-bungee`'s, *not* the Spigot processor's,
+because this module has tests that must compile on Java 17):
+
+- Parent `spigot-boot-platform-bungee:3.2.1-SNAPSHOT`; packaging `jar`.
+- `maven-compiler-plugin`: main `source/target = 1.8`, `testSource/testTarget = 17`, with
+  `<proc>none</proc>` so the JDK does not auto-run this module's own processor while
+  compiling it (matching `platform-spigot/annotation-processor/pom.xml`).
+- **No** dependencies on the Bungee API, the Spigot processor, or `spigot-boot-core` — the
+  processor uses only `javax.annotation.processing` and `javax.lang.model`.
+- **No** animal-sniffer (this module is not Bukkit-facing) and **no** `maven-shade-plugin`
+  (no javassist of its own).
+- One **test-scoped** dependency: `com.google.testing.compile:compile-testing` (pulls Truth +
+  Guava transitively, test scope only). JUnit 5 is inherited from the root pom.
+
+**Shared merge-conflict point:** `platform-bungee/pom.xml`'s `<modules>` block (today only
+`core-bungee`) gains `annotation-processor-bungee`. The sibling `commands-bungee` and
+`config-bungee` slices add their own modules to the same block, so this single line is the
+expected conflict; the plan calls it out and adds the entry adjacent to `core-bungee` to keep
+resolution trivial.
+
+### Package
+
+`tech.guilhermekaua.spigotboot.bungee.annotationprocessor` (mirrors the Spigot
+`...spigot.annotationprocessor`), with `annotations` and `plugin` subpackages as above.
+
+## Components
+
+### `@BungeePlugin` (the annotation)
+
+`@Retention(RetentionPolicy.SOURCE)`, `@Target(ElementType.TYPE)` — identical retention/target
+to Spigot's `@Plugin`, so it is build-time-only and never ships in the plugin jar. Placed on
+the class that extends `net.md_5.bungee.api.plugin.Plugin`; that class becomes `main`.
+
+```java
+public @interface BungeePlugin {
+    String name();                       // required
+    String version();                    // required
+    String author()        default "";
+    String[] depends()     default {};
+    String[] softDepends() default {};
+    String description()   default "";
+    String[] libraries()   default {};
+}
+```
+
+Element set is the BungeeCord descriptor schema minus `main` (derived) and `file`
+(runtime-only). `name`/`version` have no default (required); the rest default empty/blank and
+are omitted from the output when unset.
+
+### `BungeePluginAnnotationProcessor` (the writer)
+
+A near-mechanical mirror of `PluginAnnotationProcessor`:
+
+- `@SupportedAnnotationTypes("tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin")`,
+  `@SupportedSourceVersion(SourceVersion.RELEASE_8)`.
+- `process(...)` iterates the elements annotated with `@BungeePlugin` and, for each, opens
+  `filer.createResource(StandardLocation.CLASS_OUTPUT, "", "bungee.yml", element)` and writes
+  with a `PrintWriter` (hand-rolled YAML, no YAML library — matching Spigot).
+- `main` is `((TypeElement) element).getQualifiedName().toString()`. No subtype validation.
+- On `IOException`, reports `Diagnostic.Kind.ERROR` and returns `false` (mirrors Spigot).
+
+Emission order and rules (the exact bytes the tests pin):
+
+1. `name: <name>`
+2. `main: <FQCN of annotated class>`
+3. `version: <version>`
+4. if `author` non-empty → `author: <author>`
+5. if `depends` non-empty → `depends: [a, b]` (flow sequence, bare scalars)
+6. if `softDepends` non-empty → `softDepends: [a, b]`
+7. if `description` non-empty → `description: <description>`
+8. if `libraries` non-empty → `libraries: ['g:a:v', ...]` (each entry single-quoted, matching
+   Spigot's `libraries` serialization — safe for the colons in Maven coordinates)
+
+Generated `bungee.yml` for a fully-populated annotation:
+
+```yaml
+name: MyProxyPlugin
+main: com.example.Main
+version: 1.0.0
+author: Approximations
+depends: [SomeOther]
+softDepends: [Optional]
+description: A proxy plugin.
+libraries: ['com.squareup.okhttp3:okhttp:4.12.0']
+```
+
+And for the required-only case `@BungeePlugin(name = "MyProxyPlugin", version = "1.0.0")` on
+`com.example.Main`:
+
+```yaml
+name: MyProxyPlugin
+main: com.example.Main
+version: 1.0.0
+```
+
+Known limitation (parity with Spigot): scalar values are written unquoted, so a `description`
+containing YAML-special syntax could need manual escaping. This matches the Spigot writer and
+is acceptable for v1.
+
+### SPI registration
+
+`src/main/resources/META-INF/services/javax.annotation.processing.Processor` contains exactly
+one line:
+
+```
+tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin.BungeePluginAnnotationProcessor
+```
+
+Discovery indexing is **not** this module's concern — `core-bungee` already wires the Spigot
+`DiscoveryIndexProcessor` for `@Component` indexing, so the Bungee module ships only the
+descriptor processor.
+
+## User-facing usage
+
+A Bungee plugin combines the v1 `core-bungee` runtime with this descriptor annotation. The
+annotation goes on the same main class shown in the core-bungee spec:
+
+```java
+@BungeePlugin(
+    name = "MyProxyPlugin",
+    version = "1.0.0",
+    author = "Approximations",
+    depends = {"SomeOther"},
+    description = "A proxy plugin."
+)
+public class Main extends net.md_5.bungee.api.plugin.Plugin {
+    private BungeeBootPlugin bootPlugin;
+
+    @Override public void onEnable()  { bootPlugin = new BungeeBootPlugin(this);
+                                        BungeeBoot.initialize(bootPlugin); }
+    @Override public void onDisable() { BungeeBoot.onDisable(bootPlugin); }
+}
+```
+
+Build-time wiring (the plugin's own pom): add the descriptor processor to
+`annotationProcessorPaths` — build-time only; nothing ships, since `@BungeePlugin` is
+`SOURCE`-retained:
+
+```xml
+<annotationProcessorPaths>
+    <path>
+        <groupId>tech.guilhermekaua.spigot-boot</groupId>
+        <artifactId>spigot-boot-annotation-processor-bungee</artifactId>
+        <version>${project.version}</version>
+    </path>
+    <!-- plus spigot-boot-annotation-processor-spigot for @Component discovery indexing -->
+</annotationProcessorPaths>
+```
+
+On `package`, `bungee.yml` lands at the jar root and BungeeCord loads it.
+
+## Testing strategy
+
+Real TDD via `com.google.testing.compile` (the Spigot processor currently has no unit tests;
+this slice adds proper coverage). `BungeePluginAnnotationProcessorTest` runs the processor
+in-memory over an inline `@BungeePlugin` source and asserts the exact generated `bungee.yml`
+bytes — fully self-contained, no `test-plugin` changes:
+
+```java
+Compilation c = javac()
+    .withProcessors(new BungeePluginAnnotationProcessor())
+    .compile(JavaFileObjects.forSourceString("com.example.Main", SOURCE));
+assertThat(c).succeeded();
+assertThat(c)
+    .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+    .contentsAsUtf8String()
+    .isEqualTo("name: MyProxyPlugin\nmain: com.example.Main\nversion: 1.0.0\n...");
+```
+
+Coverage:
+
+- **Full descriptor** — every element set → emits all eight lines in order.
+- **Required-only** — only `name`/`version` → emits exactly `name`, `main`, `version`
+  (optional lines omitted).
+- **`main` resolution** — `main` equals the annotated class's fully-qualified name.
+- **camelCase dependency keys** — `depends`/`softDepends` emitted (asserts they are *not*
+  `depend`/`softdepend`), as flow sequences.
+- **`libraries` quoting** — each coordinate single-quoted.
+
+## Open items to pin at plan time (not blockers)
+
+1. **`compile-testing` version** — pin a concrete `com.google.testing.compile:compile-testing`
+   version (current line is `0.21.0`) and confirm it resolves from Maven Central and runs
+   under the JDK 21 build (the processor uses only public `javax.*` APIs, so no
+   `--add-exports` is needed, unlike processors touching `com.sun.source.*`).
+2. **`@SupportedSourceVersion(RELEASE_8)` warning** — under JDK 21's in-process `javac`,
+   compile-testing may surface a benign "supported source version less than -source" note;
+   confirm `succeeded()` still holds (warnings do not fail), or pin `-source 8` compiler
+   options in the test if needed.
+3. **Module ordering in `platform-bungee/pom.xml`** — add `annotation-processor-bungee`
+   immediately after `core-bungee` to minimize conflict churn with the sibling slices.
+
+## Roadmap (sibling and subsequent slices)
+
+This slice and the two other concurrent slices all descend from core-bungee v1's roadmap:
+
+1. **`bungee.yml` descriptor generator** — *this spec.*
+2. **`commands-bungee`** — `CommandPlatformSupport` + `CommandSenderHandle` for
+   `net.md_5.bungee.api.CommandSender` (separate spec, concurrent).
+3. **`config-bungee`** — Bungee config loader/data-folder glue (separate spec, concurrent).
+4. **Later:** a runnable Bungee sample/test plugin and on-server end-to-end validation that
+   exercises both `core-bungee` and a generated `bungee.yml`.

--- a/docs/superpowers/specs/2026-06-15-bungeecord-yml-generation-design.md
+++ b/docs/superpowers/specs/2026-06-15-bungeecord-yml-generation-design.md
@@ -286,6 +286,20 @@ Build-time wiring (the plugin's own pom): add the descriptor processor to
 </annotationProcessorPaths>
 ```
 
+`annotationProcessorPaths` does **not** contribute to the compile classpath, so the same artifact
+must also be declared as a `provided` dependency for the `@BungeePlugin` reference in source to
+resolve (mirroring how `test-plugin` wires the Spigot processor). `provided` keeps it out of the
+shipped jar — consistent with `@BungeePlugin` being `SOURCE`-retained:
+
+```xml
+<dependency>
+    <groupId>tech.guilhermekaua.spigot-boot</groupId>
+    <artifactId>spigot-boot-annotation-processor-bungee</artifactId>
+    <version>${project.version}</version>
+    <scope>provided</scope>
+</dependency>
+```
+
 On `package`, `bungee.yml` lands at the jar root and BungeeCord loads it.
 
 ## Testing strategy

--- a/platform-bungee/annotation-processor-bungee/pom.xml
+++ b/platform-bungee/annotation-processor-bungee/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>tech.guilhermekaua.spigot-boot</groupId>
+        <artifactId>spigot-boot-platform-bungee</artifactId>
+        <version>3.2.1-SNAPSHOT</version>
+    </parent>
+
+    <name>${project.artifactId}</name>
+    <description>Annotation processor that generates the BungeeCord bungee.yml descriptor from @BungeePlugin.</description>
+    <url>https://github.com/guikaua12/spigot-boot</url>
+    <artifactId>spigot-boot-annotation-processor-bungee</artifactId>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
+                    <!-- disable annotation processing while compiling this module so javac does not try to
+                         run our own (not-yet-compiled) processor on itself, mirroring the Spigot processor pom. -->
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.testing.compile</groupId>
+            <artifactId>compile-testing</artifactId>
+            <version>0.21.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/annotations/BungeePlugin.java
+++ b/platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/annotations/BungeePlugin.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares the BungeeCord plugin descriptor on the plugin's main class (the class that extends
+ * {@code net.md_5.bungee.api.plugin.Plugin}). {@code BungeePluginAnnotationProcessor} reads this
+ * annotation at compile time and emits a {@code bungee.yml} into the jar root, mirroring how the
+ * Spigot {@code @Plugin} annotation drives {@code plugin.yml}.
+ *
+ * <p>The annotated class itself becomes the descriptor's {@code main} entry. {@code name} and
+ * {@code version} are required; every other element is optional and is omitted from the generated
+ * descriptor when left at its blank/empty default.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface BungeePlugin {
+    /**
+     * The plugin name BungeeCord registers the plugin under.
+     *
+     * @return the plugin name (required)
+     */
+    String name();
+
+    /**
+     * The plugin version.
+     *
+     * @return the plugin version (required)
+     */
+    String version();
+
+    /**
+     * The single plugin author. BungeeCord's descriptor has no plural {@code authors} key, unlike
+     * Spigot's.
+     *
+     * @return the author, or an empty string to omit the key
+     */
+    String author() default "";
+
+    /**
+     * Hard dependencies that must be present and load before this plugin. Emitted under the
+     * BungeeCord {@code depends} key (camelCase, distinct from Spigot's {@code depend}).
+     *
+     * @return the hard-dependency plugin names
+     */
+    String[] depends() default {};
+
+    /**
+     * Soft dependencies loaded before this plugin when present. Emitted under the BungeeCord
+     * {@code softDepends} key (camelCase, distinct from Spigot's {@code softdepend}).
+     *
+     * @return the soft-dependency plugin names
+     */
+    String[] softDepends() default {};
+
+    /**
+     * A human-readable description.
+     *
+     * @return the description, or an empty string to omit the key
+     */
+    String description() default "";
+
+    /**
+     * Runtime Maven library coordinates ({@code group:artifact:version}) that BungeeCord 1.21+
+     * downloads via its library loader. Emitted under the {@code libraries} key.
+     *
+     * @return the library coordinates
+     */
+    String[] libraries() default {};
+}

--- a/platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessor.java
+++ b/platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessor.java
@@ -36,7 +36,9 @@ import javax.tools.Diagnostic;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -77,28 +79,81 @@ public class BungeePluginAnnotationProcessor extends AbstractProcessor {
         Filer filer = processingEnv.getFiler();
         FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "bungee.yml", element);
 
-        try (PrintWriter writer = new PrintWriter(fileObject.openWriter())) {
+        // explicit UTF-8 (not the platform default) keeps the generated descriptor byte-identical regardless of the
+        // build OS/locale, which the byte-exact tests depend on for any non-ASCII metadata.
+        try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(fileObject.openOutputStream(), StandardCharsets.UTF_8))) {
             // explicit '\n' (not println) keeps the generated descriptor byte-identical regardless of the
             // build OS, which the byte-exact tests depend on. the annotated class is assumed to be the main class.
-            writer.print("name: " + pluginAnnotation.name() + "\n");
+            writer.print("name: " + yamlScalar(pluginAnnotation.name()) + "\n");
             writer.print("main: " + ((TypeElement) element).getQualifiedName().toString() + "\n");
-            writer.print("version: " + pluginAnnotation.version() + "\n");
+            writer.print("version: " + yamlScalar(pluginAnnotation.version()) + "\n");
 
             if (!pluginAnnotation.author().isEmpty()) {
-                writer.print("author: " + pluginAnnotation.author() + "\n");
+                writer.print("author: " + yamlScalar(pluginAnnotation.author()) + "\n");
             }
             if (pluginAnnotation.depends().length > 0) {
-                writer.print("depends: [" + String.join(", ", pluginAnnotation.depends()) + "]\n");
+                writer.print("depends: " + yamlFlowList(pluginAnnotation.depends()) + "\n");
             }
             if (pluginAnnotation.softDepends().length > 0) {
-                writer.print("softDepends: [" + String.join(", ", pluginAnnotation.softDepends()) + "]\n");
+                writer.print("softDepends: " + yamlFlowList(pluginAnnotation.softDepends()) + "\n");
             }
             if (!pluginAnnotation.description().isEmpty()) {
-                writer.print("description: " + pluginAnnotation.description() + "\n");
+                writer.print("description: " + yamlScalar(pluginAnnotation.description()) + "\n");
             }
             if (pluginAnnotation.libraries().length > 0) {
-                writer.print("libraries: [" + Arrays.stream(pluginAnnotation.libraries()).map(lib -> "'" + lib + "'").collect(Collectors.joining(", ")) + "]\n");
+                writer.print("libraries: " + yamlFlowList(pluginAnnotation.libraries()) + "\n");
             }
         }
+    }
+
+    /**
+     * Renders an annotation value as a YAML scalar. Plain identifiers are emitted verbatim so descriptors stay
+     * byte-identical to the Spigot writer; only values carrying YAML-significant characters are single-quoted
+     * (with embedded {@code '} doubled), so a description like {@code Proxy: auth} or an author containing
+     * {@code '} or {@code #} still produces a parseable {@code bungee.yml}.
+     */
+    private static String yamlScalar(String value) {
+        if (!needsQuoting(value)) {
+            return value;
+        }
+        return "'" + value.replace("'", "''") + "'";
+    }
+
+    /**
+     * Renders a string array as a YAML flow list, quoting each entry only when it needs it (see
+     * {@link #yamlScalar(String)}). Library coordinates such as {@code group:artifact:version} carry a colon
+     * and are therefore quoted, matching the previously hard-coded single-quoting.
+     */
+    private static String yamlFlowList(String[] values) {
+        return Arrays.stream(values)
+                .map(BungeePluginAnnotationProcessor::yamlScalar)
+                .collect(Collectors.joining(", ", "[", "]"));
+    }
+
+    private static boolean needsQuoting(String value) {
+        if (value.isEmpty() || !value.equals(value.trim())) {
+            // empty, or has leading/trailing whitespace a plain scalar would silently strip.
+            return true;
+        }
+        switch (value.charAt(0)) {
+            // indicators that only carry special meaning when they open a scalar.
+            case '!': case '&': case '*': case '?': case '|': case '>':
+            case '@': case '%': case '`': case '-':
+                return true;
+            default:
+                break;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            switch (value.charAt(i)) {
+                // characters significant anywhere in a block scalar or a flow-list item.
+                case ':': case '#': case '\'': case '"':
+                case '\n': case '\r': case '\t':
+                case ',': case '[': case ']': case '{': case '}':
+                    return true;
+                default:
+                    break;
+            }
+        }
+        return false;
     }
 }

--- a/platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessor.java
+++ b/platform-bungee/annotation-processor-bungee/src/main/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessor.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin;
+
+import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.RoundEnvironment;
+import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Generates a BungeeCord {@code bungee.yml} descriptor at compile time from {@link BungeePlugin}.
+ * Mirrors the Spigot {@code PluginAnnotationProcessor}: the annotated type is taken as the descriptor
+ * {@code main} class, and the YAML is hand-written into {@link StandardLocation#CLASS_OUTPUT} so it
+ * lands at the jar root, where BungeeCord's {@code PluginManager} reads it (preferring {@code bungee.yml}
+ * over {@code plugin.yml}).
+ */
+@SupportedAnnotationTypes("tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class BungeePluginAnnotationProcessor extends AbstractProcessor {
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (TypeElement annotation : annotations) {
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                BungeePlugin pluginAnnotation = element.getAnnotation(BungeePlugin.class);
+
+                if (pluginAnnotation == null) {
+                    continue;
+                }
+
+                try {
+                    generateBungeeYml(pluginAnnotation, element);
+                } catch (IOException e) {
+                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Could not generate bungee.yml: " + e.getMessage(), element);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void generateBungeeYml(BungeePlugin pluginAnnotation, Element element) throws IOException {
+        Filer filer = processingEnv.getFiler();
+        FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "bungee.yml", element);
+
+        try (PrintWriter writer = new PrintWriter(fileObject.openWriter())) {
+            // explicit '\n' (not println) keeps the generated descriptor byte-identical regardless of the
+            // build OS, which the byte-exact tests depend on. the annotated class is assumed to be the main class.
+            writer.print("name: " + pluginAnnotation.name() + "\n");
+            writer.print("main: " + ((TypeElement) element).getQualifiedName().toString() + "\n");
+            writer.print("version: " + pluginAnnotation.version() + "\n");
+
+            if (!pluginAnnotation.author().isEmpty()) {
+                writer.print("author: " + pluginAnnotation.author() + "\n");
+            }
+            if (pluginAnnotation.depends().length > 0) {
+                writer.print("depends: [" + String.join(", ", pluginAnnotation.depends()) + "]\n");
+            }
+            if (pluginAnnotation.softDepends().length > 0) {
+                writer.print("softDepends: [" + String.join(", ", pluginAnnotation.softDepends()) + "]\n");
+            }
+            if (!pluginAnnotation.description().isEmpty()) {
+                writer.print("description: " + pluginAnnotation.description() + "\n");
+            }
+            if (pluginAnnotation.libraries().length > 0) {
+                writer.print("libraries: [" + Arrays.stream(pluginAnnotation.libraries()).map(lib -> "'" + lib + "'").collect(Collectors.joining(", ")) + "]\n");
+            }
+        }
+    }
+}

--- a/platform-bungee/annotation-processor-bungee/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/platform-bungee/annotation-processor-bungee/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin.BungeePluginAnnotationProcessor

--- a/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessorTest.java
+++ b/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessorTest.java
@@ -111,4 +111,31 @@ class BungeePluginAnnotationProcessorTest {
         assertFalse(yml.contains("depend:"), "must not emit the Spigot-style 'depend' key");
         assertFalse(yml.contains("softdepend:"), "must not emit the Spigot-style 'softdepend' key");
     }
+
+    @Test
+    void quotesYamlSensitiveValuesSoTheDescriptorStaysParseable() throws Exception {
+        Compilation compilation = compile(
+                "package com.example;\n" +
+                "import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;\n" +
+                "@BungeePlugin(\n" +
+                "        name = \"MyProxyPlugin\",\n" +
+                "        version = \"1.0.0\",\n" +
+                "        author = \"O'Brien\",\n" +
+                "        description = \"Proxy: auth #1\"\n" +
+                ")\n" +
+                "public class Main {}\n");
+
+        assertThat(compilation).succeeded();
+        String yml = compilation
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+                .orElseThrow(() -> new AssertionError("bungee.yml was not generated"))
+                .getCharContent(true)
+                .toString();
+
+        // a colon, hash, or apostrophe in a free-text field would otherwise yield invalid/misparsed YAML.
+        assertTrue(yml.contains("name: MyProxyPlugin\n"), "plain identifiers must stay unquoted");
+        assertTrue(yml.contains("version: 1.0.0\n"), "plain versions must stay unquoted");
+        assertTrue(yml.contains("author: 'O''Brien'\n"), "embedded apostrophes must be doubled inside a single-quoted scalar");
+        assertTrue(yml.contains("description: 'Proxy: auth #1'\n"), "colon/hash values must be single-quoted");
+    }
 }

--- a/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessorTest.java
+++ b/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginAnnotationProcessorTest.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import org.junit.jupiter.api.Test;
+
+import javax.tools.StandardLocation;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeePluginAnnotationProcessorTest {
+
+    private Compilation compile(String source) {
+        return javac()
+                .withProcessors(new BungeePluginAnnotationProcessor())
+                .compile(JavaFileObjects.forSourceString("com.example.Main", source));
+    }
+
+    @Test
+    void generatesFullDescriptorWithAllFields() {
+        Compilation compilation = compile(
+                "package com.example;\n" +
+                "import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;\n" +
+                "@BungeePlugin(\n" +
+                "        name = \"MyProxyPlugin\",\n" +
+                "        version = \"1.0.0\",\n" +
+                "        author = \"Approximations\",\n" +
+                "        depends = {\"SomeOther\"},\n" +
+                "        softDepends = {\"Optional\"},\n" +
+                "        description = \"A proxy plugin.\",\n" +
+                "        libraries = {\"com.squareup.okhttp3:okhttp:4.12.0\"}\n" +
+                ")\n" +
+                "public class Main {}\n");
+
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+                .contentsAsUtf8String()
+                .isEqualTo(
+                        "name: MyProxyPlugin\n" +
+                        "main: com.example.Main\n" +
+                        "version: 1.0.0\n" +
+                        "author: Approximations\n" +
+                        "depends: [SomeOther]\n" +
+                        "softDepends: [Optional]\n" +
+                        "description: A proxy plugin.\n" +
+                        "libraries: ['com.squareup.okhttp3:okhttp:4.12.0']\n");
+    }
+
+    @Test
+    void generatesOnlyRequiredFieldsWhenOptionalsAbsent() {
+        Compilation compilation = compile(
+                "package com.example;\n" +
+                "import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;\n" +
+                "@BungeePlugin(name = \"MyProxyPlugin\", version = \"1.0.0\")\n" +
+                "public class Main {}\n");
+
+        assertThat(compilation).succeeded();
+        assertThat(compilation)
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+                .contentsAsUtf8String()
+                .isEqualTo(
+                        "name: MyProxyPlugin\n" +
+                        "main: com.example.Main\n" +
+                        "version: 1.0.0\n");
+    }
+
+    @Test
+    void usesBungeeCamelCaseDependencyKeysNotSpigotKeys() throws Exception {
+        Compilation compilation = compile(
+                "package com.example;\n" +
+                "import tech.guilhermekaua.spigotboot.bungee.annotationprocessor.annotations.BungeePlugin;\n" +
+                "@BungeePlugin(name = \"MyProxyPlugin\", version = \"1.0.0\",\n" +
+                "        depends = {\"A\", \"B\"}, softDepends = {\"C\"})\n" +
+                "public class Main {}\n");
+
+        assertThat(compilation).succeeded();
+        String yml = compilation
+                .generatedFile(StandardLocation.CLASS_OUTPUT, "", "bungee.yml")
+                .orElseThrow(() -> new AssertionError("bungee.yml was not generated"))
+                .getCharContent(true)
+                .toString();
+
+        assertTrue(yml.contains("depends: [A, B]"), "should emit camelCase depends as a flow list");
+        assertTrue(yml.contains("softDepends: [C]"), "should emit camelCase softDepends as a flow list");
+        assertFalse(yml.contains("depend:"), "must not emit the Spigot-style 'depend' key");
+        assertFalse(yml.contains("softdepend:"), "must not emit the Spigot-style 'softdepend' key");
+    }
+}

--- a/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginProcessorRegistrationTest.java
+++ b/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginProcessorRegistrationTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.bungee.annotationprocessor.plugin;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeePluginProcessorRegistrationTest {
+
+    // proves the SPI service file is present and names the processor, so javac auto-discovers it from a
+    // downstream plugin's annotationProcessorPaths exactly as it does the Spigot PluginAnnotationProcessor.
+    @Test
+    void processorIsRegisteredAsAnnotationProcessorService() throws IOException {
+        try (InputStream in = getClass().getClassLoader()
+                .getResourceAsStream("META-INF/services/javax.annotation.processing.Processor")) {
+            assertNotNull(in, "the SPI registration file must be present on the classpath");
+            String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            assertTrue(content.contains(BungeePluginAnnotationProcessor.class.getName()),
+                    "META-INF/services/javax.annotation.processing.Processor must register "
+                            + "BungeePluginAnnotationProcessor so javac auto-discovers it");
+        }
+    }
+}

--- a/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginProcessorRegistrationTest.java
+++ b/platform-bungee/annotation-processor-bungee/src/test/java/tech/guilhermekaua/spigotboot/bungee/annotationprocessor/plugin/BungeePluginProcessorRegistrationTest.java
@@ -26,24 +26,38 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class BungeePluginProcessorRegistrationTest {
 
     // proves the SPI service file is present and names the processor, so javac auto-discovers it from a
     // downstream plugin's annotationProcessorPaths exactly as it does the Spigot PluginAnnotationProcessor.
+    // SPI service files are merged across the classpath, so we scan every entry (getResources), not just the
+    // first match — a transitive dependency (e.g. auto-value via compile-testing) ships its own processor
+    // service file that would otherwise shadow ours depending on classpath order.
     @Test
     void processorIsRegisteredAsAnnotationProcessorService() throws IOException {
-        try (InputStream in = getClass().getClassLoader()
-                .getResourceAsStream("META-INF/services/javax.annotation.processing.Processor")) {
-            assertNotNull(in, "the SPI registration file must be present on the classpath");
-            String content = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-            assertTrue(content.contains(BungeePluginAnnotationProcessor.class.getName()),
-                    "META-INF/services/javax.annotation.processing.Processor must register "
-                            + "BungeePluginAnnotationProcessor so javac auto-discovers it");
+        Enumeration<URL> resources = getClass().getClassLoader()
+                .getResources("META-INF/services/javax.annotation.processing.Processor");
+        assertTrue(resources.hasMoreElements(), "the SPI registration file must be present on the classpath");
+
+        boolean registered = false;
+        while (resources.hasMoreElements()) {
+            try (InputStream in = resources.nextElement().openStream()) {
+                if (new String(in.readAllBytes(), StandardCharsets.UTF_8)
+                        .contains(BungeePluginAnnotationProcessor.class.getName())) {
+                    registered = true;
+                    break;
+                }
+            }
         }
+
+        assertTrue(registered,
+                "META-INF/services/javax.annotation.processing.Processor must register "
+                        + "BungeePluginAnnotationProcessor so javac auto-discovers it");
     }
 }

--- a/platform-bungee/pom.xml
+++ b/platform-bungee/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>core-bungee</module>
+        <module>annotation-processor-bungee</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
Adds a build-time generator for BungeeCord's `bungee.yml` plugin descriptor, mirroring how the Spigot side auto-generates `plugin.yml`.

- **New isolated module** `platform-bungee/annotation-processor-bungee` (artifactId `spigot-boot-annotation-processor-bungee`) — kept out of the shared, high-blast-radius `platform-spigot/annotation-processor` so it can land alongside the sibling `commands-bungee`/`config-bungee` slices.
- **New `@BungeePlugin` annotation** (`name`, `version`, `author`, `depends`, `softDepends`, `description`, `libraries`) placed on the `net.md_5.bungee.api.plugin.Plugin` subclass.
- **`BungeePluginAnnotationProcessor`** hand-writes `bungee.yml` to the jar root, mirroring the Spigot writer. Schema verified against `net.md-5:bungeecord-api:1.21-R0.3`: single `author`, **camelCase** `depends`/`softDepends` (not Spigot's `depend`/`softdepend`), single-quoted `libraries`. Output uses explicit `\n` for OS-independent, byte-deterministic descriptors.
- **SPI registration** so `javac` auto-discovers the processor from a downstream plugin's `annotationProcessorPaths`.
- Design spec + implementation plan under `docs/superpowers/`.

Respects the spec non-goals: no `${project.version}` interpolation, no main-class subtype validation, no `test-plugin` changes, and no edits to the shared Spigot processor (the only reactor touch is one `<module>` line in `platform-bungee/pom.xml` — the anticipated conflict point with the sibling slices).

## Stacked on PR #72
Based on `worktree-bungeecord-core-bungee` (core-bungee v1, PR #72), so this diff is only the descriptor-generator slice. Retarget to `dev` once #72 merges.

## Test Plan
- [x] compile-testing TDD — 4 tests green (full descriptor, required-only, camelCase keys, SPI registration)
- [x] Full 32-module reactor `install -DskipTests` → BUILD SUCCESS on JDK 21
- [ ] (follow-up slice) on-server validation with a runnable Bungee sample that loads a generated `bungee.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)