### PR TITLE
feat(bungee): add platform-bungee/commands-bungee adapter

### DIFF
--- a/docs/superpowers/plans/2026-06-15-bungeecord-commands.md
+++ b/docs/superpowers/plans/2026-06-15-bungeecord-commands.md
@@ -1,0 +1,1855 @@
+# BungeeCord commands-bungee Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `platform-bungee/commands-bungee` adapter so a BungeeCord plugin using the Spigot Boot container can declare `@RootCommand`/`@Command` handler beans and have them registered with BungeeCord automatically, with argument binding, `@Permission`, tab completion, and `ProxiedPlayer`/`ServerInfo` resolvers.
+
+**Architecture:** Mirror `platform-spigot/commands-spigot` as a sibling `platform-bungee/commands-bungee` tree. The generic `commands` module (and its `CommandsConfiguration` with all 13 platform-neutral beans) is reused unchanged; `commands-bungee` adds the thin Bungee adapters (`BungeeCommandPlatformSupport`, `BungeeCommandSender`, `BungeeBootCommand extends Command implements TabExecutor`, `BungeeCommandRegistrar`, `RegisteredCommandSet`, `BungeeCommandsContextReadyRegistrar`), the Bungee `ProxiedPlayer`/`ServerInfo` resolvers + `onlinePlayers`/`servers` completions, the `BungeeCommandsModule` + marker, and a `@Configuration` (`BungeeCommandsConfiguration`) that re-declares the 8 beans that depend on `CommandPlatformSupport` plus the Bungee glue. It depends on `core-bungee` (which supplies the injectable native `Plugin`).
+
+**Tech Stack:** Java 8 bytecode (tests Java 17), Maven, `net.md-5:bungeecord-api:1.21-R0.3` (provided, Maven Central, inherited from `platform-bungee/pom.xml`), JUnit 5 + Mockito 5 (inline mock maker, inherited from the root pom). Spec: `docs/superpowers/specs/2026-06-15-bungeecord-commands-design.md`.
+
+**Build/JDK notes (read once):**
+- Build with **JDK 21** (`JAVA_HOME` must point at JDK 21, e.g. `C:/Users/Guilherme/.jdks/ms-21.0.10`, not 25 — Lombok 1.18.36 crashes on 25).
+- All commands run from the worktree root: `C:\Users\Guilherme\IdeaProjects\spigot-boot\.claude\worktrees\bungeecord-commands`, using `mvnw.cmd`.
+- Pass `-Danimal.sniffer.skip=true` on every build so a stale Spigot 1.8.8 signature in an upstream reactor module never blocks the build. `commands-bungee` itself declares no animal-sniffer check.
+- For filtered test runs (`-pl ... -am -Dtest=Xxx`), also pass `-Dsurefire.failIfNoSpecifiedTests=false` so the upstream `-am` modules (which have no class matching the `-Dtest` filter) do not fail.
+- Every new `.java` file MUST begin with the project's MIT license header (the block shown verbatim in Task 2, `Copyright © 2025 Guilherme Kauã da Silva`, matching the existing `core-bungee` files and the root `license-maven-plugin` config). Subsequent tasks say "begin with the standard MIT header" — use the exact block from Task 2.
+
+---
+
+## File Structure
+
+**Created (all under `platform-bungee/commands-bungee/`):**
+- `pom.xml` — adapter module pom; compiler + annotation-processor wiring mirroring `core-bungee`, minus shade/animal-sniffer/MockBukkit.
+- `src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSender.java` — `CommandSenderHandle` over a Bungee `CommandSender`.
+- `.../bungee/BungeeCommandPlatformSupport.java` — `CommandPlatformSupport` creating `BungeeCommandSender`.
+- `.../bungee/BungeeBootCommand.java` — `Command implements TabExecutor`, bridges to the generic dispatcher.
+- `.../bungee/RegisteredCommandSet.java` — immutable snapshot of registered commands.
+- `.../bungee/BungeeCommandRegistrar.java` — registers/unregisters via `PluginManager`.
+- `.../bungee/BungeeCommandsContextReadyRegistrar.java` — `ContextReadyListener, Ordered` that compiles + registers.
+- `.../bungee/resolve/BungeeProxiedPlayerArgumentResolver.java` — `CommandArgumentResolver<ProxiedPlayer>`.
+- `.../bungee/resolve/BungeeServerArgumentResolver.java` — `CommandArgumentResolver<ServerInfo>`.
+- `.../bungee/completion/BungeeCommandCompletionRegistryCustomizer.java` — `onlinePlayers` + `servers` named completions.
+- `.../bungee/BungeeCommandsModule.java` — near-no-op `Module`.
+- `.../bungee/configuration/BungeeCommandsConfiguration.java` — `@Configuration` wiring.
+- `src/main/resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandsModule` — empty discovery marker.
+- Tests under `src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/`: `BungeeCommandSenderTest`, `BungeeCommandPlatformSupportTest`, `BungeeBootCommandTest`, `BungeeCommandRegistrarTest`, `BungeeCommandsContextReadyRegistrarTest`, `BungeeCommandsModuleDiscoveryTest`, `BungeeBootCommandEndToEndTest`, `resolve/BungeeProxiedPlayerArgumentResolverTest`, `resolve/BungeeServerArgumentResolverTest`, `completion/BungeeCommandCompletionRegistryCustomizerTest`.
+
+**Modified:**
+- `platform-bungee/pom.xml` — add `<module>commands-bungee</module>`. **Shared file:** the sibling `config-bungee` effort edits the same `<modules>` list; this is the expected trivial merge conflict (keep both `<module>` lines).
+
+---
+
+## Task 1: Scaffold the `commands-bungee` Maven module
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/pom.xml`
+- Modify: `platform-bungee/pom.xml`
+
+- [ ] **Step 1: Create `platform-bungee/commands-bungee/pom.xml`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>tech.guilhermekaua.spigot-boot</groupId>
+        <artifactId>spigot-boot-platform-bungee</artifactId>
+        <version>3.2.1-SNAPSHOT</version>
+    </parent>
+
+    <name>${project.artifactId}</name>
+    <description>Runtime commands module for Spigot Boot on BungeeCord.</description>
+    <url>https://github.com/guikaua12/spigot-boot</url>
+    <artifactId>spigot-boot-commands-bungee</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
+                        <path>
+                            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+                            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-commands</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-core-bungee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+Note: `bungeecord-api` needs no `<version>`/`<scope>` — both (`1.21-R0.3`, `provided`) are inherited from `platform-bungee/pom.xml` dependency-management. JUnit 5 + Mockito are `test`-scoped in the root pom and inherited. `Plugin`, `ProxyServer`, `ProxyUtils`, the generic command classes, and `BungeeBootPlugin`/`Context` arrive transitively through `spigot-boot-commands` and `spigot-boot-core-bungee`.
+
+- [ ] **Step 2: Register the module in `platform-bungee/pom.xml`**
+
+In `platform-bungee/pom.xml`, change the `<modules>` block to list `commands-bungee` after `core-bungee`:
+
+```xml
+    <modules>
+        <module>core-bungee</module>
+        <module>commands-bungee</module>
+    </modules>
+```
+
+(If a concurrent branch already added `<module>config-bungee</module>`, keep all three lines — this is the expected merge point.)
+
+- [ ] **Step 3: Verify the scaffolding resolves and compiles**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true compile`
+Expected: `BUILD SUCCESS`. The module has no sources yet, so the compiler reports "No sources to compile" — that is fine. This proves `bungeecord-api`, `spigot-boot-commands`, and `spigot-boot-core-bungee` all resolve and the reactor wiring is correct. (`compile`, not `package`, avoids the javadoc/source jars that would choke on an empty module.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add platform-bungee/pom.xml platform-bungee/commands-bungee/pom.xml
+git commit -m "build(bungee): scaffold commands-bungee module"
+```
+
+---
+
+## Task 2: `BungeeCommandSender`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSender.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSenderTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandSenderTest {
+
+    @Test
+    void playerIdentityIsUuid() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        UUID uuid = UUID.randomUUID();
+        when(player.getName()).thenReturn("Alex");
+        when(player.getUniqueId()).thenReturn(uuid);
+
+        BungeeCommandSender handle = new BungeeCommandSender(player);
+
+        assertEquals("Alex", handle.getName());
+        assertEquals(uuid.toString(), handle.getIdentity());
+    }
+
+    @Test
+    void consoleIdentityFallsBackToClassAndName() {
+        CommandSender console = mock(CommandSender.class);
+        when(console.getName()).thenReturn("CONSOLE");
+
+        BungeeCommandSender handle = new BungeeCommandSender(console);
+
+        assertTrue(handle.getIdentity().endsWith(":CONSOLE"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void delegatesPermissionAndMessage() {
+        CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("a.b")).thenReturn(true);
+
+        BungeeCommandSender handle = new BungeeCommandSender(sender);
+
+        assertTrue(handle.hasPermission("a.b"));
+        handle.sendMessage("hi");
+        verify(sender).sendMessage("hi");
+    }
+
+    @Test
+    void unwrapReturnsSenderForAssignableTypeAndEmptyOtherwise() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        BungeeCommandSender handle = new BungeeCommandSender(player);
+
+        Optional<ProxiedPlayer> asPlayer = handle.unwrap(ProxiedPlayer.class);
+        Optional<CommandSender> asSender = handle.unwrap(CommandSender.class);
+        Optional<String> asString = handle.unwrap(String.class);
+
+        assertSame(player, asPlayer.orElse(null));
+        assertSame(player, asSender.orElse(null));
+        assertFalse(asString.isPresent());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandSenderTest`
+Expected: COMPILE FAILURE — `BungeeCommandSender` does not exist yet.
+
+- [ ] **Step 3: Write the implementation**
+
+```java
+/* ... standard MIT header from Task 2 ... */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Adapts a BungeeCord {@link CommandSender} to the platform-neutral {@link CommandSenderHandle}.
+ * Mirrors the Spigot {@code BukkitCommandSender}.
+ */
+public class BungeeCommandSender implements CommandSenderHandle {
+    private final CommandSender sender;
+
+    public BungeeCommandSender(CommandSender sender) {
+        this.sender = Objects.requireNonNull(sender, "sender cannot be null.");
+    }
+
+    @Override
+    public String getName() {
+        return sender.getName();
+    }
+
+    @Override
+    public String getIdentity() {
+        if (sender instanceof ProxiedPlayer) {
+            return ((ProxiedPlayer) sender).getUniqueId().toString();
+        }
+        // BungeeCord exposes no console sender type in its API; identify non-players by class + name.
+        String name = sender.getName();
+        return sender.getClass().getName() + ":" + (name == null ? "" : name);
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return sender.hasPermission(permission);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void sendMessage(String message) {
+        // the String overload is deprecated in favour of BaseComponent, but the CommandSenderHandle
+        // contract is String-based; the legacy overload renders legacy colour codes correctly.
+        sender.sendMessage(message);
+    }
+
+    @Override
+    public <T> Optional<T> unwrap(Class<T> type) {
+        if (type == null || !type.isInstance(sender)) {
+            return Optional.empty();
+        }
+        return Optional.of(type.cast(sender));
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandSenderTest`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSender.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSenderTest.java
+git commit -m "feat(bungee): add BungeeCommandSender handle"
+```
+
+---
+
+## Task 3: `BungeeCommandPlatformSupport`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupport.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupportTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandPlatformSupportTest {
+    private final BungeeCommandPlatformSupport support = new BungeeCommandPlatformSupport();
+
+    @Test
+    void createSenderWrapsBungeeSender() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(player.getName()).thenReturn("Alex");
+
+        CommandSenderHandle handle = support.createSender(player);
+
+        assertEquals("Alex", handle.getName());
+        assertSame(player, handle.unwrap(ProxiedPlayer.class).orElse(null));
+    }
+
+    @Test
+    void createSenderRejectsNonBungeeSender() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> support.createSender("not a sender"));
+        assertTrue(ex.getMessage().contains("Expected a BungeeCord CommandSender"));
+    }
+
+    @Test
+    void isSenderTypeMatchesCommandSenderHierarchy() {
+        assertTrue(support.isSenderType(CommandSender.class));
+        assertTrue(support.isSenderType(ProxiedPlayer.class));
+        assertFalse(support.isSenderType(String.class));
+        assertFalse(support.isSenderType(null));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandPlatformSupportTest`
+Expected: COMPILE FAILURE — `BungeeCommandPlatformSupport` does not exist yet.
+
+- [ ] **Step 3: Write the implementation** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+
+/**
+ * Wraps a BungeeCord {@link CommandSender} into a {@link CommandSenderHandle}. Mirrors the Spigot
+ * {@code BukkitCommandPlatformSupport}. {@code ProxiedPlayer} is a {@code CommandSender}, so it is
+ * recognised by {@link #isSenderType(Class)} too.
+ */
+public class BungeeCommandPlatformSupport implements CommandPlatformSupport {
+
+    @Override
+    public CommandSenderHandle createSender(Object nativeSender) {
+        if (!(nativeSender instanceof CommandSender)) {
+            throw new IllegalArgumentException("Expected a BungeeCord CommandSender but got " +
+                    (nativeSender == null ? "null" : nativeSender.getClass().getName()) + ".");
+        }
+        return new BungeeCommandSender((CommandSender) nativeSender);
+    }
+
+    @Override
+    public boolean isSenderType(Class<?> type) {
+        return type != null && CommandSender.class.isAssignableFrom(type);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandPlatformSupportTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupport.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupportTest.java
+git commit -m "feat(bungee): add BungeeCommandPlatformSupport"
+```
+
+---
+
+## Task 4: `BungeeBootCommand`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandAliasSet;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeBootCommandTest {
+
+    private CompiledRootCommand rootNamed(String primary) {
+        CommandAliasSet aliases = mock(CommandAliasSet.class);
+        when(aliases.getPrimary()).thenReturn(primary);
+        when(aliases.getAliases()).thenReturn(Collections.emptyList());
+        CompiledRootCommand root = mock(CompiledRootCommand.class);
+        when(root.getAliases()).thenReturn(aliases);
+        return root;
+    }
+
+    @Test
+    void baseCommandExposesNoPermissionSoDispatcherOwnsIt() {
+        BungeeBootCommand command = new BungeeBootCommand(
+                mock(Context.class), rootNamed("server"), mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
+
+        assertNull(command.getPermission());
+    }
+
+    @Test
+    void executeDelegatesToDispatcher() {
+        Context context = mock(Context.class);
+        CompiledRootCommand root = rootNamed("server");
+        CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+        CommandPlatformSupport support = mock(CommandPlatformSupport.class);
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        CommandSenderHandle handle = mock(CommandSenderHandle.class);
+        when(support.createSender(sender)).thenReturn(handle);
+
+        BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, support);
+        String[] args = {"send", "Target"};
+        command.execute(sender, args);
+
+        verify(dispatcher).dispatch(context, root, handle, "server", args);
+    }
+
+    @Test
+    void onTabCompleteDelegatesToDispatcherAndIsNullSafe() {
+        Context context = mock(Context.class);
+        CompiledRootCommand root = rootNamed("server");
+        CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+        CommandPlatformSupport support = mock(CommandPlatformSupport.class);
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        CommandSenderHandle handle = mock(CommandSenderHandle.class);
+        when(support.createSender(sender)).thenReturn(handle);
+        when(dispatcher.complete(context, root, handle, "server", new String[]{"send", "T"}))
+                .thenReturn(Collections.singletonList("Target"));
+
+        BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, support);
+
+        Iterable<String> result = command.onTabComplete(sender, new String[]{"send", "T"});
+        List<String> values = new ArrayList<>();
+        result.forEach(values::add);
+        assertEquals(Collections.singletonList("Target"), values);
+
+        when(dispatcher.complete(context, root, handle, "server", new String[]{"x"})).thenReturn(null);
+        assertFalse(command.onTabComplete(sender, new String[]{"x"}).iterator().hasNext());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeBootCommandTest`
+Expected: COMPILE FAILURE — `BungeeBootCommand` does not exist yet.
+
+- [ ] **Step 3: Write the implementation** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.TabExecutor;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A BungeeCord {@link Command} that bridges a compiled root command to the generic
+ * {@link CommandDispatcher}. Mirrors the Spigot {@code SpigotBootCommand}.
+ *
+ * <p>The base command is constructed with a {@code null} permission: BungeeCord's
+ * {@code PluginManager} only blocks execution when {@code hasPermission} fails, so leaving it null
+ * guarantees {@link #execute}/{@link #onTabComplete} are always reached and the dispatcher enforces
+ * per-route {@code @Permission} for both — the same end-state as the Spigot adapter.
+ *
+ * <p>{@link TabExecutor} is implemented because BungeeCord's base {@link Command} has no tab-complete
+ * method; the dispatcher invokes {@link #onTabComplete} via {@code instanceof TabExecutor}.
+ */
+public class BungeeBootCommand extends Command implements TabExecutor {
+    private final Context context;
+    private final CompiledRootCommand rootCommand;
+    private final CommandDispatcher dispatcher;
+    private final CommandPlatformSupport commandPlatformSupport;
+
+    public BungeeBootCommand(Context context,
+                             CompiledRootCommand rootCommand,
+                             CommandDispatcher dispatcher,
+                             CommandPlatformSupport commandPlatformSupport) {
+        super(rootCommand.getAliases().getPrimary(), null,
+                rootCommand.getAliases().getAliases().toArray(new String[0]));
+        this.context = context;
+        this.rootCommand = rootCommand;
+        this.dispatcher = dispatcher;
+        this.commandPlatformSupport = commandPlatformSupport;
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        // BungeeCord's execute() is void and provides no label; the primary name is used as the label.
+        dispatcher.dispatch(context, rootCommand, commandPlatformSupport.createSender(sender), getName(), args);
+    }
+
+    @Override
+    public Iterable<String> onTabComplete(CommandSender sender, String[] args) {
+        List<String> completions = dispatcher.complete(context, rootCommand,
+                commandPlatformSupport.createSender(sender), getName(), args);
+        return completions == null ? Collections.emptyList() : completions;
+    }
+
+    public CompiledRootCommand getRootCommand() {
+        return rootCommand;
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeBootCommandTest`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandTest.java
+git commit -m "feat(bungee): add BungeeBootCommand TabExecutor bridge"
+```
+
+---
+
+## Task 5: `RegisteredCommandSet` + `BungeeCommandRegistrar`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/RegisteredCommandSet.java`
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrar.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandAliasSet;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandRegistrarTest {
+
+    private CompiledRootCommand rootNamed(String primary) {
+        CommandAliasSet aliases = mock(CommandAliasSet.class);
+        when(aliases.getPrimary()).thenReturn(primary);
+        when(aliases.getAliases()).thenReturn(Collections.emptyList());
+        CompiledRootCommand root = mock(CompiledRootCommand.class);
+        when(root.getAliases()).thenReturn(aliases);
+        return root;
+    }
+
+    @Test
+    void registersEachRootAndUnregistersThem() {
+        Plugin plugin = mock(Plugin.class);
+        ProxyServer proxy = mock(ProxyServer.class);
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(plugin.getProxy()).thenReturn(proxy);
+        when(proxy.getPluginManager()).thenReturn(pluginManager);
+
+        Context context = mock(Context.class);
+        when(context.getBean(Plugin.class)).thenReturn(plugin);
+
+        BungeeCommandRegistrar registrar = new BungeeCommandRegistrar(
+                mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
+
+        RegisteredCommandSet set = registrar.register(context, Collections.singletonList(rootNamed("server")));
+
+        assertEquals(1, set.getCommands().size());
+        ArgumentCaptor<Command> captor = ArgumentCaptor.forClass(Command.class);
+        verify(pluginManager).registerCommand(eq(plugin), captor.capture());
+        assertEquals("server", captor.getValue().getName());
+
+        registrar.unregister(context, set);
+        verify(pluginManager).unregisterCommand(set.getCommands().get(0));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandRegistrarTest`
+Expected: COMPILE FAILURE — `BungeeCommandRegistrar`/`RegisteredCommandSet` do not exist yet.
+
+- [ ] **Step 3: Write `RegisteredCommandSet`** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable snapshot of the {@link BungeeBootCommand}s registered for a context, carried by the
+ * shutdown hook so exactly those commands are unregistered. Mirrors the Spigot
+ * {@code RegisteredCommandSet}.
+ */
+public final class RegisteredCommandSet {
+    private final List<BungeeBootCommand> commands;
+
+    public RegisteredCommandSet(List<BungeeBootCommand> commands) {
+        this.commands = Collections.unmodifiableList(commands);
+    }
+
+    public List<BungeeBootCommand> getCommands() {
+        return commands;
+    }
+}
+```
+
+- [ ] **Step 4: Write `BungeeCommandRegistrar`** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginManager;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Registers compiled commands with BungeeCord through its public {@link PluginManager} API. Unlike
+ * the Spigot registrar there is no CommandMap reflection: {@code registerCommand}/{@code
+ * unregisterCommand} are public. BungeeCord's command map is private and last-wins, so no collision
+ * detection is performed (see the design spec).
+ */
+public class BungeeCommandRegistrar {
+    private final CommandDispatcher dispatcher;
+    private final CommandPlatformSupport commandPlatformSupport;
+
+    public BungeeCommandRegistrar(CommandDispatcher dispatcher,
+                                  CommandPlatformSupport commandPlatformSupport) {
+        this.dispatcher = dispatcher;
+        this.commandPlatformSupport = commandPlatformSupport;
+    }
+
+    public RegisteredCommandSet register(Context context, List<CompiledRootCommand> roots) {
+        Plugin plugin = context.getBean(Plugin.class);
+        PluginManager pluginManager = plugin.getProxy().getPluginManager();
+
+        List<BungeeBootCommand> commands = new ArrayList<>();
+        for (CompiledRootCommand root : roots) {
+            BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, commandPlatformSupport);
+            pluginManager.registerCommand(plugin, command);
+            commands.add(command);
+        }
+        return new RegisteredCommandSet(commands);
+    }
+
+    public void unregister(Context context, RegisteredCommandSet registeredCommandSet) {
+        Plugin plugin = context.getBean(Plugin.class);
+        PluginManager pluginManager = plugin.getProxy().getPluginManager();
+        for (BungeeBootCommand command : registeredCommandSet.getCommands()) {
+            pluginManager.unregisterCommand(command);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandRegistrarTest`
+Expected: PASS (1 test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/RegisteredCommandSet.java platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrar.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java
+git commit -m "feat(bungee): add BungeeCommandRegistrar and RegisteredCommandSet"
+```
+
+---
+
+## Task 6: `BungeeCommandsContextReadyRegistrar`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrar.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrarTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandRootCompiler;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.plugin.BootPlugin;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandsContextReadyRegistrarTest {
+
+    @Test
+    void compilesRegistersAndUnregistersOnShutdown() {
+        CommandRootCompiler compiler = mock(CommandRootCompiler.class);
+        BungeeCommandRegistrar registrar = mock(BungeeCommandRegistrar.class);
+        CommandReplacementRegistry replacementRegistry = mock(CommandReplacementRegistry.class);
+
+        Context context = mock(Context.class);
+        BootPlugin bootPlugin = mock(BootPlugin.class);
+        when(bootPlugin.getName()).thenReturn("TestPlugin");
+        when(context.getPlugin()).thenReturn(bootPlugin);
+
+        CompiledRootCommand root = mock(CompiledRootCommand.class);
+        List<CompiledRootCommand> roots = Collections.singletonList(root);
+        when(compiler.compile(context)).thenReturn(roots);
+        RegisteredCommandSet set = new RegisteredCommandSet(Collections.emptyList());
+        when(registrar.register(context, roots)).thenReturn(set);
+
+        new BungeeCommandsContextReadyRegistrar(compiler, registrar, replacementRegistry).onContextReady(context);
+
+        verify(replacementRegistry).register("plugin.name", "TestPlugin");
+        verify(replacementRegistry).register("plugin", "TestPlugin");
+        verify(registrar).register(context, roots);
+
+        ArgumentCaptor<Runnable> hook = ArgumentCaptor.forClass(Runnable.class);
+        verify(context).registerShutdownHook(hook.capture());
+        hook.getValue().run();
+        verify(registrar).unregister(context, set);
+    }
+
+    @Test
+    void registersNothingWhenNoCommands() {
+        CommandRootCompiler compiler = mock(CommandRootCompiler.class);
+        BungeeCommandRegistrar registrar = mock(BungeeCommandRegistrar.class);
+        CommandReplacementRegistry replacementRegistry = mock(CommandReplacementRegistry.class);
+
+        Context context = mock(Context.class);
+        BootPlugin bootPlugin = mock(BootPlugin.class);
+        when(bootPlugin.getName()).thenReturn("TestPlugin");
+        when(context.getPlugin()).thenReturn(bootPlugin);
+        when(compiler.compile(context)).thenReturn(Collections.emptyList());
+
+        new BungeeCommandsContextReadyRegistrar(compiler, registrar, replacementRegistry).onContextReady(context);
+
+        verify(registrar, never()).register(any(), any());
+        verify(context, never()).registerShutdownHook(any());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandsContextReadyRegistrarTest`
+Expected: COMPILE FAILURE — `BungeeCommandsContextReadyRegistrar` does not exist yet.
+
+- [ ] **Step 3: Write the implementation** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandRootCompiler;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.listeners.ContextReadyListener;
+
+import java.util.List;
+
+/**
+ * Compiles every command handler bean and registers the results with BungeeCord when the context is
+ * ready, unregistering them on shutdown. Mirrors the Spigot {@code CommandsContextReadyRegistrar}.
+ */
+public class BungeeCommandsContextReadyRegistrar implements ContextReadyListener, Ordered {
+    private final CommandRootCompiler commandRootCompiler;
+    private final BungeeCommandRegistrar bungeeCommandRegistrar;
+    private final CommandReplacementRegistry replacementRegistry;
+
+    public BungeeCommandsContextReadyRegistrar(CommandRootCompiler commandRootCompiler,
+                                               BungeeCommandRegistrar bungeeCommandRegistrar,
+                                               CommandReplacementRegistry replacementRegistry) {
+        this.commandRootCompiler = commandRootCompiler;
+        this.bungeeCommandRegistrar = bungeeCommandRegistrar;
+        this.replacementRegistry = replacementRegistry;
+    }
+
+    @Override
+    public int getOrder() {
+        return 1000;
+    }
+
+    @Override
+    public void onContextReady(Context context) {
+        replacementRegistry.register("plugin.name", context.getPlugin().getName());
+        replacementRegistry.register("plugin", context.getPlugin().getName());
+
+        List<CompiledRootCommand> roots = commandRootCompiler.compile(context);
+        if (roots.isEmpty()) {
+            return;
+        }
+
+        final RegisteredCommandSet registered = bungeeCommandRegistrar.register(context, roots);
+        context.registerShutdownHook(() -> bungeeCommandRegistrar.unregister(context, registered));
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandsContextReadyRegistrarTest`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrar.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrarTest.java
+git commit -m "feat(bungee): register commands on context ready"
+```
+
+---
+
+## Task 7: `BungeeProxiedPlayerArgumentResolver`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolver.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolverTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeProxiedPlayerArgumentResolverTest {
+    private final Plugin plugin = mock(Plugin.class);
+    private final ProxyServer proxy = mock(ProxyServer.class);
+    private final BungeeProxiedPlayerArgumentResolver resolver = new BungeeProxiedPlayerArgumentResolver(plugin);
+    private final CommandExecutionContext context = mock(CommandExecutionContext.class);
+    private final CommandParameterMetadata parameter = new CommandParameterMetadata(
+            null, 0, "target", "target", ProxiedPlayer.class, ProxiedPlayer.class, false, false, false, null, null);
+
+    @BeforeEach
+    void setUp() {
+        when(plugin.getProxy()).thenReturn(proxy);
+    }
+
+    @Test
+    void supportsOnlyProxiedPlayer() {
+        assertTrue(resolver.supports(parameter));
+        CommandParameterMetadata stringParam = new CommandParameterMetadata(
+                null, 0, "s", "s", String.class, String.class, false, false, false, null, null);
+        assertFalse(resolver.supports(stringParam));
+    }
+
+    @Test
+    void resolveReturnsOnlinePlayer() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(proxy.getPlayer("Alex")).thenReturn(player);
+        assertSame(player, resolver.resolve(context, parameter, "Alex"));
+    }
+
+    @Test
+    void resolveRejectsUnknownPlayer() {
+        when(proxy.getPlayer("Ghost")).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(context, parameter, "Ghost"));
+    }
+
+    @Test
+    void defaultCompletionProviderListsOnlinePlayers() {
+        ProxiedPlayer a = mock(ProxiedPlayer.class);
+        ProxiedPlayer b = mock(ProxiedPlayer.class);
+        when(a.getName()).thenReturn("Alex");
+        when(b.getName()).thenReturn("Bob");
+        when(proxy.getPlayers()).thenReturn(Arrays.asList(a, b));
+
+        List<String> names = resolver.defaultCompletionProvider().complete(context, parameter, "");
+        assertEquals(Arrays.asList("Alex", "Bob"), names);
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeProxiedPlayerArgumentResolverTest`
+Expected: COMPILE FAILURE — `BungeeProxiedPlayerArgumentResolver` does not exist yet.
+
+- [ ] **Step 3: Write the implementation** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionProvider;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolves a {@code ProxiedPlayer} command argument by online name, with online-player tab
+ * completion. The Bungee analogue of {@code BukkitPlayerArgumentResolver}; reaches the proxy via the
+ * injected {@link Plugin}. Prefix filtering of completions is applied downstream by the framework's
+ * {@code CompletionResolver}.
+ */
+public class BungeeProxiedPlayerArgumentResolver implements CommandArgumentResolver<ProxiedPlayer>, Ordered {
+    private final Plugin plugin;
+
+    public BungeeProxiedPlayerArgumentResolver(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public int getOrder() {
+        return 1000;
+    }
+
+    @Override
+    public boolean supports(CommandParameterMetadata parameter) {
+        return ProxiedPlayer.class.equals(parameter.getValueType());
+    }
+
+    @Override
+    public ProxiedPlayer resolve(CommandExecutionContext context, CommandParameterMetadata parameter, String input) {
+        ProxiedPlayer player = plugin.getProxy().getPlayer(input);
+        if (player == null) {
+            throw new IllegalArgumentException("Player not found: " + input);
+        }
+        return player;
+    }
+
+    @Override
+    public CommandCompletionProvider defaultCompletionProvider() {
+        return (context, parameter, input) -> {
+            List<String> values = new ArrayList<>();
+            for (ProxiedPlayer player : plugin.getProxy().getPlayers()) {
+                values.add(player.getName());
+            }
+            return values;
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeProxiedPlayerArgumentResolverTest`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolver.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolverTest.java
+git commit -m "feat(bungee): add ProxiedPlayer argument resolver"
+```
+
+---
+
+## Task 8: `BungeeServerArgumentResolver`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolver.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolverTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeServerArgumentResolverTest {
+    private final Plugin plugin = mock(Plugin.class);
+    private final ProxyServer proxy = mock(ProxyServer.class);
+    private final BungeeServerArgumentResolver resolver = new BungeeServerArgumentResolver(plugin);
+    private final CommandExecutionContext context = mock(CommandExecutionContext.class);
+    private final CommandParameterMetadata parameter = new CommandParameterMetadata(
+            null, 0, "server", "server", ServerInfo.class, ServerInfo.class, false, false, false, null, null);
+
+    @BeforeEach
+    void setUp() {
+        when(plugin.getProxy()).thenReturn(proxy);
+    }
+
+    @Test
+    void supportsOnlyServerInfo() {
+        assertTrue(resolver.supports(parameter));
+    }
+
+    @Test
+    void resolveReturnsServer() {
+        ServerInfo lobby = mock(ServerInfo.class);
+        when(proxy.getServerInfo("lobby")).thenReturn(lobby);
+        assertSame(lobby, resolver.resolve(context, parameter, "lobby"));
+    }
+
+    @Test
+    void resolveRejectsUnknownServer() {
+        when(proxy.getServerInfo("void")).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(context, parameter, "void"));
+    }
+
+    @Test
+    void defaultCompletionProviderListsServers() {
+        Map<String, ServerInfo> servers = new LinkedHashMap<>();
+        servers.put("lobby", mock(ServerInfo.class));
+        servers.put("survival", mock(ServerInfo.class));
+        when(proxy.getServers()).thenReturn(servers);
+
+        List<String> names = resolver.defaultCompletionProvider().complete(context, parameter, "");
+        assertTrue(names.contains("lobby"));
+        assertTrue(names.contains("survival"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeServerArgumentResolverTest`
+Expected: COMPILE FAILURE — `BungeeServerArgumentResolver` does not exist yet.
+
+- [ ] **Step 3: Write the implementation** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionProvider;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+
+import java.util.ArrayList;
+
+/**
+ * Resolves a {@code ServerInfo} command argument by configured server name, with server-name tab
+ * completion. A proxy-specific resolver with no Bukkit analogue; reaches the proxy via the injected
+ * {@link Plugin}. Prefix filtering of completions is applied downstream by {@code CompletionResolver}.
+ */
+public class BungeeServerArgumentResolver implements CommandArgumentResolver<ServerInfo>, Ordered {
+    private final Plugin plugin;
+
+    public BungeeServerArgumentResolver(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public int getOrder() {
+        return 1000;
+    }
+
+    @Override
+    public boolean supports(CommandParameterMetadata parameter) {
+        return ServerInfo.class.equals(parameter.getValueType());
+    }
+
+    @Override
+    public ServerInfo resolve(CommandExecutionContext context, CommandParameterMetadata parameter, String input) {
+        ServerInfo server = plugin.getProxy().getServerInfo(input);
+        if (server == null) {
+            throw new IllegalArgumentException("Server not found: " + input);
+        }
+        return server;
+    }
+
+    @Override
+    public CommandCompletionProvider defaultCompletionProvider() {
+        return (context, parameter, input) -> new ArrayList<>(plugin.getProxy().getServers().keySet());
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeServerArgumentResolverTest`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolver.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolverTest.java
+git commit -m "feat(bungee): add ServerInfo argument resolver"
+```
+
+---
+
+## Task 9: `BungeeCommandCompletionRegistryCustomizer`
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizer.java`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizerTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee.completion;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionProvider;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandCompletionRegistryCustomizerTest {
+
+    @Test
+    void registersOnlinePlayersAndServersWithPrefixFiltering() {
+        Plugin plugin = mock(Plugin.class);
+        ProxyServer proxy = mock(ProxyServer.class);
+        when(plugin.getProxy()).thenReturn(proxy);
+
+        ProxiedPlayer alex = mock(ProxiedPlayer.class);
+        ProxiedPlayer bob = mock(ProxiedPlayer.class);
+        when(alex.getName()).thenReturn("Alex");
+        when(bob.getName()).thenReturn("Bob");
+        when(proxy.getPlayers()).thenReturn(Arrays.asList(alex, bob));
+
+        Map<String, ServerInfo> servers = new LinkedHashMap<>();
+        servers.put("lobby", mock(ServerInfo.class));
+        servers.put("survival", mock(ServerInfo.class));
+        when(proxy.getServers()).thenReturn(servers);
+
+        Map<String, CommandCompletionProvider> registered = new HashMap<>();
+        CommandCompletionRegistry registry = new CommandCompletionRegistry() {
+            @Override
+            public void register(String id, CommandCompletionProvider provider) {
+                registered.put(id, provider);
+            }
+
+            @Override
+            public Optional<CommandCompletionProvider> resolve(String id) {
+                return Optional.ofNullable(registered.get(id));
+            }
+        };
+
+        new BungeeCommandCompletionRegistryCustomizer(plugin).customize(registry);
+
+        assertTrue(registered.containsKey("onlinePlayers"));
+        assertTrue(registered.containsKey("servers"));
+
+        CommandExecutionContext ctx = mock(CommandExecutionContext.class);
+        assertEquals(Collections.singletonList("Alex"),
+                registered.get("onlinePlayers").complete(ctx, null, "a"));
+        assertEquals(Collections.singletonList("lobby"),
+                registered.get("servers").complete(ctx, null, "l"));
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandCompletionRegistryCustomizerTest`
+Expected: COMPILE FAILURE — `BungeeCommandCompletionRegistryCustomizer` does not exist yet.
+
+- [ ] **Step 3: Write the implementation** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee.completion;
+
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistryCustomizer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Registers the proxy-specific named completions {@code onlinePlayers} and {@code servers}, referenced
+ * from handlers via {@code @Completion("onlinePlayers")} / {@code @Completion("servers")}. Mirrors the
+ * Spigot {@code BukkitCommandCompletionRegistryCustomizer} ({@code worlds}/{@code materials} have no
+ * proxy analogue). Reaches the proxy via the injected {@link Plugin}.
+ */
+public class BungeeCommandCompletionRegistryCustomizer implements CommandCompletionRegistryCustomizer {
+    private final Plugin plugin;
+
+    public BungeeCommandCompletionRegistryCustomizer(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void customize(CommandCompletionRegistry registry) {
+        registry.register("onlinePlayers", (context, parameter, input) -> {
+            List<String> values = new ArrayList<>();
+            String lowerInput = input != null ? input.toLowerCase(Locale.ROOT) : "";
+            for (ProxiedPlayer player : plugin.getProxy().getPlayers()) {
+                if (!lowerInput.isEmpty() && !player.getName().toLowerCase(Locale.ROOT).startsWith(lowerInput)) {
+                    continue;
+                }
+                values.add(player.getName());
+            }
+            return values;
+        });
+        registry.register("servers", (context, parameter, input) -> {
+            List<String> values = new ArrayList<>();
+            String lowerInput = input != null ? input.toLowerCase(Locale.ROOT) : "";
+            for (String serverName : plugin.getProxy().getServers().keySet()) {
+                if (!lowerInput.isEmpty() && !serverName.toLowerCase(Locale.ROOT).startsWith(lowerInput)) {
+                    continue;
+                }
+                values.add(serverName);
+            }
+            return values;
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandCompletionRegistryCustomizerTest`
+Expected: PASS (1 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizer.java platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizerTest.java
+git commit -m "feat(bungee): add onlinePlayers and servers completions"
+```
+
+---
+
+## Task 10: `BungeeCommandsModule` + discovery marker
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModule.java`
+- Create: `platform-bungee/commands-bungee/src/main/resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandsModule`
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModuleDiscoveryTest.java`
+
+- [ ] **Step 1: Write the failing test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+import tech.guilhermekaua.spigotboot.core.module.ModuleDiscovery;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeeCommandsModuleDiscoveryTest {
+
+    // proves the META-INF/spigot-boot/modules marker resource is present and names the module correctly,
+    // so the framework auto-discovers it exactly as it does BungeeCoreModule.
+    @Test
+    void bungeeCommandsModuleIsAutoDiscoverable() {
+        List<Class<? extends Module>> modules =
+                new ModuleDiscovery(getClass().getClassLoader()).discover();
+
+        assertTrue(modules.contains(BungeeCommandsModule.class),
+                "BungeeCommandsModule must be discoverable via its META-INF/spigot-boot/modules marker");
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandsModuleDiscoveryTest`
+Expected: COMPILE FAILURE — `BungeeCommandsModule` does not exist yet.
+
+- [ ] **Step 3: Write the `BungeeCommandsModule`** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+
+/**
+ * Marks the Bungee commands module for discovery. The bean wiring lives in
+ * {@code BungeeCommandsConfiguration}; this module only logs initialisation, mirroring the Spigot
+ * {@code SpigotCommandsModule}.
+ */
+public class BungeeCommandsModule implements Module {
+    @Override
+    public void onInitialize(Context context) {
+        context.getPlugin().getLogger().fine("Initializing Bungee commands module.");
+    }
+}
+```
+
+- [ ] **Step 4: Create the module marker resource**
+
+File: `platform-bungee/commands-bungee/src/main/resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandsModule`
+
+Content: an empty file (zero bytes). The file *name* is the module FQCN; `ModuleDiscovery` reads the name, not the contents.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeCommandsModuleDiscoveryTest`
+Expected: PASS (1 test). If it fails, confirm the marker file landed in `target/classes/META-INF/spigot-boot/modules/` with the exact FQCN as its name (no extension, no trailing newline in the name).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModule.java "platform-bungee/commands-bungee/src/main/resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandsModule" platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModuleDiscoveryTest.java
+git commit -m "feat(bungee): add discoverable BungeeCommandsModule"
+```
+
+---
+
+## Task 11: `BungeeCommandsConfiguration` (`@Configuration` wiring)
+
+**Files:**
+- Create: `platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/configuration/BungeeCommandsConfiguration.java`
+
+This wires the 8 beans that depend on `CommandPlatformSupport` (mirroring `SpigotCommandsConfiguration`, minus the CommandMap accessor) plus the Bungee glue. There is no isolated unit test — it is validated by the reactor build here and the end-to-end test in Task 12.
+
+- [ ] **Step 1: Write the configuration** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee.configuration;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolverRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandRootCompiler;
+import tech.guilhermekaua.spigotboot.commands.CommandTextResolverChain;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterBinder;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterRoleResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandRegistrar;
+import tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandsContextReadyRegistrar;
+import tech.guilhermekaua.spigotboot.commands.bungee.completion.BungeeCommandCompletionRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeProxiedPlayerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeServerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.cooldown.CommandCooldownInterceptor;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationExecutor;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationFactory;
+import tech.guilhermekaua.spigotboot.commands.interceptor.CommandInterceptorChain;
+import tech.guilhermekaua.spigotboot.commands.message.CommandMessagesProvider;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandHandlerIntrospector;
+import tech.guilhermekaua.spigotboot.commands.parse.CommandPatternParser;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteFactory;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteValidator;
+import tech.guilhermekaua.spigotboot.commands.completion.CompletionResolver;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Bean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Configuration;
+import tech.guilhermekaua.spigotboot.core.cooldown.CooldownManager;
+
+/**
+ * Wires the BungeeCord command pipeline. The 13 platform-neutral beans come from the generic
+ * {@code CommandsConfiguration}; this configuration declares only the beans that depend on the
+ * platform {@link CommandPlatformSupport}, plus the Bungee registrar, context-ready registrar,
+ * argument resolvers, and completion customizer. Mirrors {@code SpigotCommandsConfiguration} (without
+ * the CommandMap accessor, which BungeeCord does not need).
+ */
+@Configuration
+public class BungeeCommandsConfiguration {
+
+    @Bean
+    public CommandPlatformSupport commandPlatformSupport() {
+        return new BungeeCommandPlatformSupport();
+    }
+
+    @Bean
+    public CommandParameterRoleResolver commandParameterRoleResolver(CommandPlatformSupport commandPlatformSupport) {
+        return new CommandParameterRoleResolver(commandPlatformSupport);
+    }
+
+    @Bean
+    public CommandInvocationFactory commandInvocationFactory(CommandParameterRoleResolver commandParameterRoleResolver) {
+        return new CommandInvocationFactory(commandParameterRoleResolver);
+    }
+
+    @Bean
+    public CommandRouteFactory commandRouteFactory(CommandPatternParser commandPatternParser,
+                                                   CommandReplacementRegistry commandReplacementRegistry,
+                                                   CommandTextResolverChain commandTextResolverChain,
+                                                   CommandInvocationFactory commandInvocationFactory) {
+        return new CommandRouteFactory(
+                commandPatternParser,
+                commandReplacementRegistry,
+                commandTextResolverChain,
+                commandInvocationFactory
+        );
+    }
+
+    @Bean
+    public CommandRootCompiler commandRootCompiler(CommandHandlerIntrospector commandHandlerIntrospector,
+                                                   CommandRouteFactory commandRouteFactory,
+                                                   CommandRouteValidator commandRouteValidator,
+                                                   CommandInterceptorChain commandInterceptorChain) {
+        return new CommandRootCompiler(
+                commandHandlerIntrospector,
+                commandRouteFactory,
+                commandRouteValidator,
+                commandInterceptorChain
+        );
+    }
+
+    @Bean
+    public CommandParameterBinder commandParameterBinder(CommandArgumentResolverRegistry commandArgumentResolverRegistry) {
+        return new CommandParameterBinder(commandArgumentResolverRegistry);
+    }
+
+    @Bean
+    public CommandDispatcher commandDispatcher(CommandParameterBinder commandParameterBinder,
+                                               CommandInvocationExecutor commandInvocationExecutor,
+                                               CommandMessagesProvider commandMessagesProvider,
+                                               CompletionResolver completionResolver,
+                                               CommandInterceptorChain commandInterceptorChain) {
+        return new CommandDispatcher(
+                commandParameterBinder,
+                commandInvocationExecutor,
+                commandMessagesProvider,
+                completionResolver,
+                commandInterceptorChain
+        );
+    }
+
+    @Bean
+    public CommandCooldownInterceptor commandCooldownInterceptor(CooldownManager cooldownManager,
+                                                                 CommandMessagesProvider commandMessagesProvider) {
+        return new CommandCooldownInterceptor(cooldownManager, commandMessagesProvider);
+    }
+
+    @Bean
+    public BungeeCommandRegistrar bungeeCommandRegistrar(CommandDispatcher commandDispatcher,
+                                                         CommandPlatformSupport commandPlatformSupport) {
+        return new BungeeCommandRegistrar(commandDispatcher, commandPlatformSupport);
+    }
+
+    @Bean
+    public BungeeCommandsContextReadyRegistrar bungeeCommandsContextReadyRegistrar(CommandRootCompiler commandRootCompiler,
+                                                                                   BungeeCommandRegistrar bungeeCommandRegistrar,
+                                                                                   CommandReplacementRegistry commandReplacementRegistry) {
+        return new BungeeCommandsContextReadyRegistrar(
+                commandRootCompiler,
+                bungeeCommandRegistrar,
+                commandReplacementRegistry
+        );
+    }
+
+    @Bean
+    public CommandCompletionRegistryCustomizer bungeeCommandCompletionRegistryCustomizer(Plugin plugin) {
+        return new BungeeCommandCompletionRegistryCustomizer(plugin);
+    }
+
+    @Bean
+    public CommandArgumentResolver<?> bungeeProxiedPlayerArgumentResolver(Plugin plugin) {
+        return new BungeeProxiedPlayerArgumentResolver(plugin);
+    }
+
+    @Bean
+    public CommandArgumentResolver<?> bungeeServerArgumentResolver(Plugin plugin) {
+        return new BungeeServerArgumentResolver(plugin);
+    }
+}
+```
+
+- [ ] **Step 2: Compile to verify the wiring is type-correct**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true compile`
+Expected: `BUILD SUCCESS`. This proves every `@Bean` method's parameters and return types resolve against the generic command classes and the Bungee adapters. (Full DI graph resolution is exercised by Task 12.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/configuration/BungeeCommandsConfiguration.java
+git commit -m "feat(bungee): wire BungeeCommandsConfiguration"
+```
+
+---
+
+## Task 12: End-to-end test + full-module & reactor verification
+
+**Files:**
+- Test: `platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java`
+
+This is the strongest single proof: a real `@RootCommand` handler is compiled through the real `CommandRootCompiler` pipeline and executed through a fully-wired `CommandDispatcher` (using the Bungee platform support, resolvers, and completion customizer), asserting sender binding, `ProxiedPlayer`/`ServerInfo` argument resolution, and tab completion. Mirrors `SpigotBootCommandTest` with pure Mockito (no MockBungee).
+
+- [ ] **Step 1: Write the test** (begin with the standard MIT header from Task 2)
+
+```java
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginDescription;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.annotations.Command;
+import tech.guilhermekaua.spigotboot.commands.annotations.CommandHandler;
+import tech.guilhermekaua.spigotboot.commands.annotations.RootCommand;
+import tech.guilhermekaua.spigotboot.commands.annotations.Sender;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterBinder;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterRoleResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.completion.BungeeCommandCompletionRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeProxiedPlayerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeServerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.completion.CompletionResolver;
+import tech.guilhermekaua.spigotboot.commands.completion.DefaultCommandCompletionRegistry;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationExecutor;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationFactory;
+import tech.guilhermekaua.spigotboot.commands.interceptor.CommandInterceptorChain;
+import tech.guilhermekaua.spigotboot.commands.message.CommandMessagesProvider;
+import tech.guilhermekaua.spigotboot.commands.message.DefaultCommandMessages;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandHandlerIntrospector;
+import tech.guilhermekaua.spigotboot.commands.metadata.RootCommandMetadata;
+import tech.guilhermekaua.spigotboot.commands.parse.CommandPatternParser;
+import tech.guilhermekaua.spigotboot.commands.replace.DefaultCommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.resolve.DefaultCommandArgumentResolverRegistry;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteFactory;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteValidator;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.bungee.BungeeBootPlugin;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeBootCommandEndToEndTest {
+    private final BungeeCommandPlatformSupport platformSupport = new BungeeCommandPlatformSupport();
+
+    private Plugin mockPlugin(ProxyServer proxy) {
+        Plugin plugin = mock(Plugin.class);
+        PluginDescription description = mock(PluginDescription.class);
+        when(description.getName()).thenReturn("TestPlugin");
+        when(plugin.getDescription()).thenReturn(description);
+        when(plugin.getProxy()).thenReturn(proxy);
+        return plugin;
+    }
+
+    private Context newContext(Plugin plugin) {
+        Context context = mock(Context.class);
+        when(context.getPlugin()).thenReturn(new BungeeBootPlugin(plugin));
+        when(context.getDependencyManager()).thenReturn(new DependencyManager());
+        return context;
+    }
+
+    private CompiledRootCommand compileRoot(Object handler) {
+        CommandReplacementRegistry replacementRegistry = new DefaultCommandReplacementRegistry(Collections.emptyList());
+        CommandRouteFactory factory = new CommandRouteFactory(
+                new CommandPatternParser(),
+                replacementRegistry,
+                new CommandInvocationFactory(new CommandParameterRoleResolver(platformSupport))
+        );
+        RootCommandMetadata metadata = new CommandHandlerIntrospector().introspect(handler);
+        CompiledRootCommand root = factory.create(metadata);
+        new CommandRouteValidator().validate(Collections.singletonList(root));
+        return root;
+    }
+
+    private CommandDispatcher newDispatcher(Plugin plugin) {
+        DefaultCommandArgumentResolverRegistry resolverRegistry = new DefaultCommandArgumentResolverRegistry(
+                Arrays.asList(new BungeeProxiedPlayerArgumentResolver(plugin), new BungeeServerArgumentResolver(plugin)),
+                Collections.emptyList()
+        );
+        DefaultCommandCompletionRegistry completionRegistry = new DefaultCommandCompletionRegistry(
+                Collections.singletonList(new BungeeCommandCompletionRegistryCustomizer(plugin))
+        );
+        return new CommandDispatcher(
+                new CommandParameterBinder(resolverRegistry),
+                new CommandInvocationExecutor(new CommandInterceptorChain()),
+                new CommandMessagesProvider(new DefaultCommandMessages()),
+                new CompletionResolver(completionRegistry, resolverRegistry)
+        );
+    }
+
+    @Test
+    void executesWithSenderBindingAndProxiedPlayerAndServerResolution() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        ProxiedPlayer target = mock(ProxiedPlayer.class);
+        ServerInfo lobby = mock(ServerInfo.class);
+        when(sender.getName()).thenReturn("Sender");
+        when(target.getName()).thenReturn("Target");
+        when(lobby.getName()).thenReturn("lobby");
+        when(proxy.getPlayer("Target")).thenReturn(target);
+        when(proxy.getServerInfo("lobby")).thenReturn(lobby);
+
+        ServerCommands handler = new ServerCommands();
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(handler), newDispatcher(plugin), platformSupport);
+
+        command.execute(sender, new String[]{"send", "Target", "lobby"});
+
+        assertSame(sender, handler.lastSender);
+        assertSame(target, handler.lastTarget);
+        assertSame(lobby, handler.lastServer);
+    }
+
+    @Test
+    void tabCompleteSurfacesPlayerNames() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        ProxiedPlayer target = mock(ProxiedPlayer.class);
+        when(sender.getName()).thenReturn("Sender");
+        when(target.getName()).thenReturn("Target");
+        when(proxy.getPlayers()).thenReturn(Arrays.asList(sender, target));
+
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(new ServerCommands()), newDispatcher(plugin), platformSupport);
+
+        List<String> values = new ArrayList<>();
+        command.onTabComplete(sender, new String[]{"send", "T"}).forEach(values::add);
+
+        assertEquals(Collections.singletonList("Target"), values);
+    }
+
+    @CommandHandler
+    @RootCommand("server")
+    static class ServerCommands {
+        private ProxiedPlayer lastSender;
+        private ProxiedPlayer lastTarget;
+        private ServerInfo lastServer;
+
+        @Command("send <target> <server>")
+        public void send(@Sender ProxiedPlayer sender, ProxiedPlayer target, ServerInfo server) {
+            this.lastSender = sender;
+            this.lastTarget = target;
+            this.lastServer = server;
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the end-to-end test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false test -Dtest=BungeeBootCommandEndToEndTest`
+Expected: PASS (2 tests). If `tabCompleteSurfacesPlayerNames` returns more than `["Target"]`, confirm the `<target>` parameter is typed `ProxiedPlayer` (so the resolver's online-player completion is used) and that `CompletionResolver` is filtering by the `"T"` prefix.
+
+- [ ] **Step 3: Run the full module test suite**
+
+Run: `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true test`
+Expected: PASS — all `commands-bungee` tests green across the 10 test classes (`BungeeCommandSenderTest` 4, `BungeeCommandPlatformSupportTest` 3, `BungeeBootCommandTest` 3, `BungeeCommandRegistrarTest` 1, `BungeeCommandsContextReadyRegistrarTest` 2, `BungeeProxiedPlayerArgumentResolverTest` 4, `BungeeServerArgumentResolverTest` 4, `BungeeCommandCompletionRegistryCustomizerTest` 1, `BungeeCommandsModuleDiscoveryTest` 1, `BungeeBootCommandEndToEndTest` 2 = 25 tests, 0 failures).
+
+- [ ] **Step 4: Verify the whole reactor still builds**
+
+Run: `mvnw.cmd -Danimal.sniffer.skip=true install -DskipTests`
+Expected: `BUILD SUCCESS` for every module including `spigot-boot-commands-bungee`. Confirms adding the new module did not disturb the existing reactor.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java
+git commit -m "test(bungee): end-to-end command dispatch and completion"
+```
+
+---
+
+## Done criteria
+
+- `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true test` is green (25 tests across 10 test classes).
+- `mvnw.cmd -Danimal.sniffer.skip=true install -DskipTests` builds the full reactor including `spigot-boot-commands-bungee`.
+- A BungeeCord plugin author can declare a `@RootCommand`/`@Command` handler bean and have it registered automatically on context-ready, with `@Permission` enforced, `@Sender CommandSender`/`ProxiedPlayer` binding, `ProxiedPlayer`/`ServerInfo` argument resolution, and `onlinePlayers`/`servers` tab completion — without writing any registration code.
+- `commands-bungee` ships no `maven-shade-plugin`, no javassist relocation, no `animal-sniffer` check, and no MockBukkit.
+
+## Out of scope (later slices, separate plans)
+
+- `commands-config-bungee` (the `CommandTextResolver` → config bridge; needs a future `config-bungee`).
+- Hoisting the 8 platform-support-dependent pipeline beans into the generic `CommandsConfiguration` to remove the Spigot/Bungee duplication (a deliberate follow-up refactor, after this module is merged and green).
+- A `bungee.yml` descriptor generator and any runnable BungeeCord sample/test plugin or on-server end-to-end validation.

--- a/docs/superpowers/specs/2026-06-15-bungeecord-commands-design.md
+++ b/docs/superpowers/specs/2026-06-15-bungeecord-commands-design.md
@@ -1,0 +1,440 @@
+# BungeeCord Support: commands-bungee Design
+
+Date: 2026-06-15
+Status: Approved design, pending spec review
+Target module: `platform-bungee/commands-bungee` (new), artifactId `spigot-boot-commands-bungee`
+
+## Background
+
+Spigot Boot keeps its heavy command logic in a platform-agnostic `commands` module with
+**no Bukkit dependency**: parsing, routing, binding, dispatch, completion, interceptors,
+cooldowns, and the `@Configuration` that wires all the platform-neutral beans. Each
+platform supplies a thin **adapter** that implements a small seam and registers commands
+with the native API. Today only Spigot/Paper exists, at `platform-spigot/commands-spigot`.
+
+This effort adds the BungeeCord adapter, `commands-bungee`. It is the second slice of the
+BungeeCord roadmap, building on the already-merged `core-bungee` v1 runtime foundation
+(`BungeeBootPlugin`, `BungeeCoreModule`, `BungeeListenerAutoRegistrar`, `BungeeBoot`; PR
+#72). `core-bungee` already makes the native `net.md_5.bungee.api.plugin.Plugin` and its
+`TaskScheduler` injectable; `commands-bungee` reuses that wiring.
+
+This spec mirrors `commands-spigot` as closely as the BungeeCord command API allows and
+calls out every place the API forces a divergence. It does **not** touch the generic
+`commands` module.
+
+## Target platform decision
+
+Inherited from the `core-bungee` spec: **BungeeCord now, Velocity-ready.** We build for
+classic BungeeCord (`net.md_5.bungee`, Waterfall is API-compatible). We lay the adapter out
+as a self-contained `platform-bungee/commands-bungee` tree so a future
+`platform-velocity/commands-velocity` can slot in the same way. We do **not** build
+speculative proxy-shared abstractions now (YAGNI); any shared "proxy-command" shape is
+extracted when Velocity actually arrives.
+
+## Goals
+
+- A Bungee plugin using the Spigot Boot container can declare `@RootCommand`/`@Command`
+  handler beans and have them registered with BungeeCord automatically on context-ready,
+  exactly as on Spigot.
+- All generic command behavior (parsing, routing, argument binding, `@Permission`,
+  `@Completion`, interceptors, cooldowns, error messages) works unchanged on Bungee.
+- Tab completion works for command arguments.
+- `@Sender ProxiedPlayer` / `@Sender CommandSender` parameters bind the native sender; a
+  parsed `ProxiedPlayer` or `ServerInfo` argument resolves by name with tab completion.
+- Bungee users never import a class named "Spigot" or "Bukkit" in normal usage.
+
+## Non-goals
+
+- **No `commands-config-bungee`.** The `CommandTextResolver` → config bridge (the analogue
+  of `commands-config-spigot`) is a separate, optional, future module that needs a
+  `config-bungee` to exist first. See "Roadmap". Explicitly out of scope here.
+- **No edit to the generic `commands` module.** In particular, no hoisting of the shared
+  pipeline beans (see "Considered alternative").
+- **No collision-detection / command-overwrite policy** beyond BungeeCord's native
+  last-wins behavior (see Divergence 4).
+- **No runnable Bungee sample plugin or on-server end-to-end validation.** There is no
+  `bungee.yml` descriptor generator yet (a separate roadmap slice); tests are unit tests.
+- No `OfflinePlayer`/`World`/`Material` argument resolvers or completions — these Bukkit
+  concepts do not exist on a proxy.
+
+## Reuse analysis (grounding)
+
+Verified by reading the seams and both modules:
+
+- **Reused unchanged (the complex code):** the entire generic `commands` module, including
+  `commands/configuration/CommandsConfiguration` (`@Configuration`) which already defines
+  **all 13 platform-neutral beans**: `CommandPatternParser`, `CommandHandlerIntrospector`,
+  `CommandReplacementRegistry`, `CommandTextResolverChain`, `CommandArgumentResolverRegistry`,
+  `CommandCompletionRegistry`, `DefaultCommandMessages`, `CommandMessagesProvider`,
+  `FixedCommandCooldownPolicy`, `CommandRouteValidator`, `CompletionResolver`,
+  `CommandInterceptorChain`, `CommandInvocationExecutor`. These arrive free through the
+  `spigot-boot-commands` dependency and are discovered by the annotation-processor index.
+- **Reused from `core-bungee`:** the injectable native `Plugin` bean (registered by
+  `BungeeCoreModule`), reached by the adapters via `context.getBean(Plugin.class)` and (for
+  resolvers/completions) constructor injection.
+- **New, thin adapters (mechanical mirror of `commands-spigot`):** `BungeeCommandPlatformSupport`,
+  `BungeeCommandSender`, `BungeeBootCommand`, `BungeeCommandRegistrar`, `RegisteredCommandSet`,
+  `BungeeCommandsContextReadyRegistrar`, `BungeeCommandsModule`, and the `@Configuration`
+  `BungeeCommandsConfiguration` that re-declares the **8 platform-support-dependent beans**
+  (see below) plus the Bungee glue.
+- **New, genuinely platform-specific:** the `TabExecutor` bridge, the `Plugin`-injected
+  `ProxiedPlayer`/`ServerInfo` resolvers, and the `onlinePlayers`/`servers` completions.
+- **Deleted vs. Spigot (no analogue needed):** `BukkitCommandMapAccessor` — Bungee's
+  registration API is public, so no reflection wrapper exists.
+
+### The platform seam (exact)
+
+A platform adapter implements two interfaces and registers a `CommandPlatformSupport` bean:
+
+```java
+public interface CommandPlatformSupport {
+    CommandSenderHandle createSender(Object nativeSender);
+    boolean isSenderType(Class<?> type);
+}
+
+public interface CommandSenderHandle {
+    String getName();
+    String getIdentity();
+    boolean hasPermission(String permission);
+    void sendMessage(String message);
+    <T> Optional<T> unwrap(Class<T> type);
+}
+```
+
+The native command object bridges to the generic dispatcher, which takes a
+`CommandSenderHandle` and owns all per-route permission enforcement:
+
+```java
+public boolean dispatch(Context context, CompiledRootCommand root, CommandSenderHandle sender, String label, String[] args);
+public List<String> complete(Context context, CompiledRootCommand root, CommandSenderHandle sender, String label, String[] args);
+```
+
+### The bean split (why `BungeeCommandsConfiguration` re-declares 8 beans)
+
+`CommandsConfiguration` (generic) defines every bean that does **not** depend on
+`CommandPlatformSupport`. The 8 beans that **do** depend on it (directly or transitively)
+live in the *platform* `@Configuration`, so `commands-bungee` must re-declare them exactly
+as `commands-spigot` does, swapping the platform support implementation:
+
+1. `commandPlatformSupport()` → `new BungeeCommandPlatformSupport()`
+2. `commandParameterRoleResolver(CommandPlatformSupport)`
+3. `commandInvocationFactory(CommandParameterRoleResolver)`
+4. `commandRouteFactory(CommandPatternParser, CommandReplacementRegistry, CommandTextResolverChain, CommandInvocationFactory)`
+5. `commandRootCompiler(CommandHandlerIntrospector, CommandRouteFactory, CommandRouteValidator, CommandInterceptorChain)`
+6. `commandParameterBinder(CommandArgumentResolverRegistry)`
+7. `commandDispatcher(CommandParameterBinder, CommandInvocationExecutor, CommandMessagesProvider, CompletionResolver, CommandInterceptorChain)`
+8. `commandCooldownInterceptor(CooldownManager, CommandMessagesProvider)`
+
+Plus the Bungee glue beans: `bungeeCommandRegistrar`, `bungeeCommandsContextReadyRegistrar`,
+`bungeeCommandCompletionRegistryCustomizer`, `bungeeProxiedPlayerArgumentResolver`,
+`bungeeServerArgumentResolver`. The `CommandArgumentResolver<?>` beans are auto-collected
+into the generic `CommandArgumentResolverRegistry`; the `CommandCompletionRegistryCustomizer`
+bean is auto-collected into the generic `CommandCompletionRegistry`.
+
+## Key decisions (BungeeCord command API)
+
+Verified against `net.md-5:bungeecord-api:1.21-R0.3` sources.
+
+### Permission — base permission is null; the dispatcher owns `@Permission`
+
+`PluginManager.dispatchCommand` calls `command.hasPermission(sender)` **before** `execute`
+and, on failure, sends the permission message and skips `execute` (still returning handled).
+`Command.hasPermission` returns true when the permission is null/empty. So `BungeeBootCommand`
+passes **null** permission to `super(name, null, aliases)`, guaranteeing Bungee always
+reaches `execute`/`onTabComplete`, and the generic `CommandDispatcher` enforces per-route
+`@Permission` for both dispatch (sends `messages.noPermission`) and completion (skips routes
+the sender lacks). This is the same end-state as Spigot's `SpigotBootCommand.getPermission()`
+returning null, reached by a different mechanism.
+
+### Tab completion — `implements TabExecutor`
+
+BungeeCord's base `Command` has no tab-complete method. Completion requires also implementing
+the separate interface `TabExecutor { Iterable<String> onTabComplete(CommandSender, String[]); }`,
+which `dispatchCommand` invokes via `instanceof TabExecutor` (and only once the command line
+contains a space — the command-name token itself is completed by the proxy, identical in
+effect to Bukkit). `BungeeBootCommand extends Command implements TabExecutor` and delegates
+`onTabComplete` to `dispatcher.complete(...)`, whose `List<String>` return is a valid
+`Iterable<String>`.
+
+### Threading — synchronous, no thread-hop
+
+BungeeCord has no main thread; `execute` runs synchronously on the caller (Netty connection)
+thread. Mirroring Spigot, `commands-bungee` dispatches synchronously with no thread switch.
+Authors needing async work use the `TaskScheduler` already injected by `core-bungee`
+(`@Inject TaskScheduler` → `runAsync`). No threading machinery in this module.
+
+## Architecture
+
+### Module & Maven structure (mirror `commands-spigot`)
+
+```
+platform-bungee/                    packaging: pom (already exists)
+  pom.xml                           add <module>commands-bungee</module>  ← shared edit
+  core-bungee/                      (exists, PR #72)
+  commands-bungee/                  artifactId: spigot-boot-commands-bungee  (new)
+    pom.xml
+    src/main/java/...
+    src/main/resources/META-INF/spigot-boot/modules/<BungeeCommandsModule FQCN>
+    src/test/java/...
+```
+
+`commands-bungee` dependencies:
+
+- `net.md-5:bungeecord-api` (`provided`) — version inherited from `platform-bungee/pom.xml`
+  dependency-management (`1.21-R0.3`).
+- `tech.guilhermekaua.spigot-boot:spigot-boot-commands` (compile) — the generic module.
+- `tech.guilhermekaua.spigot-boot:spigot-boot-core-bungee` (compile) — supplies the
+  injectable native `Plugin` and the `BungeeCoreModule`.
+- `tech.guilhermekaua.spigot-boot:spigot-boot-annotation-processor-spigot`
+  (`provided`/`optional`, and in `annotationProcessorPaths` alongside Lombok) — indexes this
+  module's `@Configuration`/`@Component` and `Module` beans.
+- Tests: JUnit 5 + Mockito inherited from the root pom. **No MockBukkit.**
+
+Compiler: `<source>1.8</source><target>1.8</target>`, `testSource`/`testTarget` 17,
+`-parameters`. **No `maven-shade-plugin`, no `animal-sniffer-maven-plugin`** (this module
+targets the Bungee API, not the Bukkit 1.8.8 API; and it ships no javassist of its own).
+
+### Package
+
+`tech.guilhermekaua.spigotboot.commands.bungee` (mirrors `...commands.spigot`), with a
+`bungee/completion/` and `bungee/resolve/` subpackage as on Spigot, and a
+`bungee/configuration/` subpackage for `BungeeCommandsConfiguration`.
+
+### javassist / shading determination
+
+`commands-bungee` **creates no javassist proxies and references no javassist API** — it does
+not even use `ProxyUtils` (unlike `BungeeListenerAutoRegistrar`, which warns on proxied
+listeners). Command dispatch is framework-driven (the dispatcher invokes handler methods
+through the generic invocation plan), so the proxied-*listener* caveat does not apply, and
+`commands-spigot`'s command registrar likewise ignores proxies. Per the CLAUDE.md
+"Shading & javassist" rules this module falls under *neither* javassist case: it neither
+creates proxies (no relocation execution) nor inspects them (no `ProxyUtils` reference).
+**Conclusion: no `maven-shade-plugin`, no relocation, no javassist dependency at any scope.**
+
+## Components
+
+### `BungeeCommandPlatformSupport implements CommandPlatformSupport`
+
+Mirror of `BukkitCommandPlatformSupport`. `createSender` requires a
+`net.md_5.bungee.api.CommandSender` (throws `IllegalArgumentException` otherwise) and wraps
+it in `BungeeCommandSender`. `isSenderType(type)` = `type != null && CommandSender.class.isAssignableFrom(type)`
+(true for `CommandSender` and `ProxiedPlayer`).
+
+### `BungeeCommandSender implements CommandSenderHandle`
+
+Mirror of `BukkitCommandSender`, wrapping a `CommandSender`:
+
+| method | mapping |
+|---|---|
+| `getName()` | `sender.getName()` |
+| `getIdentity()` | `((ProxiedPlayer) sender).getUniqueId().toString()` if `sender instanceof ProxiedPlayer`, else `sender.getClass().getName() + ":" + getName()` (console identity; there is no console sender *type* in the Bungee API to test against) |
+| `hasPermission(p)` | `sender.hasPermission(p)` |
+| `sendMessage(m)` | `sender.sendMessage(m)` — Bungee's String overload (deprecated but functional; renders legacy color codes). The `CommandSenderHandle` contract is String-based; mapping framework messages to `TextComponent` is a deliberate non-goal |
+| `unwrap(type)` | `type.isInstance(sender) ? Optional.of(type.cast(sender)) : Optional.empty()` |
+
+### `BungeeBootCommand extends net.md_5.bungee.api.plugin.Command implements TabExecutor`
+
+```java
+public BungeeBootCommand(Context context, CompiledRootCommand rootCommand,
+                         CommandDispatcher dispatcher, CommandPlatformSupport platformSupport) {
+    super(rootCommand.getAliases().getPrimary(), null,        // null permission — dispatcher owns @Permission
+          rootCommand.getAliases().getAliases().toArray(new String[0]));
+    ...
+}
+
+@Override public void execute(CommandSender sender, String[] args) {            // Bungee execute() is void
+    dispatcher.dispatch(context, rootCommand, platformSupport.createSender(sender), getName(), args);
+}
+
+@Override public Iterable<String> onTabComplete(CommandSender sender, String[] args) {
+    List<String> completions = dispatcher.complete(context, rootCommand,
+            platformSupport.createSender(sender), getName(), args);
+    return completions == null ? Collections.emptyList() : completions;
+}
+```
+
+Notes: Bungee's `execute` is `void`, so the dispatcher's boolean return is ignored. Bungee
+passes no label/alias, so `getName()` (the primary) is used as the dispatcher `label` (used
+only to build the usage/echo string). `getAliases()` is a `List<String>` and is converted to
+the `String...` the Bungee `Command` constructor wants.
+
+### `BungeeCommandRegistrar`
+
+Constructor `(CommandDispatcher dispatcher, CommandPlatformSupport platformSupport)` — **no
+`BukkitCommandMapAccessor` analogue**. `register(Context, List<CompiledRootCommand>)`:
+
+```java
+Plugin plugin = context.getBean(Plugin.class);
+PluginManager pm = plugin.getProxy().getPluginManager();
+List<BungeeBootCommand> commands = new ArrayList<>();
+for (CompiledRootCommand root : roots) {
+    BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, platformSupport);
+    pm.registerCommand(plugin, command);                      // public API, no reflection
+    commands.add(command);
+}
+return new RegisteredCommandSet(commands);
+```
+
+`unregister(RegisteredCommandSet)` resolves the plugin again and calls
+`pm.unregisterCommand(command)` for each tracked command (surgical — only our commands, not
+`unregisterCommands(plugin)`), mirroring Spigot's `RegisteredCommandSet` tracking.
+
+### `RegisteredCommandSet`
+
+Immutable snapshot `List<BungeeBootCommand>`, mirror of the Spigot value object, carried by
+the shutdown hook for unregistration.
+
+### `BungeeCommandsContextReadyRegistrar implements ContextReadyListener, Ordered`
+
+`getOrder()` returns `1000`. `onContextReady` is the exact mirror of
+`CommandsContextReadyRegistrar`:
+
+```java
+replacementRegistry.register("plugin.name", context.getPlugin().getName());
+replacementRegistry.register("plugin", context.getPlugin().getName());
+List<CompiledRootCommand> roots = commandRootCompiler.compile(context);
+if (roots.isEmpty()) return;
+RegisteredCommandSet registered = bungeeCommandRegistrar.register(context, roots);
+context.registerShutdownHook(() -> bungeeCommandRegistrar.unregister(registered));
+```
+
+### `BungeeProxiedPlayerArgumentResolver implements CommandArgumentResolver<ProxiedPlayer>, Ordered`
+
+Constructor injects `Plugin` (reaches the proxy via `plugin.getProxy()` — cleaner DI than
+Spigot's static `Bukkit.*`, and plain-Mockito-testable). `getOrder()` = `1000`. `supports` =
+`ProxiedPlayer.class.equals(parameter.getValueType())`. `resolve` = `plugin.getProxy().getPlayer(input)`,
+throwing `IllegalArgumentException("Player not found: " + input)` when null.
+`defaultCompletionProvider()` returns online player names matching the input prefix.
+
+### `BungeeServerArgumentResolver implements CommandArgumentResolver<ServerInfo>, Ordered`
+
+Constructor injects `Plugin`. `supports` = `ServerInfo.class.equals(parameter.getValueType())`.
+`resolve` = `plugin.getProxy().getServerInfo(input)`, throwing
+`IllegalArgumentException("Server not found: " + input)` when null. `defaultCompletionProvider()`
+returns configured server names matching the input prefix
+(`plugin.getProxy().getServers().keySet()`).
+
+### `BungeeCommandCompletionRegistryCustomizer implements CommandCompletionRegistryCustomizer`
+
+Constructor injects `Plugin`. Registers two named completions (referenced from handlers via
+`@Completion("onlinePlayers")` / `@Completion("servers")`, keeping command code portable
+across platforms):
+
+- `onlinePlayers` → `plugin.getProxy().getPlayers()` names, prefix-filtered.
+- `servers` → `plugin.getProxy().getServers().keySet()`, prefix-filtered.
+
+(No `worlds`/`materials`/`offlinePlayers` — no proxy analogue.)
+
+### `BungeeCommandsModule implements Module` + marker
+
+Near-no-op (logs `getLogger().fine("Initializing Bungee commands module.")`), mirroring
+`SpigotCommandsModule`. Discovered via the empty marker resource
+`META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandsModule`.
+
+### `BungeeCommandsConfiguration` (`@Configuration`)
+
+Re-declares the 8 platform-support-dependent beans (see "The bean split") with
+`new BungeeCommandPlatformSupport()` as the platform support, plus `bungeeCommandRegistrar`,
+`bungeeCommandsContextReadyRegistrar`, `bungeeCommandCompletionRegistryCustomizer`,
+`bungeeProxiedPlayerArgumentResolver(Plugin)`, `bungeeServerArgumentResolver(Plugin)`. The
+shared collaborators (`CommandPatternParser`, `CommandReplacementRegistry`,
+`CommandTextResolverChain`, `CommandHandlerIntrospector`, `CommandRouteValidator`,
+`CommandInterceptorChain`, `CommandArgumentResolverRegistry`, `CommandInvocationExecutor`,
+`CommandMessagesProvider`, `CompletionResolver`, `CooldownManager`) are injected from the
+generic config / core.
+
+## User-facing usage
+
+```java
+public final class ExampleCommands {
+    @RootCommand(value = "server", aliases = "srv")
+    public static class ServerCommand {
+        @DefaultCommand
+        public void info(@Sender CommandSender sender) {
+            sender.sendMessage("Usage: /server send <player> <server>");
+        }
+
+        @Command("send <target> <server>")
+        @Permission("example.server.send")
+        public void send(@Sender CommandSender sender,
+                         @Completion("onlinePlayers") ProxiedPlayer target,
+                         @Completion("servers") ServerInfo server) {
+            target.connect(server);
+            sender.sendMessage(target.getName() + " -> " + server.getName());
+        }
+    }
+}
+```
+
+A `@Component` (or `@CommandHandler`) bean holding such a `@RootCommand` is compiled and
+registered automatically when the context becomes ready — the author writes no registration
+code. (The plugin still needs a `bungee.yml` descriptor to load until the descriptor
+generator slice exists; the eventual test plugin hand-writes one.)
+
+## Considered alternative (deliberately deferred)
+
+Hoist the 8 platform-support-dependent pipeline beans (role resolver → … → cooldown
+interceptor) into the generic `CommandsConfiguration`, injecting `CommandPlatformSupport` as
+a parameter, so neither platform config duplicates them. This is attractive now that the
+second platform reveals the shared shape, but it **edits the shared `commands` core**, which
+(a) creates merge-conflict surface with the concurrent `config-bungee` work, and (b) risks
+regressing `commands-spigot`. It is out of scope for this isolated slice and is recorded as a
+recommended follow-up refactor, to be done deliberately and reviewably once `commands-bungee`
+is merged and green — matching `core-bungee`'s principle of extracting shared structure only
+after the second implementation exists.
+
+## Testing strategy
+
+Pure Mockito (no MockBukkit/MockBungee). Mock `Plugin`, `ProxyServer`, `PluginManager`,
+`CommandSender`, `ProxiedPlayer`, `ServerInfo`, `Context`, `CommandDispatcher`. Coverage:
+
+- `BungeeCommandPlatformSupportTest` — `createSender` wraps a `CommandSender` and rejects a
+  non-sender; `isSenderType` true for `CommandSender`/`ProxiedPlayer`, false otherwise.
+- `BungeeCommandSenderTest` — `getIdentity` is the UUID for a `ProxiedPlayer` and the
+  console identity for a plain `CommandSender`; `getName`/`hasPermission`/`sendMessage`
+  delegate; `unwrap` returns `ProxiedPlayer`/`CommandSender` and empty for mismatches.
+- `BungeeBootCommandTest` — `getPermission()` is null; `execute` delegates to
+  `dispatcher.dispatch` with the platform-created sender; `onTabComplete` delegates to
+  `dispatcher.complete` and is null-safe.
+- `BungeeCommandRegistrarTest` — `register` calls `pluginManager.registerCommand(plugin, cmd)`
+  for each root and returns a `RegisteredCommandSet`; `unregister` calls
+  `unregisterCommand` for each (mock `Plugin → ProxyServer → PluginManager`, the
+  `BungeeListenerAutoRegistrarTest` pattern).
+- `BungeeCommandsContextReadyRegistrarTest` — compiles via a mocked `CommandRootCompiler`,
+  registers, and the captured shutdown hook unregisters; empty roots register nothing.
+- `BungeeProxiedPlayerArgumentResolverTest` / `BungeeServerArgumentResolverTest` — resolve
+  by name, throw when absent, and complete by prefix (mock `Plugin → ProxyServer`).
+- `BungeeCommandCompletionRegistryCustomizerTest` — registers `onlinePlayers` and `servers`
+  and the providers prefix-filter.
+- `BungeeCommandsModuleDiscoveryTest` — the marker resource makes `BungeeCommandsModule`
+  discoverable via `ModuleDiscovery` (mirror of `BungeeModuleDiscoveryTest`).
+- `BungeeBootCommandEndToEndTest` — a real `@RootCommand` handler with a `@Command` method
+  taking `@Sender CommandSender`, a `ProxiedPlayer`, and a `ServerInfo`, compiled through
+  `CommandRootCompiler` and executed through a fully-wired `CommandDispatcher`; asserts the
+  handler received the resolved player/server and that tab completion surfaces player and
+  server names (the `SpigotBootCommandTest` analogue, the strongest single proof).
+
+## Open items to pin at plan time (not blockers)
+
+1. **`ProxyServer.getInstance()` vs. injected `Plugin`.** Decided: inject `Plugin`
+   (verified `Plugin.getProxy()` reaches `getPlayers()/getServers()/getServerInfo()`),
+   avoiding the static singleton and keeping resolvers plain-Mockito-testable. Pin the exact
+   `@Bean` parameter wiring in the plan.
+2. **Console sender identity string.** The Bungee API jar contains no console sender *type*
+   (it lives in the proxy runtime), so `getIdentity` falls back to `class:name` for
+   non-`ProxiedPlayer` senders. Confirm this matches `BukkitCommandSender`'s non-entity
+   branch in the test.
+3. **Shared `platform-bungee/pom.xml` edit.** Adding `<module>commands-bungee</module>` is
+   also performed by the sibling `config-bungee` effort; the plan notes this as the expected
+   trivial merge conflict.
+
+## Roadmap (subsequent slices, each its own spec)
+
+1. **`bungee.yml` descriptor generator** — needed before any runnable Bungee sample/test
+   plugin can load.
+2. **`config-bungee`** — the YAML config module (SnakeYAML is available on Bungee).
+3. **`commands-config-bungee`** — the `CommandTextResolver` → config bridge (mirror of
+   `commands-config-spigot`), depending on `commands-bungee` + `config-bungee`. Lets command
+   text/messages come from config via `${config.key}` tokens. Out of scope here.
+4. **Hoist shared pipeline beans** into the generic `CommandsConfiguration` (the deferred
+   refactor above).

--- a/docs/superpowers/specs/2026-06-15-bungeecord-commands-design.md
+++ b/docs/superpowers/specs/2026-06-15-bungeecord-commands-design.md
@@ -50,8 +50,12 @@ extracted when Velocity actually arrives.
   `config-bungee` to exist first. See "Roadmap". Explicitly out of scope here.
 - **No edit to the generic `commands` module.** In particular, no hoisting of the shared
   pipeline beans (see "Considered alternative").
-- **No collision-detection / command-overwrite policy** beyond BungeeCord's native
-  last-wins behavior (see Divergence 4).
+- ~~**No collision-detection / command-overwrite policy** beyond BungeeCord's native
+  last-wins behavior.~~ **Superseded (post-review):** BungeeCord's `PluginManager.getCommands()`
+  is a public read accessor, so the registrar now mirrors Spigot's collision policy without
+  reflection — a label held by this plugin's own command is re-registered, a foreign collision
+  raises `IllegalStateException` instead of silently shadowing it (see the `BungeeCommandRegistrar`
+  section).
 - **No runnable Bungee sample plugin or on-server end-to-end validation.** There is no
   `bungee.yml` descriptor generator yet (a separate roadmap slice); tests are unit tests.
 - No `OfflinePlayer`/`World`/`Material` argument resolvers or completions — these Bukkit
@@ -261,19 +265,35 @@ the `String...` the Bungee `Command` constructor wants.
 ### `BungeeCommandRegistrar`
 
 Constructor `(CommandDispatcher dispatcher, CommandPlatformSupport platformSupport)` — **no
-`BukkitCommandMapAccessor` analogue**. `register(Context, List<CompiledRootCommand>)`:
+`BukkitCommandMapAccessor` analogue** (no reflection: the public `PluginManager.getCommands()`
+view replaces Spigot's reflective `knownCommands` map). `register(Context, List<CompiledRootCommand>)`
+mirrors Spigot's collision policy:
 
 ```java
 Plugin plugin = context.getBean(Plugin.class);
 PluginManager pm = plugin.getProxy().getPluginManager();
+Map<String, Command> known = index(pm.getCommands());         // public accessor, no reflection
+Set<Command> toReplace = Collections.newSetFromMap(new IdentityHashMap<>());
 List<BungeeBootCommand> commands = new ArrayList<>();
 for (CompiledRootCommand root : roots) {
-    BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, platformSupport);
-    pm.registerCommand(plugin, command);                      // public API, no reflection
-    commands.add(command);
+    for (String label : root.getAliases().allValues()) {     // collision scan per alias
+        Command existing = known.get(normalizeLabel(label));
+        if (existing == null) continue;
+        if (existing instanceof BungeeBootCommand && ((BungeeBootCommand) existing).isOwnedBy(plugin)) {
+            toReplace.add(existing);                          // our own command (e.g. reload) — replace
+        } else {
+            throw new IllegalStateException("Command label collision detected for '" + label + "'.");
+        }
+    }
+    commands.add(new BungeeBootCommand(context, root, dispatcher, platformSupport));
 }
+toReplace.forEach(pm::unregisterCommand);
+commands.forEach(c -> pm.registerCommand(plugin, c));
 return new RegisteredCommandSet(commands);
 ```
+
+`BungeeBootCommand#isOwnedBy(Plugin)` (mirror of `SpigotBootCommand#isOwnedBy`) compares the
+plugin captured from the context at construction.
 
 `unregister(RegisteredCommandSet)` resolves the plugin again and calls
 `pm.unregisterCommand(command)` for each tracked command (surgical — only our commands, not

--- a/platform-bungee/commands-bungee/pom.xml
+++ b/platform-bungee/commands-bungee/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>tech.guilhermekaua.spigot-boot</groupId>
+        <artifactId>spigot-boot-platform-bungee</artifactId>
+        <version>3.2.1-SNAPSHOT</version>
+    </parent>
+
+    <name>${project.artifactId}</name>
+    <description>Runtime commands module for Spigot Boot on BungeeCord.</description>
+    <url>https://github.com/guikaua12/spigot-boot</url>
+    <artifactId>spigot-boot-commands-bungee</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
+                        <path>
+                            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+                            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-commands</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-core-bungee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.TabExecutor;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A BungeeCord {@link Command} that bridges a compiled root command to the generic
+ * {@link CommandDispatcher}. Mirrors the Spigot {@code SpigotBootCommand}.
+ *
+ * <p>The base command is constructed with a {@code null} permission: BungeeCord's
+ * {@code PluginManager} only blocks execution when {@code hasPermission} fails, so leaving it null
+ * guarantees {@link #execute}/{@link #onTabComplete} are always reached and the dispatcher enforces
+ * per-route {@code @Permission} for both — the same end-state as the Spigot adapter.
+ *
+ * <p>{@link TabExecutor} is implemented because BungeeCord's base {@link Command} has no tab-complete
+ * method; the dispatcher invokes {@link #onTabComplete} via {@code instanceof TabExecutor}.
+ */
+public class BungeeBootCommand extends Command implements TabExecutor {
+    private final Context context;
+    private final CompiledRootCommand rootCommand;
+    private final CommandDispatcher dispatcher;
+    private final CommandPlatformSupport commandPlatformSupport;
+
+    public BungeeBootCommand(Context context,
+                             CompiledRootCommand rootCommand,
+                             CommandDispatcher dispatcher,
+                             CommandPlatformSupport commandPlatformSupport) {
+        super(rootCommand.getAliases().getPrimary(), null,
+                rootCommand.getAliases().getAliases().toArray(new String[0]));
+        this.context = context;
+        this.rootCommand = rootCommand;
+        this.dispatcher = dispatcher;
+        this.commandPlatformSupport = commandPlatformSupport;
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        // BungeeCord's execute() is void and provides no label; the primary name is used as the label.
+        dispatcher.dispatch(context, rootCommand, commandPlatformSupport.createSender(sender), getName(), args);
+    }
+
+    @Override
+    public Iterable<String> onTabComplete(CommandSender sender, String[] args) {
+        List<String> completions = dispatcher.complete(context, rootCommand,
+                commandPlatformSupport.createSender(sender), getName(), args);
+        return completions == null ? Collections.emptyList() : completions;
+    }
+
+    public CompiledRootCommand getRootCommand() {
+        return rootCommand;
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java
@@ -24,6 +24,7 @@ package tech.guilhermekaua.spigotboot.commands.bungee;
 
 import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.TabExecutor;
 import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
 import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
@@ -47,6 +48,7 @@ import java.util.List;
  */
 public class BungeeBootCommand extends Command implements TabExecutor {
     private final Context context;
+    private final Plugin plugin;
     private final CompiledRootCommand rootCommand;
     private final CommandDispatcher dispatcher;
     private final CommandPlatformSupport commandPlatformSupport;
@@ -58,6 +60,7 @@ public class BungeeBootCommand extends Command implements TabExecutor {
         super(rootCommand.getAliases().getPrimary(), null,
                 rootCommand.getAliases().getAliases().toArray(new String[0]));
         this.context = context;
+        this.plugin = context.getBean(Plugin.class);
         this.rootCommand = rootCommand;
         this.dispatcher = dispatcher;
         this.commandPlatformSupport = commandPlatformSupport;
@@ -78,5 +81,17 @@ public class BungeeBootCommand extends Command implements TabExecutor {
 
     public CompiledRootCommand getRootCommand() {
         return rootCommand;
+    }
+
+    /**
+     * Returns whether this command was registered by the given plugin. Mirrors the Spigot
+     * {@code SpigotBootCommand#isOwnedBy}; {@link BungeeCommandRegistrar} uses it to tell a
+     * re-registration of this plugin's own command apart from a genuine foreign collision.
+     *
+     * @param plugin the plugin to test ownership against
+     * @return {@code true} if this command belongs to {@code plugin}
+     */
+    public boolean isOwnedBy(Plugin plugin) {
+        return this.plugin != null && this.plugin.equals(plugin);
     }
 }

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupport.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupport.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+
+/**
+ * Wraps a BungeeCord {@link CommandSender} into a {@link CommandSenderHandle}. Mirrors the Spigot
+ * {@code BukkitCommandPlatformSupport}. {@code ProxiedPlayer} is a {@code CommandSender}, so it is
+ * recognised by {@link #isSenderType(Class)} too.
+ */
+public class BungeeCommandPlatformSupport implements CommandPlatformSupport {
+
+    @Override
+    public CommandSenderHandle createSender(Object nativeSender) {
+        if (!(nativeSender instanceof CommandSender)) {
+            throw new IllegalArgumentException("Expected a BungeeCord CommandSender but got " +
+                    (nativeSender == null ? "null" : nativeSender.getClass().getName()) + ".");
+        }
+        return new BungeeCommandSender((CommandSender) nativeSender);
+    }
+
+    @Override
+    public boolean isSenderType(Class<?> type) {
+        return type != null && CommandSender.class.isAssignableFrom(type);
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrar.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrar.java
@@ -22,21 +22,31 @@
  */
 package tech.guilhermekaua.spigotboot.commands.bungee;
 
+import net.md_5.bungee.api.plugin.Command;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
 import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.internal.CommandSupport;
 import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
 import tech.guilhermekaua.spigotboot.core.context.Context;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Registers compiled commands with BungeeCord through its public {@link PluginManager} API. Unlike
- * the Spigot registrar there is no CommandMap reflection: {@code registerCommand}/{@code
- * unregisterCommand} are public. BungeeCord's command map is private and last-wins, so no collision
- * detection is performed (see the design spec).
+ * the Spigot registrar there is no CommandMap reflection: {@code registerCommand}, {@code
+ * unregisterCommand} and {@code getCommands} are all public. The public {@code getCommands} view
+ * lets this registrar mirror the Spigot collision policy without reflection: a label already owned by
+ * this plugin's own {@link BungeeBootCommand} is unregistered and replaced (so reloads work), while a
+ * label held by any foreign command raises {@link IllegalStateException} instead of silently shadowing
+ * it (BungeeCord's own {@code registerCommand} is otherwise last-wins).
  */
 public class BungeeCommandRegistrar {
     private final CommandDispatcher dispatcher;
@@ -51,12 +61,21 @@ public class BungeeCommandRegistrar {
     public RegisteredCommandSet register(Context context, List<CompiledRootCommand> roots) {
         Plugin plugin = context.getBean(Plugin.class);
         PluginManager pluginManager = plugin.getProxy().getPluginManager();
+        Map<String, Command> knownCommands = indexRegisteredCommands(pluginManager);
 
+        Set<Command> toReplace = Collections.newSetFromMap(new IdentityHashMap<>());
         List<BungeeBootCommand> commands = new ArrayList<>();
         for (CompiledRootCommand root : roots) {
-            BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, commandPlatformSupport);
+            collectCollisions(plugin, root, knownCommands, toReplace);
+            commands.add(new BungeeBootCommand(context, root, dispatcher, commandPlatformSupport));
+        }
+
+        for (Command existing : toReplace) {
+            pluginManager.unregisterCommand(existing);
+        }
+
+        for (BungeeBootCommand command : commands) {
             pluginManager.registerCommand(plugin, command);
-            commands.add(command);
         }
         return new RegisteredCommandSet(commands);
     }
@@ -66,6 +85,33 @@ public class BungeeCommandRegistrar {
         PluginManager pluginManager = plugin.getProxy().getPluginManager();
         for (BungeeBootCommand command : registeredCommandSet.getCommands()) {
             pluginManager.unregisterCommand(command);
+        }
+    }
+
+    private Map<String, Command> indexRegisteredCommands(PluginManager pluginManager) {
+        Map<String, Command> knownCommands = new HashMap<>();
+        for (Map.Entry<String, Command> entry : pluginManager.getCommands()) {
+            knownCommands.put(CommandSupport.normalizeLabel(entry.getKey()), entry.getValue());
+        }
+        return knownCommands;
+    }
+
+    private void collectCollisions(Plugin plugin,
+                                   CompiledRootCommand root,
+                                   Map<String, Command> knownCommands,
+                                   Set<Command> toReplace) {
+        for (String label : root.getAliases().allValues()) {
+            Command existing = knownCommands.get(CommandSupport.normalizeLabel(label));
+            if (existing == null) {
+                continue;
+            }
+
+            if (existing instanceof BungeeBootCommand && ((BungeeBootCommand) existing).isOwnedBy(plugin)) {
+                toReplace.add(existing);
+                continue;
+            }
+
+            throw new IllegalStateException("Command label collision detected for '" + label + "'.");
         }
     }
 }

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrar.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrar.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginManager;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Registers compiled commands with BungeeCord through its public {@link PluginManager} API. Unlike
+ * the Spigot registrar there is no CommandMap reflection: {@code registerCommand}/{@code
+ * unregisterCommand} are public. BungeeCord's command map is private and last-wins, so no collision
+ * detection is performed (see the design spec).
+ */
+public class BungeeCommandRegistrar {
+    private final CommandDispatcher dispatcher;
+    private final CommandPlatformSupport commandPlatformSupport;
+
+    public BungeeCommandRegistrar(CommandDispatcher dispatcher,
+                                  CommandPlatformSupport commandPlatformSupport) {
+        this.dispatcher = dispatcher;
+        this.commandPlatformSupport = commandPlatformSupport;
+    }
+
+    public RegisteredCommandSet register(Context context, List<CompiledRootCommand> roots) {
+        Plugin plugin = context.getBean(Plugin.class);
+        PluginManager pluginManager = plugin.getProxy().getPluginManager();
+
+        List<BungeeBootCommand> commands = new ArrayList<>();
+        for (CompiledRootCommand root : roots) {
+            BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, commandPlatformSupport);
+            pluginManager.registerCommand(plugin, command);
+            commands.add(command);
+        }
+        return new RegisteredCommandSet(commands);
+    }
+
+    public void unregister(Context context, RegisteredCommandSet registeredCommandSet) {
+        Plugin plugin = context.getBean(Plugin.class);
+        PluginManager pluginManager = plugin.getProxy().getPluginManager();
+        for (BungeeBootCommand command : registeredCommandSet.getCommands()) {
+            pluginManager.unregisterCommand(command);
+        }
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSender.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSender.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Adapts a BungeeCord {@link CommandSender} to the platform-neutral {@link CommandSenderHandle}.
+ * Mirrors the Spigot {@code BukkitCommandSender}.
+ */
+public class BungeeCommandSender implements CommandSenderHandle {
+    private final CommandSender sender;
+
+    public BungeeCommandSender(CommandSender sender) {
+        this.sender = Objects.requireNonNull(sender, "sender cannot be null.");
+    }
+
+    @Override
+    public String getName() {
+        return sender.getName();
+    }
+
+    @Override
+    public String getIdentity() {
+        if (sender instanceof ProxiedPlayer) {
+            return ((ProxiedPlayer) sender).getUniqueId().toString();
+        }
+        // BungeeCord exposes no console sender type in its API; identify non-players by class + name.
+        String name = sender.getName();
+        return sender.getClass().getName() + ":" + (name == null ? "" : name);
+    }
+
+    @Override
+    public boolean hasPermission(String permission) {
+        return sender.hasPermission(permission);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void sendMessage(String message) {
+        // the String overload is deprecated in favour of BaseComponent, but the CommandSenderHandle
+        // contract is String-based; the legacy overload renders legacy colour codes correctly.
+        sender.sendMessage(message);
+    }
+
+    @Override
+    public <T> Optional<T> unwrap(Class<T> type) {
+        if (type == null || !type.isInstance(sender)) {
+            return Optional.empty();
+        }
+        return Optional.of(type.cast(sender));
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrar.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrar.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandRootCompiler;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.listeners.ContextReadyListener;
+
+import java.util.List;
+
+/**
+ * Compiles every command handler bean and registers the results with BungeeCord when the context is
+ * ready, unregistering them on shutdown. Mirrors the Spigot {@code CommandsContextReadyRegistrar}.
+ */
+public class BungeeCommandsContextReadyRegistrar implements ContextReadyListener, Ordered {
+    private final CommandRootCompiler commandRootCompiler;
+    private final BungeeCommandRegistrar bungeeCommandRegistrar;
+    private final CommandReplacementRegistry replacementRegistry;
+
+    public BungeeCommandsContextReadyRegistrar(CommandRootCompiler commandRootCompiler,
+                                               BungeeCommandRegistrar bungeeCommandRegistrar,
+                                               CommandReplacementRegistry replacementRegistry) {
+        this.commandRootCompiler = commandRootCompiler;
+        this.bungeeCommandRegistrar = bungeeCommandRegistrar;
+        this.replacementRegistry = replacementRegistry;
+    }
+
+    @Override
+    public int getOrder() {
+        return 1000;
+    }
+
+    @Override
+    public void onContextReady(Context context) {
+        replacementRegistry.register("plugin.name", context.getPlugin().getName());
+        replacementRegistry.register("plugin", context.getPlugin().getName());
+
+        List<CompiledRootCommand> roots = commandRootCompiler.compile(context);
+        if (roots.isEmpty()) {
+            return;
+        }
+
+        final RegisteredCommandSet registered = bungeeCommandRegistrar.register(context, roots);
+        context.registerShutdownHook(() -> bungeeCommandRegistrar.unregister(context, registered));
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModule.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModule.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+
+/**
+ * Marks the Bungee commands module for discovery. The bean wiring lives in
+ * {@code BungeeCommandsConfiguration}; this module only logs initialisation, mirroring the Spigot
+ * {@code SpigotCommandsModule}.
+ */
+public class BungeeCommandsModule implements Module {
+    @Override
+    public void onInitialize(Context context) {
+        context.getPlugin().getLogger().fine("Initializing Bungee commands module.");
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/RegisteredCommandSet.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/RegisteredCommandSet.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Immutable snapshot of the {@link BungeeBootCommand}s registered for a context, carried by the
+ * shutdown hook so exactly those commands are unregistered. Mirrors the Spigot
+ * {@code RegisteredCommandSet}.
+ */
+public final class RegisteredCommandSet {
+    private final List<BungeeBootCommand> commands;
+
+    public RegisteredCommandSet(List<BungeeBootCommand> commands) {
+        this.commands = Collections.unmodifiableList(commands);
+    }
+
+    public List<BungeeBootCommand> getCommands() {
+        return commands;
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizer.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizer.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee.completion;
+
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistryCustomizer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Registers the proxy-specific named completions {@code onlinePlayers} and {@code servers}, referenced
+ * from handlers via {@code @Completion("onlinePlayers")} / {@code @Completion("servers")}. Mirrors the
+ * Spigot {@code BukkitCommandCompletionRegistryCustomizer} ({@code worlds}/{@code materials} have no
+ * proxy analogue). Reaches the proxy via the injected {@link Plugin}.
+ */
+public class BungeeCommandCompletionRegistryCustomizer implements CommandCompletionRegistryCustomizer {
+    private final Plugin plugin;
+
+    public BungeeCommandCompletionRegistryCustomizer(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public void customize(CommandCompletionRegistry registry) {
+        registry.register("onlinePlayers", (context, parameter, input) -> {
+            List<String> values = new ArrayList<>();
+            String lowerInput = input != null ? input.toLowerCase(Locale.ROOT) : "";
+            for (ProxiedPlayer player : plugin.getProxy().getPlayers()) {
+                if (!lowerInput.isEmpty() && !player.getName().toLowerCase(Locale.ROOT).startsWith(lowerInput)) {
+                    continue;
+                }
+                values.add(player.getName());
+            }
+            return values;
+        });
+        registry.register("servers", (context, parameter, input) -> {
+            List<String> values = new ArrayList<>();
+            String lowerInput = input != null ? input.toLowerCase(Locale.ROOT) : "";
+            for (String serverName : plugin.getProxy().getServers().keySet()) {
+                if (!lowerInput.isEmpty() && !serverName.toLowerCase(Locale.ROOT).startsWith(lowerInput)) {
+                    continue;
+                }
+                values.add(serverName);
+            }
+            return values;
+        });
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/configuration/BungeeCommandsConfiguration.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/configuration/BungeeCommandsConfiguration.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee.configuration;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolverRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandRootCompiler;
+import tech.guilhermekaua.spigotboot.commands.CommandTextResolverChain;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterBinder;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterRoleResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandRegistrar;
+import tech.guilhermekaua.spigotboot.commands.bungee.BungeeCommandsContextReadyRegistrar;
+import tech.guilhermekaua.spigotboot.commands.bungee.completion.BungeeCommandCompletionRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeProxiedPlayerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeServerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.cooldown.CommandCooldownInterceptor;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationExecutor;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationFactory;
+import tech.guilhermekaua.spigotboot.commands.interceptor.CommandInterceptorChain;
+import tech.guilhermekaua.spigotboot.commands.message.CommandMessagesProvider;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandHandlerIntrospector;
+import tech.guilhermekaua.spigotboot.commands.parse.CommandPatternParser;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteFactory;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteValidator;
+import tech.guilhermekaua.spigotboot.commands.completion.CompletionResolver;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Bean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Configuration;
+import tech.guilhermekaua.spigotboot.core.cooldown.CooldownManager;
+
+/**
+ * Wires the BungeeCord command pipeline. The 13 platform-neutral beans come from the generic
+ * {@code CommandsConfiguration}; this configuration declares only the beans that depend on the
+ * platform {@link CommandPlatformSupport}, plus the Bungee registrar, context-ready registrar,
+ * argument resolvers, and completion customizer. Mirrors {@code SpigotCommandsConfiguration} (without
+ * the CommandMap accessor, which BungeeCord does not need).
+ */
+@Configuration
+public class BungeeCommandsConfiguration {
+
+    @Bean
+    public CommandPlatformSupport commandPlatformSupport() {
+        return new BungeeCommandPlatformSupport();
+    }
+
+    @Bean
+    public CommandParameterRoleResolver commandParameterRoleResolver(CommandPlatformSupport commandPlatformSupport) {
+        return new CommandParameterRoleResolver(commandPlatformSupport);
+    }
+
+    @Bean
+    public CommandInvocationFactory commandInvocationFactory(CommandParameterRoleResolver commandParameterRoleResolver) {
+        return new CommandInvocationFactory(commandParameterRoleResolver);
+    }
+
+    @Bean
+    public CommandRouteFactory commandRouteFactory(CommandPatternParser commandPatternParser,
+                                                   CommandReplacementRegistry commandReplacementRegistry,
+                                                   CommandTextResolverChain commandTextResolverChain,
+                                                   CommandInvocationFactory commandInvocationFactory) {
+        return new CommandRouteFactory(
+                commandPatternParser,
+                commandReplacementRegistry,
+                commandTextResolverChain,
+                commandInvocationFactory
+        );
+    }
+
+    @Bean
+    public CommandRootCompiler commandRootCompiler(CommandHandlerIntrospector commandHandlerIntrospector,
+                                                   CommandRouteFactory commandRouteFactory,
+                                                   CommandRouteValidator commandRouteValidator,
+                                                   CommandInterceptorChain commandInterceptorChain) {
+        return new CommandRootCompiler(
+                commandHandlerIntrospector,
+                commandRouteFactory,
+                commandRouteValidator,
+                commandInterceptorChain
+        );
+    }
+
+    @Bean
+    public CommandParameterBinder commandParameterBinder(CommandArgumentResolverRegistry commandArgumentResolverRegistry) {
+        return new CommandParameterBinder(commandArgumentResolverRegistry);
+    }
+
+    @Bean
+    public CommandDispatcher commandDispatcher(CommandParameterBinder commandParameterBinder,
+                                               CommandInvocationExecutor commandInvocationExecutor,
+                                               CommandMessagesProvider commandMessagesProvider,
+                                               CompletionResolver completionResolver,
+                                               CommandInterceptorChain commandInterceptorChain) {
+        return new CommandDispatcher(
+                commandParameterBinder,
+                commandInvocationExecutor,
+                commandMessagesProvider,
+                completionResolver,
+                commandInterceptorChain
+        );
+    }
+
+    @Bean
+    public CommandCooldownInterceptor commandCooldownInterceptor(CooldownManager cooldownManager,
+                                                                 CommandMessagesProvider commandMessagesProvider) {
+        return new CommandCooldownInterceptor(cooldownManager, commandMessagesProvider);
+    }
+
+    @Bean
+    public BungeeCommandRegistrar bungeeCommandRegistrar(CommandDispatcher commandDispatcher,
+                                                         CommandPlatformSupport commandPlatformSupport) {
+        return new BungeeCommandRegistrar(commandDispatcher, commandPlatformSupport);
+    }
+
+    @Bean
+    public BungeeCommandsContextReadyRegistrar bungeeCommandsContextReadyRegistrar(CommandRootCompiler commandRootCompiler,
+                                                                                   BungeeCommandRegistrar bungeeCommandRegistrar,
+                                                                                   CommandReplacementRegistry commandReplacementRegistry) {
+        return new BungeeCommandsContextReadyRegistrar(
+                commandRootCompiler,
+                bungeeCommandRegistrar,
+                commandReplacementRegistry
+        );
+    }
+
+    @Bean
+    public CommandCompletionRegistryCustomizer bungeeCommandCompletionRegistryCustomizer(Plugin plugin) {
+        return new BungeeCommandCompletionRegistryCustomizer(plugin);
+    }
+
+    @Bean
+    public CommandArgumentResolver<?> bungeeProxiedPlayerArgumentResolver(Plugin plugin) {
+        return new BungeeProxiedPlayerArgumentResolver(plugin);
+    }
+
+    @Bean
+    public CommandArgumentResolver<?> bungeeServerArgumentResolver(Plugin plugin) {
+        return new BungeeServerArgumentResolver(plugin);
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolver.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolver.java
@@ -32,12 +32,14 @@ import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * Resolves a {@code ProxiedPlayer} command argument by online name, with online-player tab
- * completion. The Bungee analogue of {@code BukkitPlayerArgumentResolver}; reaches the proxy via the
- * injected {@link Plugin}. Prefix filtering of completions is applied downstream by the framework's
- * {@code CompletionResolver}.
+ * completion. The Bungee analogue of {@code BukkitPlayerArgumentResolver}; like it, an exact lookup is
+ * tried first and, failing that, a unique case-insensitive prefix match is accepted (ambiguous
+ * prefixes are rejected). Reaches the proxy via the injected {@link Plugin}. Prefix filtering of
+ * completions is applied downstream by the framework's {@code CompletionResolver}.
  */
 public class BungeeProxiedPlayerArgumentResolver implements CommandArgumentResolver<ProxiedPlayer>, Ordered {
     private final Plugin plugin;
@@ -59,6 +61,21 @@ public class BungeeProxiedPlayerArgumentResolver implements CommandArgumentResol
     @Override
     public ProxiedPlayer resolve(CommandExecutionContext context, CommandParameterMetadata parameter, String input) {
         ProxiedPlayer player = plugin.getProxy().getPlayer(input);
+        if (player == null) {
+            // mirror BukkitPlayerArgumentResolver: fall back to a unique case-insensitive prefix match
+            String prefix = input == null ? "" : input.toLowerCase(Locale.ROOT);
+            List<ProxiedPlayer> matches = new ArrayList<>();
+            for (ProxiedPlayer candidate : plugin.getProxy().getPlayers()) {
+                if (candidate.getName().toLowerCase(Locale.ROOT).startsWith(prefix)) {
+                    matches.add(candidate);
+                }
+            }
+            if (matches.size() == 1) {
+                player = matches.get(0);
+            } else if (matches.size() > 1) {
+                throw new IllegalArgumentException("Ambiguous player name: " + input);
+            }
+        }
         if (player == null) {
             throw new IllegalArgumentException("Player not found: " + input);
         }

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolver.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolver.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionProvider;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Resolves a {@code ProxiedPlayer} command argument by online name, with online-player tab
+ * completion. The Bungee analogue of {@code BukkitPlayerArgumentResolver}; reaches the proxy via the
+ * injected {@link Plugin}. Prefix filtering of completions is applied downstream by the framework's
+ * {@code CompletionResolver}.
+ */
+public class BungeeProxiedPlayerArgumentResolver implements CommandArgumentResolver<ProxiedPlayer>, Ordered {
+    private final Plugin plugin;
+
+    public BungeeProxiedPlayerArgumentResolver(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public int getOrder() {
+        return 1000;
+    }
+
+    @Override
+    public boolean supports(CommandParameterMetadata parameter) {
+        return ProxiedPlayer.class.equals(parameter.getValueType());
+    }
+
+    @Override
+    public ProxiedPlayer resolve(CommandExecutionContext context, CommandParameterMetadata parameter, String input) {
+        ProxiedPlayer player = plugin.getProxy().getPlayer(input);
+        if (player == null) {
+            throw new IllegalArgumentException("Player not found: " + input);
+        }
+        return player;
+    }
+
+    @Override
+    public CommandCompletionProvider defaultCompletionProvider() {
+        return (context, parameter, input) -> {
+            List<String> values = new ArrayList<>();
+            for (ProxiedPlayer player : plugin.getProxy().getPlayers()) {
+                values.add(player.getName());
+            }
+            return values;
+        };
+    }
+}

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolver.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolver.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.plugin.Plugin;
+import tech.guilhermekaua.spigotboot.commands.CommandArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionProvider;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+
+import java.util.ArrayList;
+
+/**
+ * Resolves a {@code ServerInfo} command argument by configured server name, with server-name tab
+ * completion. A proxy-specific resolver with no Bukkit analogue; reaches the proxy via the injected
+ * {@link Plugin}. Prefix filtering of completions is applied downstream by {@code CompletionResolver}.
+ */
+public class BungeeServerArgumentResolver implements CommandArgumentResolver<ServerInfo>, Ordered {
+    private final Plugin plugin;
+
+    public BungeeServerArgumentResolver(Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public int getOrder() {
+        return 1000;
+    }
+
+    @Override
+    public boolean supports(CommandParameterMetadata parameter) {
+        return ServerInfo.class.equals(parameter.getValueType());
+    }
+
+    @Override
+    public ServerInfo resolve(CommandExecutionContext context, CommandParameterMetadata parameter, String input) {
+        ServerInfo server = plugin.getProxy().getServerInfo(input);
+        if (server == null) {
+            throw new IllegalArgumentException("Server not found: " + input);
+        }
+        return server;
+    }
+
+    @Override
+    public CommandCompletionProvider defaultCompletionProvider() {
+        return (context, parameter, input) -> new ArrayList<>(plugin.getProxy().getServers().keySet());
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java
@@ -1,0 +1,178 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginDescription;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.annotations.Command;
+import tech.guilhermekaua.spigotboot.commands.annotations.CommandHandler;
+import tech.guilhermekaua.spigotboot.commands.annotations.RootCommand;
+import tech.guilhermekaua.spigotboot.commands.annotations.Sender;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterBinder;
+import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterRoleResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.completion.BungeeCommandCompletionRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeProxiedPlayerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.bungee.resolve.BungeeServerArgumentResolver;
+import tech.guilhermekaua.spigotboot.commands.completion.CompletionResolver;
+import tech.guilhermekaua.spigotboot.commands.completion.DefaultCommandCompletionRegistry;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationExecutor;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandInvocationFactory;
+import tech.guilhermekaua.spigotboot.commands.interceptor.CommandInterceptorChain;
+import tech.guilhermekaua.spigotboot.commands.message.CommandMessagesProvider;
+import tech.guilhermekaua.spigotboot.commands.message.DefaultCommandMessages;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandHandlerIntrospector;
+import tech.guilhermekaua.spigotboot.commands.metadata.RootCommandMetadata;
+import tech.guilhermekaua.spigotboot.commands.parse.CommandPatternParser;
+import tech.guilhermekaua.spigotboot.commands.replace.DefaultCommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.resolve.DefaultCommandArgumentResolverRegistry;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteFactory;
+import tech.guilhermekaua.spigotboot.commands.route.CommandRouteValidator;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.bungee.BungeeBootPlugin;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeBootCommandEndToEndTest {
+    private final BungeeCommandPlatformSupport platformSupport = new BungeeCommandPlatformSupport();
+
+    private Plugin mockPlugin(ProxyServer proxy) {
+        Plugin plugin = mock(Plugin.class);
+        PluginDescription description = mock(PluginDescription.class);
+        when(description.getName()).thenReturn("TestPlugin");
+        when(plugin.getDescription()).thenReturn(description);
+        when(plugin.getProxy()).thenReturn(proxy);
+        return plugin;
+    }
+
+    private Context newContext(Plugin plugin) {
+        Context context = mock(Context.class);
+        when(context.getPlugin()).thenReturn(new BungeeBootPlugin(plugin));
+        when(context.getDependencyManager()).thenReturn(new DependencyManager());
+        return context;
+    }
+
+    private CompiledRootCommand compileRoot(Object handler) {
+        CommandReplacementRegistry replacementRegistry = new DefaultCommandReplacementRegistry(Collections.emptyList());
+        CommandRouteFactory factory = new CommandRouteFactory(
+                new CommandPatternParser(),
+                replacementRegistry,
+                new CommandInvocationFactory(new CommandParameterRoleResolver(platformSupport))
+        );
+        RootCommandMetadata metadata = new CommandHandlerIntrospector().introspect(handler);
+        CompiledRootCommand root = factory.create(metadata);
+        new CommandRouteValidator().validate(Collections.singletonList(root));
+        return root;
+    }
+
+    private CommandDispatcher newDispatcher(Plugin plugin) {
+        DefaultCommandArgumentResolverRegistry resolverRegistry = new DefaultCommandArgumentResolverRegistry(
+                Arrays.asList(new BungeeProxiedPlayerArgumentResolver(plugin), new BungeeServerArgumentResolver(plugin)),
+                Collections.emptyList()
+        );
+        DefaultCommandCompletionRegistry completionRegistry = new DefaultCommandCompletionRegistry(
+                Collections.singletonList(new BungeeCommandCompletionRegistryCustomizer(plugin))
+        );
+        return new CommandDispatcher(
+                new CommandParameterBinder(resolverRegistry),
+                new CommandInvocationExecutor(new CommandInterceptorChain()),
+                new CommandMessagesProvider(new DefaultCommandMessages()),
+                new CompletionResolver(completionRegistry, resolverRegistry)
+        );
+    }
+
+    @Test
+    void executesWithSenderBindingAndProxiedPlayerAndServerResolution() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        ProxiedPlayer target = mock(ProxiedPlayer.class);
+        ServerInfo lobby = mock(ServerInfo.class);
+        when(sender.getName()).thenReturn("Sender");
+        when(target.getName()).thenReturn("Target");
+        when(lobby.getName()).thenReturn("lobby");
+        when(proxy.getPlayer("Target")).thenReturn(target);
+        when(proxy.getServerInfo("lobby")).thenReturn(lobby);
+
+        ServerCommands handler = new ServerCommands();
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(handler), newDispatcher(plugin), platformSupport);
+
+        command.execute(sender, new String[]{"send", "Target", "lobby"});
+
+        assertSame(sender, handler.lastSender);
+        assertSame(target, handler.lastTarget);
+        assertSame(lobby, handler.lastServer);
+    }
+
+    @Test
+    void tabCompleteSurfacesPlayerNames() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        ProxiedPlayer target = mock(ProxiedPlayer.class);
+        when(sender.getName()).thenReturn("Sender");
+        when(target.getName()).thenReturn("Target");
+        when(proxy.getPlayers()).thenReturn(Arrays.asList(sender, target));
+
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(new ServerCommands()), newDispatcher(plugin), platformSupport);
+
+        List<String> values = new ArrayList<>();
+        command.onTabComplete(sender, new String[]{"send", "T"}).forEach(values::add);
+
+        assertEquals(Collections.singletonList("Target"), values);
+    }
+
+    @CommandHandler
+    @RootCommand("server")
+    static class ServerCommands {
+        private ProxiedPlayer lastSender;
+        private ProxiedPlayer lastTarget;
+        private ServerInfo lastServer;
+
+        @Command("send <target> <server>")
+        public void send(@Sender ProxiedPlayer sender, ProxiedPlayer target, ServerInfo server) {
+            this.lastSender = sender;
+            this.lastTarget = target;
+            this.lastServer = server;
+        }
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandTest.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandAliasSet;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeBootCommandTest {
+
+    private CompiledRootCommand rootNamed(String primary) {
+        CommandAliasSet aliases = mock(CommandAliasSet.class);
+        when(aliases.getPrimary()).thenReturn(primary);
+        when(aliases.getAliases()).thenReturn(Collections.emptyList());
+        CompiledRootCommand root = mock(CompiledRootCommand.class);
+        when(root.getAliases()).thenReturn(aliases);
+        return root;
+    }
+
+    @Test
+    void baseCommandExposesNoPermissionSoDispatcherOwnsIt() {
+        BungeeBootCommand command = new BungeeBootCommand(
+                mock(Context.class), rootNamed("server"), mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
+
+        assertNull(command.getPermission());
+    }
+
+    @Test
+    void executeDelegatesToDispatcher() {
+        Context context = mock(Context.class);
+        CompiledRootCommand root = rootNamed("server");
+        CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+        CommandPlatformSupport support = mock(CommandPlatformSupport.class);
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        CommandSenderHandle handle = mock(CommandSenderHandle.class);
+        when(support.createSender(sender)).thenReturn(handle);
+
+        BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, support);
+        String[] args = {"send", "Target"};
+        command.execute(sender, args);
+
+        verify(dispatcher).dispatch(context, root, handle, "server", args);
+    }
+
+    @Test
+    void onTabCompleteDelegatesToDispatcherAndIsNullSafe() {
+        Context context = mock(Context.class);
+        CompiledRootCommand root = rootNamed("server");
+        CommandDispatcher dispatcher = mock(CommandDispatcher.class);
+        CommandPlatformSupport support = mock(CommandPlatformSupport.class);
+        ProxiedPlayer sender = mock(ProxiedPlayer.class);
+        CommandSenderHandle handle = mock(CommandSenderHandle.class);
+        when(support.createSender(sender)).thenReturn(handle);
+        when(dispatcher.complete(context, root, handle, "server", new String[]{"send", "T"}))
+                .thenReturn(Collections.singletonList("Target"));
+
+        BungeeBootCommand command = new BungeeBootCommand(context, root, dispatcher, support);
+
+        Iterable<String> result = command.onTabComplete(sender, new String[]{"send", "T"});
+        List<String> values = new ArrayList<>();
+        result.forEach(values::add);
+        assertEquals(Collections.singletonList("Target"), values);
+
+        when(dispatcher.complete(context, root, handle, "server", new String[]{"x"})).thenReturn(null);
+        assertFalse(command.onTabComplete(sender, new String[]{"x"}).iterator().hasNext());
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupportTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandPlatformSupportTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandSenderHandle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandPlatformSupportTest {
+    private final BungeeCommandPlatformSupport support = new BungeeCommandPlatformSupport();
+
+    @Test
+    void createSenderWrapsBungeeSender() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(player.getName()).thenReturn("Alex");
+
+        CommandSenderHandle handle = support.createSender(player);
+
+        assertEquals("Alex", handle.getName());
+        assertSame(player, handle.unwrap(ProxiedPlayer.class).orElse(null));
+    }
+
+    @Test
+    void createSenderRejectsNonBungeeSender() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+                () -> support.createSender("not a sender"));
+        assertTrue(ex.getMessage().contains("Expected a BungeeCord CommandSender"));
+    }
+
+    @Test
+    void isSenderTypeMatchesCommandSenderHierarchy() {
+        assertTrue(support.isSenderType(CommandSender.class));
+        assertTrue(support.isSenderType(ProxiedPlayer.class));
+        assertFalse(support.isSenderType(String.class));
+        assertFalse(support.isSenderType(null));
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java
@@ -34,11 +34,15 @@ import tech.guilhermekaua.spigotboot.commands.metadata.CommandAliasSet;
 import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
 import tech.guilhermekaua.spigotboot.core.context.Context;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,14 +71,18 @@ class BungeeCommandRegistrarTest {
         BungeeCommandRegistrar registrar = new BungeeCommandRegistrar(
                 mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
 
-        RegisteredCommandSet set = registrar.register(context, Collections.singletonList(rootNamed("server")));
+        RegisteredCommandSet set = registrar.register(
+                context, Arrays.asList(rootNamed("server"), rootNamed("network")));
 
-        assertEquals(1, set.getCommands().size());
+        assertEquals(2, set.getCommands().size());
         ArgumentCaptor<Command> captor = ArgumentCaptor.forClass(Command.class);
-        verify(pluginManager).registerCommand(eq(plugin), captor.capture());
-        assertEquals("server", captor.getValue().getName());
+        verify(pluginManager, times(2)).registerCommand(eq(plugin), captor.capture());
+        List<String> names = captor.getAllValues().stream().map(Command::getName).toList();
+        assertTrue(names.contains("server"));
+        assertTrue(names.contains("network"));
 
         registrar.unregister(context, set);
         verify(pluginManager).unregisterCommand(set.getCommands().get(0));
+        verify(pluginManager).unregisterCommand(set.getCommands().get(1));
     }
 }

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java
@@ -36,12 +36,17 @@ import tech.guilhermekaua.spigotboot.core.context.Context;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,6 +57,7 @@ class BungeeCommandRegistrarTest {
         CommandAliasSet aliases = mock(CommandAliasSet.class);
         when(aliases.getPrimary()).thenReturn(primary);
         when(aliases.getAliases()).thenReturn(Collections.emptyList());
+        when(aliases.allValues()).thenReturn(Collections.singletonList(primary));
         CompiledRootCommand root = mock(CompiledRootCommand.class);
         when(root.getAliases()).thenReturn(aliases);
         return root;
@@ -64,6 +70,8 @@ class BungeeCommandRegistrarTest {
         PluginManager pluginManager = mock(PluginManager.class);
         when(plugin.getProxy()).thenReturn(proxy);
         when(proxy.getPluginManager()).thenReturn(pluginManager);
+
+        when(pluginManager.getCommands()).thenReturn(Collections.<Map.Entry<String, Command>>emptyList());
 
         Context context = mock(Context.class);
         when(context.getBean(Plugin.class)).thenReturn(plugin);
@@ -84,5 +92,59 @@ class BungeeCommandRegistrarTest {
         registrar.unregister(context, set);
         verify(pluginManager).unregisterCommand(set.getCommands().get(0));
         verify(pluginManager).unregisterCommand(set.getCommands().get(1));
+    }
+
+    @Test
+    void rejectsCollisionWithForeignCommand() {
+        Plugin plugin = mock(Plugin.class);
+        ProxyServer proxy = mock(ProxyServer.class);
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(plugin.getProxy()).thenReturn(proxy);
+        when(proxy.getPluginManager()).thenReturn(pluginManager);
+
+        // an unrelated plugin already owns /server (Bungee lower-cases registered labels)
+        Command foreign = mock(Command.class);
+        Map<String, Command> known = new HashMap<>();
+        known.put("server", foreign);
+        when(pluginManager.getCommands()).thenReturn(known.entrySet());
+
+        Context context = mock(Context.class);
+        when(context.getBean(Plugin.class)).thenReturn(plugin);
+
+        BungeeCommandRegistrar registrar = new BungeeCommandRegistrar(
+                mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
+
+        assertThrows(IllegalStateException.class,
+                () -> registrar.register(context, Collections.singletonList(rootNamed("server"))));
+        verify(pluginManager, never()).registerCommand(any(), any());
+    }
+
+    @Test
+    void replacesOwnCommandOnReRegistration() {
+        Plugin plugin = mock(Plugin.class);
+        ProxyServer proxy = mock(ProxyServer.class);
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(plugin.getProxy()).thenReturn(proxy);
+        when(proxy.getPluginManager()).thenReturn(pluginManager);
+
+        Context context = mock(Context.class);
+        when(context.getBean(Plugin.class)).thenReturn(plugin);
+
+        // a previously-registered command owned by this same plugin (e.g. a reload)
+        BungeeBootCommand previous = new BungeeBootCommand(
+                context, rootNamed("server"), mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
+        Map<String, Command> known = new HashMap<>();
+        known.put("server", previous);
+        when(pluginManager.getCommands()).thenReturn(known.entrySet());
+
+        BungeeCommandRegistrar registrar = new BungeeCommandRegistrar(
+                mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
+
+        RegisteredCommandSet set = registrar.register(
+                context, Collections.singletonList(rootNamed("server")));
+
+        assertEquals(1, set.getCommands().size());
+        verify(pluginManager).unregisterCommand(previous);
+        verify(pluginManager).registerCommand(eq(plugin), eq(set.getCommands().get(0)));
     }
 }

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandRegistrarTest.java
@@ -1,0 +1,80 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.plugin.Command;
+import net.md_5.bungee.api.plugin.Plugin;
+import net.md_5.bungee.api.plugin.PluginManager;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.guilhermekaua.spigotboot.commands.CommandPlatformSupport;
+import tech.guilhermekaua.spigotboot.commands.execution.CommandDispatcher;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandAliasSet;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandRegistrarTest {
+
+    private CompiledRootCommand rootNamed(String primary) {
+        CommandAliasSet aliases = mock(CommandAliasSet.class);
+        when(aliases.getPrimary()).thenReturn(primary);
+        when(aliases.getAliases()).thenReturn(Collections.emptyList());
+        CompiledRootCommand root = mock(CompiledRootCommand.class);
+        when(root.getAliases()).thenReturn(aliases);
+        return root;
+    }
+
+    @Test
+    void registersEachRootAndUnregistersThem() {
+        Plugin plugin = mock(Plugin.class);
+        ProxyServer proxy = mock(ProxyServer.class);
+        PluginManager pluginManager = mock(PluginManager.class);
+        when(plugin.getProxy()).thenReturn(proxy);
+        when(proxy.getPluginManager()).thenReturn(pluginManager);
+
+        Context context = mock(Context.class);
+        when(context.getBean(Plugin.class)).thenReturn(plugin);
+
+        BungeeCommandRegistrar registrar = new BungeeCommandRegistrar(
+                mock(CommandDispatcher.class), mock(CommandPlatformSupport.class));
+
+        RegisteredCommandSet set = registrar.register(context, Collections.singletonList(rootNamed("server")));
+
+        assertEquals(1, set.getCommands().size());
+        ArgumentCaptor<Command> captor = ArgumentCaptor.forClass(Command.class);
+        verify(pluginManager).registerCommand(eq(plugin), captor.capture());
+        assertEquals("server", captor.getValue().getName());
+
+        registrar.unregister(context, set);
+        verify(pluginManager).unregisterCommand(set.getCommands().get(0));
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSenderTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandSenderTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import net.md_5.bungee.api.CommandSender;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandSenderTest {
+
+    @Test
+    void playerIdentityIsUuid() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        UUID uuid = UUID.randomUUID();
+        when(player.getName()).thenReturn("Alex");
+        when(player.getUniqueId()).thenReturn(uuid);
+
+        BungeeCommandSender handle = new BungeeCommandSender(player);
+
+        assertEquals("Alex", handle.getName());
+        assertEquals(uuid.toString(), handle.getIdentity());
+    }
+
+    @Test
+    void consoleIdentityFallsBackToClassAndName() {
+        CommandSender console = mock(CommandSender.class);
+        when(console.getName()).thenReturn("CONSOLE");
+
+        BungeeCommandSender handle = new BungeeCommandSender(console);
+
+        assertTrue(handle.getIdentity().endsWith(":CONSOLE"));
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void delegatesPermissionAndMessage() {
+        CommandSender sender = mock(CommandSender.class);
+        when(sender.hasPermission("a.b")).thenReturn(true);
+
+        BungeeCommandSender handle = new BungeeCommandSender(sender);
+
+        assertTrue(handle.hasPermission("a.b"));
+        handle.sendMessage("hi");
+        verify(sender).sendMessage("hi");
+    }
+
+    @Test
+    void unwrapReturnsSenderForAssignableTypeAndEmptyOtherwise() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        BungeeCommandSender handle = new BungeeCommandSender(player);
+
+        Optional<ProxiedPlayer> asPlayer = handle.unwrap(ProxiedPlayer.class);
+        Optional<CommandSender> asSender = handle.unwrap(CommandSender.class);
+        Optional<String> asString = handle.unwrap(String.class);
+
+        assertSame(player, asPlayer.orElse(null));
+        assertSame(player, asSender.orElse(null));
+        assertFalse(asString.isPresent());
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrarTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsContextReadyRegistrarTest.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandRootCompiler;
+import tech.guilhermekaua.spigotboot.commands.route.CompiledRootCommand;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.plugin.BootPlugin;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandsContextReadyRegistrarTest {
+
+    @Test
+    void compilesRegistersAndUnregistersOnShutdown() {
+        CommandRootCompiler compiler = mock(CommandRootCompiler.class);
+        BungeeCommandRegistrar registrar = mock(BungeeCommandRegistrar.class);
+        CommandReplacementRegistry replacementRegistry = mock(CommandReplacementRegistry.class);
+
+        Context context = mock(Context.class);
+        BootPlugin bootPlugin = mock(BootPlugin.class);
+        when(bootPlugin.getName()).thenReturn("TestPlugin");
+        when(context.getPlugin()).thenReturn(bootPlugin);
+
+        CompiledRootCommand root = mock(CompiledRootCommand.class);
+        List<CompiledRootCommand> roots = Collections.singletonList(root);
+        when(compiler.compile(context)).thenReturn(roots);
+        RegisteredCommandSet set = new RegisteredCommandSet(Collections.emptyList());
+        when(registrar.register(context, roots)).thenReturn(set);
+
+        new BungeeCommandsContextReadyRegistrar(compiler, registrar, replacementRegistry).onContextReady(context);
+
+        verify(replacementRegistry).register("plugin.name", "TestPlugin");
+        verify(replacementRegistry).register("plugin", "TestPlugin");
+        verify(registrar).register(context, roots);
+
+        ArgumentCaptor<Runnable> hook = ArgumentCaptor.forClass(Runnable.class);
+        verify(context).registerShutdownHook(hook.capture());
+        hook.getValue().run();
+        verify(registrar).unregister(context, set);
+    }
+
+    @Test
+    void registersNothingWhenNoCommands() {
+        CommandRootCompiler compiler = mock(CommandRootCompiler.class);
+        BungeeCommandRegistrar registrar = mock(BungeeCommandRegistrar.class);
+        CommandReplacementRegistry replacementRegistry = mock(CommandReplacementRegistry.class);
+
+        Context context = mock(Context.class);
+        BootPlugin bootPlugin = mock(BootPlugin.class);
+        when(bootPlugin.getName()).thenReturn("TestPlugin");
+        when(context.getPlugin()).thenReturn(bootPlugin);
+        when(compiler.compile(context)).thenReturn(Collections.emptyList());
+
+        new BungeeCommandsContextReadyRegistrar(compiler, registrar, replacementRegistry).onContextReady(context);
+
+        verify(registrar, never()).register(any(), any());
+        verify(context, never()).registerShutdownHook(any());
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModuleDiscoveryTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeCommandsModuleDiscoveryTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+import tech.guilhermekaua.spigotboot.core.module.ModuleDiscovery;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeeCommandsModuleDiscoveryTest {
+
+    // proves the META-INF/spigot-boot/modules marker resource is present and names the module correctly,
+    // so the framework auto-discovers it exactly as it does BungeeCoreModule.
+    @Test
+    void bungeeCommandsModuleIsAutoDiscoverable() {
+        List<Class<? extends Module>> modules =
+                new ModuleDiscovery(getClass().getClassLoader()).discover();
+
+        assertTrue(modules.contains(BungeeCommandsModule.class),
+                "BungeeCommandsModule must be discoverable via its META-INF/spigot-boot/modules marker");
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizerTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizerTest.java
@@ -85,5 +85,16 @@ class BungeeCommandCompletionRegistryCustomizerTest {
                 registered.get("onlinePlayers").complete(ctx, null, "a"));
         assertEquals(Collections.singletonList("lobby"),
                 registered.get("servers").complete(ctx, null, "l"));
+
+        // empty/null prefix => every candidate (the all-suggestions branch owned by these lambdas).
+        // case-insensitivity is enforced downstream by CompletionResolver, so it is not asserted here.
+        assertEquals(Arrays.asList("Alex", "Bob"),
+                registered.get("onlinePlayers").complete(ctx, null, ""));
+        assertEquals(Arrays.asList("Alex", "Bob"),
+                registered.get("onlinePlayers").complete(ctx, null, null));
+        assertEquals(Arrays.asList("lobby", "survival"),
+                registered.get("servers").complete(ctx, null, ""));
+        assertEquals(Arrays.asList("lobby", "survival"),
+                registered.get("servers").complete(ctx, null, null));
     }
 }

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizerTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/completion/BungeeCommandCompletionRegistryCustomizerTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee.completion;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionProvider;
+import tech.guilhermekaua.spigotboot.commands.CommandCompletionRegistry;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeCommandCompletionRegistryCustomizerTest {
+
+    @Test
+    void registersOnlinePlayersAndServersWithPrefixFiltering() {
+        Plugin plugin = mock(Plugin.class);
+        ProxyServer proxy = mock(ProxyServer.class);
+        when(plugin.getProxy()).thenReturn(proxy);
+
+        ProxiedPlayer alex = mock(ProxiedPlayer.class);
+        ProxiedPlayer bob = mock(ProxiedPlayer.class);
+        when(alex.getName()).thenReturn("Alex");
+        when(bob.getName()).thenReturn("Bob");
+        when(proxy.getPlayers()).thenReturn(Arrays.asList(alex, bob));
+
+        Map<String, ServerInfo> servers = new LinkedHashMap<>();
+        servers.put("lobby", mock(ServerInfo.class));
+        servers.put("survival", mock(ServerInfo.class));
+        when(proxy.getServers()).thenReturn(servers);
+
+        Map<String, CommandCompletionProvider> registered = new HashMap<>();
+        CommandCompletionRegistry registry = new CommandCompletionRegistry() {
+            @Override
+            public void register(String id, CommandCompletionProvider provider) {
+                registered.put(id, provider);
+            }
+
+            @Override
+            public Optional<CommandCompletionProvider> resolve(String id) {
+                return Optional.ofNullable(registered.get(id));
+            }
+        };
+
+        new BungeeCommandCompletionRegistryCustomizer(plugin).customize(registry);
+
+        assertTrue(registered.containsKey("onlinePlayers"));
+        assertTrue(registered.containsKey("servers"));
+
+        CommandExecutionContext ctx = mock(CommandExecutionContext.class);
+        assertEquals(Collections.singletonList("Alex"),
+                registered.get("onlinePlayers").complete(ctx, null, "a"));
+        assertEquals(Collections.singletonList("lobby"),
+                registered.get("servers").complete(ctx, null, "l"));
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolverTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolverTest.java
@@ -31,6 +31,7 @@ import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
 import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -72,7 +73,28 @@ class BungeeProxiedPlayerArgumentResolverTest {
     @Test
     void resolveRejectsUnknownPlayer() {
         when(proxy.getPlayer("Ghost")).thenReturn(null);
+        when(proxy.getPlayers()).thenReturn(Collections.emptyList());
         assertThrows(IllegalArgumentException.class, () -> resolver.resolve(context, parameter, "Ghost"));
+    }
+
+    @Test
+    void resolveAcceptsUniquePrefixMatch() {
+        ProxiedPlayer target = mock(ProxiedPlayer.class);
+        when(target.getName()).thenReturn("Target");
+        when(proxy.getPlayer("Tar")).thenReturn(null);
+        when(proxy.getPlayers()).thenReturn(Collections.singletonList(target));
+        assertSame(target, resolver.resolve(context, parameter, "Tar"));
+    }
+
+    @Test
+    void resolveRejectsAmbiguousPrefixMatch() {
+        ProxiedPlayer target = mock(ProxiedPlayer.class);
+        ProxiedPlayer tango = mock(ProxiedPlayer.class);
+        when(target.getName()).thenReturn("Target");
+        when(tango.getName()).thenReturn("Tango");
+        when(proxy.getPlayer("Ta")).thenReturn(null);
+        when(proxy.getPlayers()).thenReturn(Arrays.asList(target, tango));
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(context, parameter, "Ta"));
     }
 
     @Test

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolverTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeProxiedPlayerArgumentResolverTest.java
@@ -1,0 +1,89 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeProxiedPlayerArgumentResolverTest {
+    private final Plugin plugin = mock(Plugin.class);
+    private final ProxyServer proxy = mock(ProxyServer.class);
+    private final BungeeProxiedPlayerArgumentResolver resolver = new BungeeProxiedPlayerArgumentResolver(plugin);
+    private final CommandExecutionContext context = mock(CommandExecutionContext.class);
+    private final CommandParameterMetadata parameter = new CommandParameterMetadata(
+            null, 0, "target", "target", ProxiedPlayer.class, ProxiedPlayer.class, false, false, false, null, null);
+
+    @BeforeEach
+    void setUp() {
+        when(plugin.getProxy()).thenReturn(proxy);
+    }
+
+    @Test
+    void supportsOnlyProxiedPlayer() {
+        assertTrue(resolver.supports(parameter));
+        CommandParameterMetadata stringParam = new CommandParameterMetadata(
+                null, 0, "s", "s", String.class, String.class, false, false, false, null, null);
+        assertFalse(resolver.supports(stringParam));
+    }
+
+    @Test
+    void resolveReturnsOnlinePlayer() {
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(proxy.getPlayer("Alex")).thenReturn(player);
+        assertSame(player, resolver.resolve(context, parameter, "Alex"));
+    }
+
+    @Test
+    void resolveRejectsUnknownPlayer() {
+        when(proxy.getPlayer("Ghost")).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(context, parameter, "Ghost"));
+    }
+
+    @Test
+    void defaultCompletionProviderListsOnlinePlayers() {
+        ProxiedPlayer a = mock(ProxiedPlayer.class);
+        ProxiedPlayer b = mock(ProxiedPlayer.class);
+        when(a.getName()).thenReturn("Alex");
+        when(b.getName()).thenReturn("Bob");
+        when(proxy.getPlayers()).thenReturn(Arrays.asList(a, b));
+
+        List<String> names = resolver.defaultCompletionProvider().complete(context, parameter, "");
+        assertEquals(Arrays.asList("Alex", "Bob"), names);
+    }
+}

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolverTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolverTest.java
@@ -34,6 +34,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -56,6 +57,9 @@ class BungeeServerArgumentResolverTest {
     @Test
     void supportsOnlyServerInfo() {
         assertTrue(resolver.supports(parameter));
+        CommandParameterMetadata stringParam = new CommandParameterMetadata(
+                null, 0, "s", "s", String.class, String.class, false, false, false, null, null);
+        assertFalse(resolver.supports(stringParam));
     }
 
     @Test

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolverTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/resolve/BungeeServerArgumentResolverTest.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.commands.bungee.resolve;
+
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.config.ServerInfo;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.commands.CommandExecutionContext;
+import tech.guilhermekaua.spigotboot.commands.metadata.CommandParameterMetadata;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class BungeeServerArgumentResolverTest {
+    private final Plugin plugin = mock(Plugin.class);
+    private final ProxyServer proxy = mock(ProxyServer.class);
+    private final BungeeServerArgumentResolver resolver = new BungeeServerArgumentResolver(plugin);
+    private final CommandExecutionContext context = mock(CommandExecutionContext.class);
+    private final CommandParameterMetadata parameter = new CommandParameterMetadata(
+            null, 0, "server", "server", ServerInfo.class, ServerInfo.class, false, false, false, null, null);
+
+    @BeforeEach
+    void setUp() {
+        when(plugin.getProxy()).thenReturn(proxy);
+    }
+
+    @Test
+    void supportsOnlyServerInfo() {
+        assertTrue(resolver.supports(parameter));
+    }
+
+    @Test
+    void resolveReturnsServer() {
+        ServerInfo lobby = mock(ServerInfo.class);
+        when(proxy.getServerInfo("lobby")).thenReturn(lobby);
+        assertSame(lobby, resolver.resolve(context, parameter, "lobby"));
+    }
+
+    @Test
+    void resolveRejectsUnknownServer() {
+        when(proxy.getServerInfo("void")).thenReturn(null);
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(context, parameter, "void"));
+    }
+
+    @Test
+    void defaultCompletionProviderListsServers() {
+        Map<String, ServerInfo> servers = new LinkedHashMap<>();
+        servers.put("lobby", mock(ServerInfo.class));
+        servers.put("survival", mock(ServerInfo.class));
+        when(proxy.getServers()).thenReturn(servers);
+
+        List<String> names = resolver.defaultCompletionProvider().complete(context, parameter, "");
+        assertTrue(names.contains("lobby"));
+        assertTrue(names.contains("survival"));
+    }
+}

--- a/platform-bungee/pom.xml
+++ b/platform-bungee/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>core-bungee</module>
+        <module>commands-bungee</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary

Adds `platform-bungee/commands-bungee` (`spigot-boot-commands-bungee`) — the BungeeCord adapter for the generic `commands` framework, mirroring `platform-spigot/commands-spigot`.

- **`BungeeBootCommand extends Command implements TabExecutor`** bridges native `execute`/`onTabComplete` to the generic `CommandDispatcher`. The base command carries a **null permission**, so the dispatcher owns per-route `@Permission` enforcement for both dispatch and completion (same end-state as Spigot's `getPermission()→null`).
- **`BungeeCommandPlatformSupport` / `BungeeCommandSender`** implement the platform seam (`CommandPlatformSupport` / `CommandSenderHandle`); identity is the UUID for `ProxiedPlayer`, else a console identity.
- **`BungeeCommandRegistrar` + `RegisteredCommandSet`** register/unregister via BungeeCord's public `PluginManager.registerCommand`/`unregisterCommand` — no CommandMap reflection (so no `BukkitCommandMapAccessor` analogue).
- **`BungeeCommandsContextReadyRegistrar`** (`Ordered` 1000) compiles command beans and registers them on context-ready, with a shutdown hook to unregister.
- **`ProxiedPlayer` and `ServerInfo` argument resolvers** + **`onlinePlayers` / `servers` tab-completions** (resolvers inject the native `Plugin`; reachable because `BungeeCoreModule` registers it).
- **`BungeeCommandsConfiguration`** (`@Configuration`) re-declares the 8 platform-support-dependent pipeline beans + the Bungee glue; the 13 platform-neutral beans come free from the generic `CommandsConfiguration`.
- No `maven-shade-plugin`, no javassist, no `animal-sniffer` (this module targets the Bungee API, ships no proxies). Pure-Mockito tests (no MockBukkit/MockBungee).

Design spec: `docs/superpowers/specs/2026-06-15-bungeecord-commands-design.md`
Plan: `docs/superpowers/plans/2026-06-15-bungeecord-commands.md`

## Stacking / dependencies

Stacked on **#72** (core-bungee v1). This PR is based on `worktree-bungeecord-core-bungee`; once #72 merges, GitHub auto-retargets it to `dev`. The `platform-bungee/pom.xml` `<modules>` edit is the expected trivial merge point with the sibling **config-bungee** effort. `commands-config-bungee` (the `CommandTextResolver`→config bridge) is intentionally out of scope (needs a future `config-bungee`).

## Test plan

- [x] `mvnw.cmd -pl platform-bungee/commands-bungee -am -Danimal.sniffer.skip=true test` → **25 tests, 0 failures** across 11 test classes (platform support, sender, boot command, registrar, context-ready registrar, both resolvers, completion customizer, module discovery, and an end-to-end dispatch+completion test).
- [x] `mvnw.cmd -Danimal.sniffer.skip=true install -DskipTests` → **BUILD SUCCESS** (all 9 modules incl. `spigot-boot-commands-bungee`).
- [ ] On-server validation deferred until a `bungee.yml` generator + sample plugin exist (separate slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)