### PR TITLE
feat(bungee): config-bungee — BungeeCord configuration adapter (v1)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-bungeecord-config.md
+++ b/docs/superpowers/plans/2026-06-15-bungeecord-config.md
@@ -1,0 +1,1115 @@
+# BungeeCord config-bungee (v1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `platform-bungee/config-bungee` adapter module that gives BungeeCord plugins the full Spigot Boot configuration framework — `@Config` live-reload, `@ConfigValue`, `@OnConfigReload`, `@FolderConfig`, and `${...}` references — at full parity with `config-spigot`, in a relocation-safe shaded jar.
+
+**Architecture:** The generic `spigot-boot-config` core (annotations, `Binder`, refs, node tree, `ConfigLoader`/`ConfigSource`, serializer registry) is reused unchanged. `config-bungee` is a 1:1 port of `platform-spigot/config-spigot`'s platform layer into the `tech.guilhermekaua.spigotboot.config.bungee` package: SnakeYAML-direct loader/node, the javassist `ConfigProxy`, the manager + registry + folder + injector + reference + reload subsystems, DI wiring, and a `Module` + discovery marker. The **only** platform delta is the plugin seam (`net.md_5.bungee.api.plugin.Plugin` instead of `org.bukkit.plugin.Plugin`, `getResourceAsStream` instead of `getResource`) and dropping the Bukkit serializers (keeping only `Duration`). Because `ConfigProxy` uses the javassist API directly, the module shades `javassist` -> the relocated package and proves relocation safety with a packaging-phase integration test.
+
+**Tech Stack:** Java 8 bytecode (tests Java 17), Maven. `tech.guilhermekaua.spigot-boot:spigot-boot-config` + `spigot-boot-core-bungee` (compile), `org.javassist:javassist:3.30.2-GA` (provided), `net.md-5:bungeecord-api:1.21-R0.3` (provided, inherited). SnakeYAML is transitively present (no new dependency). JUnit 5 + Mockito 5 inherited from the root pom. Spec: `docs/superpowers/specs/2026-06-15-bungeecord-config-design.md`.
+
+**Build/JDK notes (read once):**
+- Build with **JDK 21** (`JAVA_HOME` must point at JDK 21, not 25 — Lombok 1.18.36 crashes on 25).
+- All commands run from the worktree root: `C:\Users\Guilherme\IdeaProjects\spigot-boot\.claude\worktrees\bungeecord-config`.
+- Always pass `-Danimal.sniffer.skip=true`: `config-bungee` does not declare the animal-sniffer 1.8.8 check, but `-am` pulls in upstream Bukkit-facing modules that do, and a stale 1.8.8 signature must never block the build.
+- For filtered `-Dtest=...` runs that may match no tests in some upstream module, add `-Dsurefire.failIfNoSpecifiedTests=false`.
+- The root `license-maven-plugin` enforces the MIT header. **Every new `.java` file MUST begin with the MIT header** (the `Copyright © 2025 Guilherme Kauã da Silva` block, present verbatim atop every source file in `config-spigot`). All ported files already carry it; for the few new files written here, the header is shown inline.
+- `config-bungee` and `core-bungee` already exist in this worktree (the reactor builds them). The sibling `commands-bungee` effort edits the same `platform-bungee/pom.xml` `<modules>` list — a trivial merge conflict there is expected.
+
+## The standard Bungee port transform
+
+Most of this module is a **verbatim port** of `config-spigot` source files. Re-listing
+~5000 lines inline would invite transcription errors; instead each port task names the
+exact source file(s) under `platform-spigot/config-spigot/src/...` and the exact target
+path(s) under `platform-bungee/config-bungee/src/...`, and you apply this transform. It is
+exhaustive — there is nothing else to change. Every port task ends with a compile + test
+run + a leftover-reference grep that catches any miss.
+
+Throughout this plan, `…/config/spigot/` is shorthand for
+`platform-spigot/config-spigot/src/{main,test}/java/tech/guilhermekaua/spigotboot/config/spigot/`
+and `…/config/bungee/` for
+`platform-bungee/config-bungee/src/{main,test}/java/tech/guilhermekaua/spigotboot/config/bungee/`.
+The exact full paths appear in the `File Structure` section and in every `git add` command.
+
+Apply to every copied file (main and test):
+
+1. **Package + imports:** replace `tech.guilhermekaua.spigotboot.config.spigot` with
+   `tech.guilhermekaua.spigotboot.config.bungee` in the `package` statement and in every
+   `import` (and in the directory path, so the file lands in the mirrored package).
+2. **Class renames** (declaration, filename, and every reference across all files):
+   - `SpigotConfigManager` -> `BungeeConfigManager`
+   - `SpigotConfigReferenceLookup` -> `BungeeConfigReferenceLookup`
+   - `SpigotConfigModule` -> `BungeeConfigModule`
+   - `BukkitSerializers` -> `BungeeConfigSerializers`
+3. **Plugin type** (appears in exactly three main files — `ConfigConfiguration`,
+   `SpigotConfigManager`, `FolderConfigEntry` — and in the tests that mock it): replace
+   `import org.bukkit.plugin.Plugin;` with `import net.md_5.bungee.api.plugin.Plugin;`.
+   The `Plugin` simple name and all its uses (`getDataFolder()`, `getLogger()`,
+   `getClassLoader()`) stay identical — both APIs share those signatures.
+4. **Plugin resource method** (exactly two call-sites: `SpigotConfigManager` and
+   `FolderConfigEntry`): change `plugin.getResource(` to `plugin.getResourceAsStream(`.
+   **Do NOT** change `...getClassLoader().getResource(` in `FolderConfigEntry` — that is
+   the `ClassLoader` API (returns a `URL`) and is unchanged.
+5. **MIT header:** keep it verbatim. The one source file that lacks it
+   (`ConfigConfiguration.java`) gets the header added in its target (shown in Task 9).
+
+Files NOT ported (they cover dropped Bukkit serializers): `serialization/MaterialSerializer.java`,
+`serialization/SoundSerializer.java`, `serialization/WorldSerializer.java`,
+`serialization/LocationSerializer.java`, and the tests
+`serialization/SoundSerializerTest.java`, `test/binding/MaterialSerializerBindingTest.java`.
+
+---
+
+## File Structure
+
+**Created (module + new files):**
+- `platform-bungee/config-bungee/pom.xml` — module pom: compiler (main 1.8 / tests 17), the javassist relocation shade execution, the failsafe relocation guard, and dependencies.
+- `platform-bungee/config-bungee/src/main/resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigModule` — empty discovery marker.
+- `platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/BungeeConfigSerializers.java` — Duration-only serializer registrar (replaces `BukkitSerializers`).
+- `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/serialization/DurationSerializerTest.java` — new unit test for the ported `DurationSerializer`.
+- `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeModuleDiscoveryTest.java` — proves the marker resolves `BungeeConfigModule`.
+- `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxyRelocationIT.java` — failsafe packaging-phase relocation guard.
+
+**Created (ported 1:1 from `config-spigot`, package `…config.bungee`):**
+- main: `BungeeConfigManager` (was `SpigotConfigManager`), `ConfigBindingCoordinator`, `ConfigEntryAccessor`, `BungeeConfigModule` (was `SpigotConfigModule`), `configuration/ConfigConfiguration`, `loader/YamlConfigLoader`, `node/YamlConfigNode`, `proxy/ConfigProxy`, `registry/ConfigRegistry`, `folder/FolderConfigEntry`, `folder/DefaultFolderConfigRef`, `folder/DefaultFolderConfigEditor`, `folder/DefaultFolderConfigSnapshot`, `injector/ConfigRefInjector`, `injector/FolderConfigInjector`, `injector/ConfigValueInjector`, `injector/ConfigValueResolver`, `reference/ConfigReferenceManager`, `reference/ReferenceResolvingPreprocessor`, `reference/BungeeConfigReferenceLookup` (was `SpigotConfigReferenceLookup`), `reload/OnConfigReloadProcessor`, `reload/OnConfigReloadBinder`, `reload/OnConfigReloadInvoker`, `serialization/DurationSerializer`.
+- tests: `test/node/YamlConfigNodeTest`, `test/loader/YamlConfigLoaderTest`, `test/proxy/ConfigProxyTest`, `test/folder/FolderConfigEntryTest`, `test/manager/SpigotConfigManagerTest` -> `BungeeConfigManagerTest`, `test/manager/SpigotConfigManagerValueAccessTest` -> `BungeeConfigManagerValueAccessTest`, `test/manager/SpigotConfigManagerFolderItemTypesTest` -> `BungeeConfigManagerFolderItemTypesTest`, `test/binding/ConfigEnumListBindingTest`, `test/registry/ConfigRegistryTest`, `test/injector/ConfigValueInjectorTest`, `test/injector/ConfigValueResolverTest`, `test/reference/ReferenceResolvingPreprocessorTest`, `test/reload/OnConfigReloadBinderTest`, `test/reload/OnConfigReloadInvokerTest`, `test/reload/OnConfigReloadProcessorTest`, `test/reload/OnConfigReloadProcessorIntegrationTest`, `test/configuration/ConfigConfigurationTest`.
+
+**Modified:**
+- `platform-bungee/pom.xml` — add `<module>config-bungee</module>` to `<modules>`.
+
+---
+
+## Task 1: Scaffold the `config-bungee` module
+
+**Files:**
+- Create: `platform-bungee/config-bungee/pom.xml`
+- Modify: `platform-bungee/pom.xml` — add the module
+
+- [ ] **Step 1: Create the module pom `platform-bungee/config-bungee/pom.xml`**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>tech.guilhermekaua.spigot-boot</groupId>
+        <artifactId>spigot-boot-platform-bungee</artifactId>
+        <version>3.2.1-SNAPSHOT</version>
+    </parent>
+
+    <name>${project.artifactId}</name>
+    <description>BungeeCord implementation of Spigot Boot configuration system.</description>
+    <url>https://github.com/guikaua12/spigot-boot</url>
+    <artifactId>spigot-boot-config-bungee</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
+                        <path>
+                            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+                            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <!-- ConfigProxy uses the javassist proxy API directly. javassist ships only as the
+                 relocated copy bundled inside spigot-boot-core, so this module's own bytecode must
+                 reference the shaded names too; otherwise it throws NoClassDefFoundError:
+                 javassist/util/proxy/* at runtime. nothing is bundled here (core owns the shaded
+                 javassist) — this execution only rewrites this module's references. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <!-- version managed by the parent pluginManagement (3.5.1) -->
+                <executions>
+                    <execution>
+                        <id>relocate-javassist-references</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <!-- include only this module's own classes so nothing is bundled; the execution
+                                 exists purely to rewrite this module's javassist references to the shaded package. -->
+                            <artifactSet>
+                                <includes>
+                                    <include>tech.guilhermekaua.spigot-boot:spigot-boot-config-bungee</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>javassist</pattern>
+                                    <shadedPattern>tech.guilhermekaua.spigotboot.shaded.javassist</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- runs *IT tests in the integration-test phase (after package/shade) so the relocation
+                 guard can inspect the SHADED jar; surefire (test phase) excludes *IT by default. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <project.build.directory>${project.build.directory}</project.build.directory>
+                        <project.build.finalName>${project.build.finalName}</project.build.finalName>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- ConfigProxy uses the javassist proxy API; provided (never bundled) because the relocated
+             copy is supplied at runtime by spigot-boot-core and this module's references are rewritten
+             to the shaded package by the shade execution above. -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.30.2-GA</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+            <!-- version + provided scope inherited from the platform-bungee parent's dependencyManagement -->
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- runtime pairing: a plugin pulling in config-bungee also gets the Bungee bootstrap and the
+             Plugin bean producer (BungeeCoreModule). Mirrors config-spigot depending on core-spigot. -->
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-core-bungee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+Note: JUnit 5 + Mockito and the surefire 3.5.3 config (with the junit5 tree reporter) are
+inherited from the **root** pom — do not redeclare them. `javassist` resolves at `provided`
+scope for the IT/tests too.
+
+- [ ] **Step 2: Register the module in `platform-bungee/pom.xml`**
+
+In `platform-bungee/pom.xml`, add `config-bungee` to the `<modules>` block, after
+`core-bungee`:
+
+```xml
+    <modules>
+        <module>core-bungee</module>
+        <module>config-bungee</module>
+    </modules>
+```
+
+(If the sibling `commands-bungee` effort already added its module here, keep all entries —
+this is the expected trivial merge point.)
+
+- [ ] **Step 3: Verify the scaffolding resolves and compiles**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true compile`
+Expected: `BUILD SUCCESS`. The module has no sources yet, so the compiler reports "No sources to compile" — that is fine. This proves `javassist`, `bungeecord-api`, `spigot-boot-config`, and `spigot-boot-core-bungee` all resolve and the reactor wiring is correct. The `compile` phase does not run the shade/failsafe executions (bound to `package`/`verify`), so an empty module is fine here.
+
+If `bungeecord-api:1.21-R0.3` fails to resolve (it should not — `core-bungee` already consumes it in this reactor), fall back to the Sonatype snapshot repo: add a `<repositories>` entry to `platform-bungee/pom.xml` with id `sonatype-oss-snapshots`, url `https://oss.sonatype.org/content/repositories/snapshots`, and change the managed version to `1.21-R0.1-SNAPSHOT`. Re-run.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add platform-bungee/pom.xml platform-bungee/config-bungee/pom.xml
+git commit -m "build(bungee): scaffold config-bungee module with javassist shade + failsafe"
+```
+
+---
+
+## Task 2: Port the YAML loader + node
+
+**Files:**
+- Create: `platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/node/YamlConfigNode.java`
+- Create: `platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/loader/YamlConfigLoader.java`
+- Test: `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/node/YamlConfigNodeTest.java`
+- Test: `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/loader/YamlConfigLoaderTest.java`
+
+- [ ] **Step 1: Port the two test files (apply the standard transform)**
+
+Copy, applying the standard port transform (package only — these are platform-neutral):
+- `…/config/spigot/test/node/YamlConfigNodeTest.java` -> `…/config/bungee/test/node/YamlConfigNodeTest.java`
+- `…/config/spigot/test/loader/YamlConfigLoaderTest.java` -> `…/config/bungee/test/loader/YamlConfigLoaderTest.java`
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=YamlConfigNodeTest,YamlConfigLoaderTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — `YamlConfigNode` / `YamlConfigLoader` do not exist yet.
+
+- [ ] **Step 3: Port the two implementation files (apply the standard transform)**
+
+Copy, applying the standard port transform (package only — no `Plugin`/`org.bukkit` here):
+- `…/config/spigot/node/YamlConfigNode.java` -> `…/config/bungee/node/YamlConfigNode.java`
+- `…/config/spigot/loader/YamlConfigLoader.java` -> `…/config/bungee/loader/YamlConfigLoader.java`
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=YamlConfigNodeTest,YamlConfigLoaderTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS — all tests in both ported classes green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/node/YamlConfigNode.java platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/loader/YamlConfigLoader.java platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/node/YamlConfigNodeTest.java platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/loader/YamlConfigLoaderTest.java
+git commit -m "feat(bungee): port YAML config loader and node to config-bungee"
+```
+
+---
+
+## Task 3: Port `ConfigProxy` (javassist)
+
+**Files:**
+- Create: `platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxy.java`
+- Test: `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/proxy/ConfigProxyTest.java`
+
+- [ ] **Step 1: Port the test (apply the standard transform)**
+
+Copy, applying the standard port transform (package only):
+- `…/config/spigot/test/proxy/ConfigProxyTest.java` -> `…/config/bungee/test/proxy/ConfigProxyTest.java`
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=ConfigProxyTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — `ConfigProxy` does not exist yet.
+
+- [ ] **Step 3: Port the implementation (apply the standard transform)**
+
+Copy, applying the standard port transform (package only — the `import javassist.util.proxy.*` lines stay **unchanged** in source; they are rewritten to the shaded package later, at `package` phase, by the shade execution):
+- `…/config/spigot/proxy/ConfigProxy.java` -> `…/config/bungee/proxy/ConfigProxy.java`
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=ConfigProxyTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS — all tests green. (At this phase `javassist` is on the test classpath as the original package, so the proxy works in tests; relocation safety is proven separately in Task 10.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxy.java platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/proxy/ConfigProxyTest.java
+git commit -m "feat(bungee): port ConfigProxy (javassist) to config-bungee"
+```
+
+---
+
+## Task 4: Duration serializer + `BungeeConfigSerializers`
+
+**Files:**
+- Create: `platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/DurationSerializer.java`
+- Create: `platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/BungeeConfigSerializers.java`
+- Test: `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/serialization/DurationSerializerTest.java`
+
+- [ ] **Step 1: Write the failing test**
+
+`platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/serialization/DurationSerializerTest.java`:
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.serialization;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
+import tech.guilhermekaua.spigotboot.config.bungee.node.YamlConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.serialization.DurationSerializer;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DurationSerializerTest {
+
+    private final DurationSerializer serializer = new DurationSerializer();
+
+    @Test
+    void deserializesHumanReadableUnits() {
+        assertEquals(Duration.ofMillis(500), serializer.deserialize(new YamlConfigNode("500ms"), Duration.class));
+        assertEquals(Duration.ofSeconds(30), serializer.deserialize(new YamlConfigNode("30s"), Duration.class));
+        assertEquals(Duration.ofMinutes(5), serializer.deserialize(new YamlConfigNode("5m"), Duration.class));
+        assertEquals(Duration.ofHours(2), serializer.deserialize(new YamlConfigNode("2h"), Duration.class));
+        assertEquals(Duration.ofDays(1), serializer.deserialize(new YamlConfigNode("1d"), Duration.class));
+        assertEquals(Duration.ofDays(7), serializer.deserialize(new YamlConfigNode("1w"), Duration.class));
+    }
+
+    @Test
+    void deserializesPlainNumberAsSeconds() {
+        assertEquals(Duration.ofSeconds(45), serializer.deserialize(new YamlConfigNode(45), Duration.class));
+    }
+
+    @Test
+    void rejectsInvalidFormat() {
+        assertThrows(SerializationException.class,
+                () -> serializer.deserialize(new YamlConfigNode("not-a-duration"), Duration.class));
+    }
+
+    @Test
+    void serializesToCompactUnit() {
+        YamlConfigNode node = new YamlConfigNode();
+        serializer.serialize(Duration.ofMinutes(5), node);
+        assertEquals("5m", node.raw());
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=DurationSerializerTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — `DurationSerializer` does not exist yet.
+
+- [ ] **Step 3: Port `DurationSerializer` (apply the standard transform)**
+
+Copy, applying the standard port transform (package only — it is platform-neutral):
+- `…/config/spigot/serialization/DurationSerializer.java` -> `…/config/bungee/serialization/DurationSerializer.java`
+
+- [ ] **Step 4: Write `BungeeConfigSerializers` (replaces `BukkitSerializers`)**
+
+`platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/BungeeConfigSerializers.java`:
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.serialization;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistry;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Registers BungeeCord-appropriate type serializers. BungeeCord has no Material/Sound/World/Location
+ * equivalents, so unlike the Spigot {@code BukkitSerializers} only the platform-neutral
+ * {@link Duration} serializer is registered.
+ */
+public final class BungeeConfigSerializers {
+
+    private BungeeConfigSerializers() {
+    }
+
+    /**
+     * Registers all BungeeCord serializers to the given registry.
+     *
+     * @param registry the registry to populate
+     */
+    public static void registerAll(@NotNull TypeSerializerRegistry registry) {
+        Objects.requireNonNull(registry, "registry cannot be null");
+
+        registry.register(Duration.class, new DurationSerializer());
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=DurationSerializerTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/DurationSerializer.java platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/BungeeConfigSerializers.java platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/serialization/DurationSerializerTest.java
+git commit -m "feat(bungee): add Duration serializer and BungeeConfigSerializers"
+```
+
+---
+
+## Task 5: Port the folder-config subsystem
+
+**Files:**
+- Create: `…/config/bungee/folder/FolderConfigEntry.java` (seam: `Plugin` + `getResourceAsStream`)
+- Create: `…/config/bungee/folder/DefaultFolderConfigRef.java`
+- Create: `…/config/bungee/folder/DefaultFolderConfigEditor.java`
+- Create: `…/config/bungee/folder/DefaultFolderConfigSnapshot.java`
+- Test: `…/config/bungee/test/folder/FolderConfigEntryTest.java`
+
+(All paths under `platform-bungee/config-bungee/src/...`.)
+
+- [ ] **Step 1: Port the test (apply the standard transform)**
+
+Copy, applying the standard port transform. `FolderConfigEntryTest` mocks the plugin, so
+apply transform rule 3 (`org.bukkit.plugin.Plugin` -> `net.md_5.bungee.api.plugin.Plugin`):
+- `…/config/spigot/test/folder/FolderConfigEntryTest.java` -> `…/config/bungee/test/folder/FolderConfigEntryTest.java`
+
+Note: if any test stub calls `plugin.getResource(...)`, change it to
+`plugin.getResourceAsStream(...)` (transform rule 4). Leave any
+`getClassLoader().getResource(...)` untouched.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=FolderConfigEntryTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — the `folder` classes do not exist yet.
+
+- [ ] **Step 3: Port the four implementation files (apply the standard transform)**
+
+Copy, applying the standard port transform:
+- `…/config/spigot/folder/DefaultFolderConfigSnapshot.java` -> `…/config/bungee/folder/DefaultFolderConfigSnapshot.java` (package only)
+- `…/config/spigot/folder/DefaultFolderConfigEditor.java` -> `…/config/bungee/folder/DefaultFolderConfigEditor.java` (package only)
+- `…/config/spigot/folder/DefaultFolderConfigRef.java` -> `…/config/bungee/folder/DefaultFolderConfigRef.java` (package only)
+- `…/config/spigot/folder/FolderConfigEntry.java` -> `…/config/bungee/folder/FolderConfigEntry.java` — **seam**: apply transform rules 3 (Plugin type) and 4 (`plugin.getResource(` -> `plugin.getResourceAsStream(` at the single `plugin.getResource` call-site). The `pluginObject.getClass().getClassLoader().getResource(resourcePath)` call stays unchanged.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=FolderConfigEntryTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS — all tests in `FolderConfigEntryTest` green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/ platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/folder/
+git commit -m "feat(bungee): port folder-config support to config-bungee"
+```
+
+---
+
+## Task 6: Port the config manager + reference engine
+
+**Files:**
+- Create: `…/config/bungee/BungeeConfigManager.java` (was `SpigotConfigManager`; seam: `Plugin` + `getResourceAsStream`)
+- Create: `…/config/bungee/ConfigBindingCoordinator.java`
+- Create: `…/config/bungee/ConfigEntryAccessor.java`
+- Create: `…/config/bungee/reference/ConfigReferenceManager.java`
+- Create: `…/config/bungee/reference/ReferenceResolvingPreprocessor.java`
+- Create: `…/config/bungee/reference/BungeeConfigReferenceLookup.java` (was `SpigotConfigReferenceLookup`)
+- Test: `…/config/bungee/test/manager/BungeeConfigManagerTest.java`
+- Test: `…/config/bungee/test/manager/BungeeConfigManagerValueAccessTest.java`
+- Test: `…/config/bungee/test/manager/BungeeConfigManagerFolderItemTypesTest.java`
+- Test: `…/config/bungee/test/reference/ReferenceResolvingPreprocessorTest.java`
+
+(`ConfigEnumListBindingTest` is ported later, in Task 7, where the full manager + injector
+stack it may touch is present.)
+
+- [ ] **Step 1: Port the test files (apply the standard transform)**
+
+Copy, applying the standard port transform. The three manager tests are renamed
+(`SpigotConfigManager*Test` -> `BungeeConfigManager*Test`, transform rule 2) and their
+`Plugin` mocks swapped (rule 3):
+- `…/config/spigot/test/manager/SpigotConfigManagerTest.java` -> `…/config/bungee/test/manager/BungeeConfigManagerTest.java`
+- `…/config/spigot/test/manager/SpigotConfigManagerValueAccessTest.java` -> `…/config/bungee/test/manager/BungeeConfigManagerValueAccessTest.java`
+- `…/config/spigot/test/manager/SpigotConfigManagerFolderItemTypesTest.java` -> `…/config/bungee/test/manager/BungeeConfigManagerFolderItemTypesTest.java`
+- `…/config/spigot/test/reference/ReferenceResolvingPreprocessorTest.java` -> `…/config/bungee/test/reference/ReferenceResolvingPreprocessorTest.java`
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=BungeeConfigManagerTest,BungeeConfigManagerValueAccessTest,BungeeConfigManagerFolderItemTypesTest,ReferenceResolvingPreprocessorTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — `BungeeConfigManager` and the reference classes do not exist yet.
+
+- [ ] **Step 3: Port the implementation files (apply the standard transform)**
+
+Copy, applying the standard port transform:
+- `…/config/spigot/ConfigEntryAccessor.java` -> `…/config/bungee/ConfigEntryAccessor.java` (package + rule 2 renames where `SpigotConfigManager` is referenced)
+- `…/config/spigot/ConfigBindingCoordinator.java` -> `…/config/bungee/ConfigBindingCoordinator.java` (package + rule 2)
+- `…/config/spigot/reference/ReferenceResolvingPreprocessor.java` -> `…/config/bungee/reference/ReferenceResolvingPreprocessor.java` (package + rule 2)
+- `…/config/spigot/reference/SpigotConfigReferenceLookup.java` -> `…/config/bungee/reference/BungeeConfigReferenceLookup.java` (package + rule 2: rename the class to `BungeeConfigReferenceLookup` and all references)
+- `…/config/spigot/reference/ConfigReferenceManager.java` -> `…/config/bungee/reference/ConfigReferenceManager.java` (package + rule 2; it references the lookup type)
+- `…/config/spigot/SpigotConfigManager.java` -> `…/config/bungee/BungeeConfigManager.java` — **seam**: apply rule 2 (class rename), rule 3 (Plugin type: import + field + all three constructors), and rule 4 (`plugin.getResource(` -> `plugin.getResourceAsStream(` at the single call-site). `plugin.getDataFolder()` is unchanged.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=BungeeConfigManagerTest,BungeeConfigManagerValueAccessTest,BungeeConfigManagerFolderItemTypesTest,ReferenceResolvingPreprocessorTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS — all tests across the four classes green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeConfigManager.java platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/ConfigBindingCoordinator.java platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/ConfigEntryAccessor.java platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reference/ platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/manager/ platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reference/
+git commit -m "feat(bungee): port BungeeConfigManager and reference engine"
+```
+
+---
+
+## Task 7: Port the config registry + DI injectors
+
+**Files:**
+- Create: `…/config/bungee/registry/ConfigRegistry.java`
+- Create: `…/config/bungee/injector/ConfigRefInjector.java`
+- Create: `…/config/bungee/injector/FolderConfigInjector.java`
+- Create: `…/config/bungee/injector/ConfigValueInjector.java`
+- Create: `…/config/bungee/injector/ConfigValueResolver.java`
+- Test: `…/config/bungee/test/registry/ConfigRegistryTest.java`
+- Test: `…/config/bungee/test/injector/ConfigValueInjectorTest.java`
+- Test: `…/config/bungee/test/injector/ConfigValueResolverTest.java`
+- Test: `…/config/bungee/test/binding/ConfigEnumListBindingTest.java`
+
+- [ ] **Step 1: Port the test files (apply the standard transform)**
+
+Copy, applying the standard port transform (package + rule 2 renames; the injector tests
+mock the `Plugin`, so apply rule 3). `ConfigEnumListBindingTest` only needs the `Plugin`
+import swap (rule 3) — its enum is a plain Java enum:
+- `…/config/spigot/test/registry/ConfigRegistryTest.java` -> `…/config/bungee/test/registry/ConfigRegistryTest.java`
+- `…/config/spigot/test/injector/ConfigValueInjectorTest.java` -> `…/config/bungee/test/injector/ConfigValueInjectorTest.java`
+- `…/config/spigot/test/injector/ConfigValueResolverTest.java` -> `…/config/bungee/test/injector/ConfigValueResolverTest.java`
+- `…/config/spigot/test/binding/ConfigEnumListBindingTest.java` -> `…/config/bungee/test/binding/ConfigEnumListBindingTest.java`
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=ConfigRegistryTest,ConfigValueInjectorTest,ConfigValueResolverTest,ConfigEnumListBindingTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — the registry/injector classes do not exist yet.
+
+- [ ] **Step 3: Port the implementation files (apply the standard transform)**
+
+Copy, applying the standard port transform (package + rule 2; none of these reference
+`Plugin` directly — `ConfigRegistry` uses `Context.getPlugin()`):
+- `…/config/spigot/injector/ConfigRefInjector.java` -> `…/config/bungee/injector/ConfigRefInjector.java`
+- `…/config/spigot/injector/FolderConfigInjector.java` -> `…/config/bungee/injector/FolderConfigInjector.java`
+- `…/config/spigot/injector/ConfigValueResolver.java` -> `…/config/bungee/injector/ConfigValueResolver.java`
+- `…/config/spigot/injector/ConfigValueInjector.java` -> `…/config/bungee/injector/ConfigValueInjector.java`
+- `…/config/spigot/registry/ConfigRegistry.java` -> `…/config/bungee/registry/ConfigRegistry.java`
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=ConfigRegistryTest,ConfigValueInjectorTest,ConfigValueResolverTest,ConfigEnumListBindingTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS — all tests across the four classes green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/registry/ platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/ platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/registry/ platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/injector/ platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/binding/
+git commit -m "feat(bungee): port config registry and DI injectors"
+```
+
+---
+
+## Task 8: Port the `@OnConfigReload` subsystem
+
+**Files:**
+- Create: `…/config/bungee/reload/OnConfigReloadProcessor.java`
+- Create: `…/config/bungee/reload/OnConfigReloadBinder.java`
+- Create: `…/config/bungee/reload/OnConfigReloadInvoker.java`
+- Test: `…/config/bungee/test/reload/OnConfigReloadBinderTest.java`
+- Test: `…/config/bungee/test/reload/OnConfigReloadInvokerTest.java`
+- Test: `…/config/bungee/test/reload/OnConfigReloadProcessorTest.java`
+- Test: `…/config/bungee/test/reload/OnConfigReloadProcessorIntegrationTest.java`
+
+- [ ] **Step 1: Port the test files (apply the standard transform)**
+
+Copy, applying the standard port transform (package + rule 2;
+`OnConfigReloadProcessorIntegrationTest` mocks the `Plugin`, so apply rule 3):
+- `…/config/spigot/test/reload/OnConfigReloadBinderTest.java` -> `…/config/bungee/test/reload/OnConfigReloadBinderTest.java`
+- `…/config/spigot/test/reload/OnConfigReloadInvokerTest.java` -> `…/config/bungee/test/reload/OnConfigReloadInvokerTest.java`
+- `…/config/spigot/test/reload/OnConfigReloadProcessorTest.java` -> `…/config/bungee/test/reload/OnConfigReloadProcessorTest.java`
+- `…/config/spigot/test/reload/OnConfigReloadProcessorIntegrationTest.java` -> `…/config/bungee/test/reload/OnConfigReloadProcessorIntegrationTest.java`
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=OnConfigReloadBinderTest,OnConfigReloadInvokerTest,OnConfigReloadProcessorTest,OnConfigReloadProcessorIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — the reload classes do not exist yet.
+
+- [ ] **Step 3: Port the implementation files (apply the standard transform)**
+
+Copy, applying the standard port transform (package + rule 2; `OnConfigReloadProcessor`
+takes a `Logger`, not a `Plugin`, so no Plugin-type change is needed inside these files):
+- `…/config/spigot/reload/OnConfigReloadInvoker.java` -> `…/config/bungee/reload/OnConfigReloadInvoker.java`
+- `…/config/spigot/reload/OnConfigReloadBinder.java` -> `…/config/bungee/reload/OnConfigReloadBinder.java`
+- `…/config/spigot/reload/OnConfigReloadProcessor.java` -> `…/config/bungee/reload/OnConfigReloadProcessor.java`
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=OnConfigReloadBinderTest,OnConfigReloadInvokerTest,OnConfigReloadProcessorTest,OnConfigReloadProcessorIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS — all tests across the four classes green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reload/ platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/
+git commit -m "feat(bungee): port @OnConfigReload support to config-bungee"
+```
+
+---
+
+## Task 9: DI configuration + module + discovery marker
+
+**Files:**
+- Create: `…/config/bungee/configuration/ConfigConfiguration.java` (seam: Plugin type + Duration serializer bean)
+- Create: `…/config/bungee/BungeeConfigModule.java` (was `SpigotConfigModule`)
+- Create: `…/config/bungee/../resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigModule` (empty marker)
+- Test: `…/config/bungee/test/configuration/ConfigConfigurationTest.java`
+- Test: `…/config/bungee/BungeeModuleDiscoveryTest.java`
+
+- [ ] **Step 1: Write the failing tests**
+
+Port `ConfigConfigurationTest`, applying the standard transform (package + rule 2 renames
+`SpigotConfigManager` -> `BungeeConfigManager`; rule 3 swaps the `Plugin` mock):
+- `…/config/spigot/test/configuration/ConfigConfigurationTest.java` -> `…/config/bungee/test/configuration/ConfigConfigurationTest.java`
+
+Then write the new module-discovery test (mirrors core-bungee's `BungeeModuleDiscoveryTest`):
+
+`platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeModuleDiscoveryTest.java`:
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+import tech.guilhermekaua.spigotboot.core.module.ModuleDiscovery;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeeModuleDiscoveryTest {
+
+    // proves the META-INF/spigot-boot/modules marker resource is present and names the module correctly,
+    // so SpigotBootBuilder.autoDiscover() picks it up exactly as it does SpigotConfigModule on Spigot.
+    @Test
+    void bungeeConfigModuleIsAutoDiscoverable() {
+        List<Class<? extends Module>> modules =
+                new ModuleDiscovery(getClass().getClassLoader()).discover();
+
+        assertTrue(modules.contains(BungeeConfigModule.class),
+                "BungeeConfigModule must be discoverable via its META-INF/spigot-boot/modules marker");
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=ConfigConfigurationTest,BungeeModuleDiscoveryTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: COMPILE FAILURE — `ConfigConfiguration` / `BungeeConfigModule` do not exist yet.
+
+- [ ] **Step 3: Write `BungeeConfigModule` (port of `SpigotConfigModule`)**
+
+`platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeConfigModule.java`:
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.bungee.registry.ConfigRegistry;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Order;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+
+import java.util.logging.Logger;
+
+/**
+ * Spigot Boot module providing configuration management on BungeeCord.
+ * <p>
+ * Scans for {@code @Config} and {@code @FolderConfig} annotated classes, loads configs, and
+ * registers them as beans. Mirrors the Spigot {@code SpigotConfigModule}.
+ * <p>
+ * Runs early (after {@code BungeeCoreModule}, which registers the plugin at {@code @Order(-1000)},
+ * but before default-order modules) so that {@code @Config} beans are registered before any later
+ * module resolves a component that depends on them.
+ */
+@Order(-500)
+public class BungeeConfigModule implements Module {
+
+    @Override
+    public void onInitialize(@NotNull Context context) throws Exception {
+        Logger logger = context.getPlugin().getLogger();
+
+        logger.info("Initializing Config Module...");
+
+        context.getBean(ConfigRegistry.class)
+                .registerConfigs(context);
+
+        logger.info("Config Module initialized.");
+
+        context.registerShutdownHook(() -> {
+            logger.info("Config Module shutting down...");
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Write `ConfigConfiguration` (port of the Spigot one, Plugin + Duration deltas)**
+
+`platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/configuration/ConfigConfiguration.java`:
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.configuration;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceErrorHandler;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistry;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigRefInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigValueInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.FolderConfigInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadProcessor;
+import tech.guilhermekaua.spigotboot.config.bungee.serialization.BungeeConfigSerializers;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Bean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Configuration;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjectorRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.core.context.dependency.postprocessor.BeanPostProcessorRegistryCustomizer;
+
+import java.util.List;
+
+@Configuration
+public class ConfigConfiguration {
+    @Bean
+    public BungeeConfigManager configManager(
+            Plugin plugin,
+            @Nullable ConfigReferenceErrorHandler errorHandler,
+            List<TypeSerializerRegistryCustomizer> serializerCustomizers
+    ) {
+        return new BungeeConfigManager(plugin, errorHandler, serializerCustomizers);
+    }
+
+    @Bean
+    public CustomInjectorRegistryCustomizer configInjectors(BungeeConfigManager configManager) {
+        return (registry) -> {
+            registry.register(new FolderConfigInjector(configManager));
+            registry.register(new ConfigRefInjector(configManager));
+            registry.register(new ConfigValueInjector(configManager));
+        };
+    }
+
+    @Bean
+    public BeanPostProcessorRegistryCustomizer onConfigReloadProcessor(BungeeConfigManager configManager, Plugin plugin) {
+        return registry -> registry.register(new OnConfigReloadProcessor(configManager, plugin.getLogger()));
+    }
+
+    @Bean
+    public TypeSerializerRegistryCustomizer bungeeTypeSerializers() {
+        return new TypeSerializerRegistryCustomizer() {
+            @Override
+            public void customize(@NotNull TypeSerializerRegistry registry) {
+                BungeeConfigSerializers.registerAll(registry);
+            }
+
+            @Override
+            public int getOrder() {
+                return -100;
+            }
+        };
+    }
+}
+```
+
+- [ ] **Step 5: Create the empty discovery marker**
+
+File: `platform-bungee/config-bungee/src/main/resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigModule`
+
+Content: an empty file (zero bytes). The file *name* is the module FQCN; `ModuleDiscovery`
+reads the name, not the contents.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true test -Dtest=ConfigConfigurationTest,BungeeModuleDiscoveryTest -Dsurefire.failIfNoSpecifiedTests=false`
+Expected: PASS — `ConfigConfigurationTest` (2 tests) + `BungeeModuleDiscoveryTest` (1 test). If `BungeeModuleDiscoveryTest` fails, confirm the marker file landed in `target/classes/META-INF/spigot-boot/modules/` with the exact FQCN as its name (no extension, no trailing newline in the name).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/configuration/ConfigConfiguration.java platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeConfigModule.java "platform-bungee/config-bungee/src/main/resources/META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigModule" platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/configuration/ConfigConfigurationTest.java platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeModuleDiscoveryTest.java
+git commit -m "feat(bungee): wire config-bungee DI configuration and module discovery"
+```
+
+---
+
+## Task 10: Relocation guard — prove the shaded jar is javassist-safe
+
+**Files:**
+- Test: `platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxyRelocationIT.java`
+
+- [ ] **Step 1: Write the failsafe integration test**
+
+`platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxyRelocationIT.java`:
+
+```java
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for the shaded-javassist NoClassDefFoundError. {@code ConfigProxy} uses the
+ * javassist proxy API directly, so its pre-shade bytecode legitimately references {@code javassist/};
+ * only the PACKAGED (shaded) jar must be clean. A normal surefire test runs against the un-shaded
+ * {@code target/classes} and cannot catch this — so this is a failsafe {@code *IT} bound to the
+ * {@code verify} phase (after {@code package}/shade), inspecting the produced jar.
+ */
+class ConfigProxyRelocationIT {
+
+    private static final String SHADED_PREFIX = "tech/guilhermekaua/spigotboot/shaded/javassist/";
+    private static final String CONFIG_PROXY_ENTRY =
+            "tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxy.class";
+
+    @Test
+    void packagedConfigProxyReferencesOnlyShadedJavassist() throws IOException {
+        String buildDir = System.getProperty("project.build.directory");
+        String finalName = System.getProperty("project.build.finalName");
+        assertNotNull(buildDir, "project.build.directory must be supplied by the failsafe plugin");
+        assertNotNull(finalName, "project.build.finalName must be supplied by the failsafe plugin");
+
+        Path jar = Path.of(buildDir, finalName + ".jar");
+        assertTrue(Files.exists(jar),
+                "shaded jar not found at " + jar + " — run the package/verify phase, not just test");
+
+        byte[] bytes;
+        try (ZipFile zip = new ZipFile(jar.toFile())) {
+            ZipEntry entry = zip.getEntry(CONFIG_PROXY_ENTRY);
+            assertNotNull(entry, CONFIG_PROXY_ENTRY + " not found inside " + jar);
+            try (InputStream in = zip.getInputStream(entry)) {
+                bytes = in.readAllBytes();
+            }
+        }
+
+        // constant-pool type references use the slashed internal form (javassist/util/proxy/...);
+        // decode byte-preserving so they appear verbatim as substrings.
+        String pool = new String(bytes, StandardCharsets.ISO_8859_1);
+
+        assertTrue(pool.contains(SHADED_PREFIX),
+                "ConfigProxy.class must reference the relocated javassist package " + SHADED_PREFIX
+                        + " in the packaged jar (relocation did not run)");
+
+        // strip the shaded prefix first: the relocated form ITSELF contains the substring "javassist/",
+        // so a naive contains("javassist/") would false-match. what must not remain is any un-relocated ref.
+        String withoutShaded = pool.replace(SHADED_PREFIX, "");
+        assertFalse(withoutShaded.contains("javassist/"),
+                "ConfigProxy.class still references the un-relocated javassist package in the packaged jar");
+    }
+}
+```
+
+- [ ] **Step 2: Run the packaging build so the IT executes against the shaded jar**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true verify`
+Expected: `BUILD SUCCESS`. The `package` phase runs surefire (all unit tests green) then the `relocate-javassist-references` shade execution; the `integration-test`/`verify` phases then run `ConfigProxyRelocationIT` against `target/spigot-boot-config-bungee-3.2.1-SNAPSHOT.jar`, which passes only because `ConfigProxy.class` inside the jar references `tech/guilhermekaua/spigotboot/shaded/javassist/` and nothing un-relocated.
+
+Sanity check it actually guards: temporarily remove the `<relocations>` block from the shade execution in `platform-bungee/config-bungee/pom.xml` and re-run the command — `ConfigProxyRelocationIT` must now FAIL (proving the guard has teeth). Restore the `<relocations>` block before committing.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxyRelocationIT.java
+git commit -m "test(bungee): guard ConfigProxy javassist relocation in the shaded jar"
+```
+
+---
+
+## Task 11: Full-module + reactor verification
+
+**Files:** none (verification gate; all code already committed).
+
+- [ ] **Step 1: Run the full module suite (unit + integration)**
+
+Run: `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true verify`
+Expected: `BUILD SUCCESS` — every ported unit test green and `ConfigProxyRelocationIT` green.
+
+- [ ] **Step 2: Confirm no un-ported references leaked into the new subtree**
+
+Run: `git grep -nE "config\.spigot|org\.bukkit" -- platform-bungee/config-bungee/src`
+Expected: **no output**. Any hit means a copied file kept a `config.spigot` import/reference or an `org.bukkit` import — fix it (it indicates a missed transform rule 1, 2, or 3) and re-run Step 1.
+
+- [ ] **Step 3: Verify the whole reactor still builds and installs**
+
+Run: `mvnw.cmd -Danimal.sniffer.skip=true install -DskipTests`
+Expected: `BUILD SUCCESS` for every module including `spigot-boot-config-bungee`. The shade execution runs during `install` and produces the relocation-safe jar in the local repo. This confirms adding the new module did not disturb the existing reactor.
+
+---
+
+## Done criteria
+
+- `mvnw.cmd -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true verify` is green — all ported unit tests pass AND `ConfigProxyRelocationIT` proves the packaged `ConfigProxy.class` references only the shaded javassist package.
+- `git grep -nE "config\.spigot|org\.bukkit" -- platform-bungee/config-bungee/src` returns nothing (the port is clean: no leftover Spigot package refs, no Bukkit API).
+- `mvnw.cmd -Danimal.sniffer.skip=true install -DskipTests` builds and installs the full reactor including `spigot-boot-config-bungee`.
+- A BungeeCord plugin author (already booting via `core-bungee`) can declare `@Config`, `@FolderConfig`, `@ConfigValue`, and `@OnConfigReload` classes and have them loaded, injected, live-reloaded, and reference-resolved exactly as on Spigot — using SnakeYAML-backed YAML files under the plugin's data folder, with the Duration serializer available.
+
+## Out of scope (later slices, separate plans)
+
+- Extracting a shared `config-platform-common` module to de-duplicate the platform-neutral classes copied between config-spigot and config-bungee.
+- Bungee-specific serializers (`ServerInfo`, chat `BaseComponent`/`ChatColor`).
+- On-proxy end-to-end validation inside a runnable BungeeCord sample plugin (depends on the `bungee.yml` descriptor-generator slice).

--- a/docs/superpowers/specs/2026-06-15-bungeecord-config-design.md
+++ b/docs/superpowers/specs/2026-06-15-bungeecord-config-design.md
@@ -1,0 +1,405 @@
+# BungeeCord Support: config-bungee (v1) Design
+
+Date: 2026-06-15
+Status: Approved design, pending spec review
+Target module: `platform-bungee/config-bungee` (new), artifactId `spigot-boot-config-bungee`
+
+## Background
+
+Spigot Boot is a multi-module framework whose heavy logic already lives in
+platform-agnostic modules. The configuration framework is one of them: the generic
+`config` module (artifactId `spigot-boot-config`) owns **everything that is not
+platform-specific** — the annotations (`@Config`, `@FolderConfig`, `@ConfigValue`,
+`@OnConfigReload`, `@Comment`, `@NodeKey`, …), the reflection `Binder`, the
+`ConfigRef`/`FolderConfigRef`/`FolderConfigSnapshot` interfaces, the `${...}` reference
+engine, the `ConfigNode`/`MutableConfigNode` tree abstraction, the
+`ConfigLoader`/`ConfigSource` seam, and the `TypeSerializer`/`TypeSerializerRegistry`
+registry. It has **no Bukkit dependency, no javassist, and no YAML library** of its own
+(verified: a grep for `javassist|Bukkit|snakeyaml` over `config/src/main` returns
+nothing).
+
+Each platform supplies a thin **adapter** that plugs into those seams. Today only
+Spigot/Paper exists, under `platform-spigot/config-spigot` (artifactId
+`spigot-boot-config-spigot`). That adapter is the reference implementation this spec
+mirrors.
+
+This effort adds the BungeeCord configuration adapter, **`config-bungee` v1**. It is the
+third BungeeCord slice (after `core-bungee`, which this module builds on). Like the other
+slices it gets its own spec -> plan -> implementation cycle.
+
+**Scope: full parity with `config-spigot`.** v1 ships the complete feature set —
+single `@Config` classes with live-reload proxies, `@ConfigValue` injection,
+`@OnConfigReload` callbacks, `@FolderConfig` directory-backed collections, and `${...}`
+cross-config references — so config-bungee is a drop-in peer to config-spigot, differing
+only in the small platform seam (below) and in dropping the Bukkit-specific serializers.
+
+## YAML backend decision
+
+**config-bungee uses SnakeYAML directly, exactly as config-spigot does — it does
+*not* use `net.md_5.bungee.config.*`.** This is the load-bearing decision of the whole
+design, because it overturns the intuitive framing ("map the core onto BungeeCord's
+`Configuration`/`ConfigurationProvider`").
+
+The intuition is wrong because **config-spigot does not use Bukkit's `FileConfiguration`
+either.** Verified by reading every file in `platform-spigot/config-spigot/src/main`:
+there are **zero** references to `org.bukkit.configuration.*`. All YAML I/O is done
+straight through SnakeYAML (`org.yaml.snakeyaml.Yaml`) in `YamlConfigLoader`, with a
+hand-rolled comment-aware writer and a `YamlConfigNode` (a `MutableConfigNode` over plain
+`Map`/`List`/scalar values). The platform config API is bypassed entirely on both sides.
+
+So the *true* mirror is to bypass `net.md_5.bungee.config.*` as well and reuse the same
+SnakeYAML approach. BungeeCord bundles SnakeYAML 2.2 (it is a transitive dependency of the
+runtime via `net.md-5:bungeecord-config`), so `YamlConfigLoader`/`YamlConfigNode` port
+across **verbatim** — no new runtime dependency, no behavioral change.
+
+Using `net.md_5.bungee.config.Configuration` instead was considered and rejected: it would
+*reduce* reuse (a bespoke `ConfigLoader`/`ConfigNode` over BungeeCord's `Configuration`),
+lose YAML comment preservation (BungeeCord's `YamlConfiguration` does not round-trip
+comments), force manual handling of its divergences (single `Configuration` type with no
+`ConfigurationSection`, no `copyDefaults` merge, a public mutable `self` map), and make
+config-bungee structurally *diverge* from config-spigot rather than mirror it.
+
+## Goals
+
+- A Bungee plugin (already booting via `core-bungee`) can declare `@Config`,
+  `@FolderConfig`, `@ConfigValue`, and `@OnConfigReload` classes and have them loaded,
+  bound, injected, and live-reloaded — identically to config-spigot.
+- Directly-injected `@Config` beans transparently reflect reloads, via the same javassist
+  `ConfigProxy` mechanism config-spigot uses.
+- `${configName:path}` cross-config references resolve, with the same topological reload
+  ordering and cycle detection.
+- The packaged jar is **relocation-safe**: its javassist references point only at the
+  shaded package `tech.guilhermekaua.spigotboot.shaded.javassist`, proven by an automated
+  packaging-phase check.
+- Bungee users never import a class named "Spigot" in normal usage (config beans are
+  injected; the module is auto-discovered).
+
+## Non-goals (v1)
+
+- **No use of `net.md_5.bungee.config.*`.** See "YAML backend decision".
+- **No Bukkit-world serializers.** `Material`/`Sound`/`World`/`Location` have no
+  BungeeCord equivalent and are dropped. Only the platform-neutral `Duration` serializer
+  is ported (see Components → serialization).
+- **No extraction of a shared `config-platform-common` module.** Full parity means the
+  platform-neutral classes config-spigot keeps locally (binder coordinator, folder impls,
+  reference manager, loader/node) are *copied* into config-bungee, not refactored out of
+  config-spigot. De-duplication is deferred (see Roadmap); per the effort's ground rule,
+  all new code lives in the `platform-bungee/config-bungee/**` subtree and config-spigot
+  is left untouched.
+- **No new config features.** This is a port, not a redesign; behavior matches
+  config-spigot one-for-one (minus the dropped serializers).
+
+## Reuse analysis (grounding)
+
+Verified by reading the seams (`config/src/main`, `platform-spigot/config-spigot/src`,
+`platform-bungee/core-bungee/src`):
+
+- **Reused unchanged (the complex code):** the entire `spigot-boot-config` core — all
+  annotations, `Binder`/`DefaultBinder`, `NamingStrategy`, `ConfigRef`/`DefaultConfigRef`,
+  the folder and reference *interfaces*, `ConfigNode`/`MutableConfigNode`/
+  `AbstractValueConfigNode`/`SnapshotConfigNode`, `ConfigLoader`/`ConfigSource` (whose
+  built-in `FileConfigSource`/`ResourceConfigSource` are pure `java.nio`/classloader, no
+  Bukkit), `TypeSerializer`/`TypeSerializerRegistry`, the exceptions, and the build-time
+  discovery (`@SpigotBootDiscoveryCategory`, `DiscoveryIndexReader`, `ClassPathScanner`).
+  Also reused: the generic `core` DI seams (`Module`, `@Component`, `@Configuration`,
+  `@Bean`, `@Order`, `CustomInjector`/`CustomInjectorRegistryCustomizer`,
+  `BeanPostProcessor`/`BeanPostProcessorRegistryCustomizer`, `Context`,
+  `DependencyManager`) and `utils` (`ProxyUtils`). All arrive transitively through
+  `spigot-boot-config`.
+- **Reused from `core-bungee`:** at runtime the `Plugin` bean config-bungee injects is the
+  one `BungeeCoreModule` registers (`net.md_5.bungee.api.plugin.Plugin`). config-bungee
+  depends on `spigot-boot-core-bungee` so a plugin pulling in config-bungee also gets the
+  Bungee bootstrap (ergonomic parity with config-spigot, which pulls in `core-spigot`).
+- **New, near-mechanical copies (platform-neutral, but duplicated here per the no-shared-
+  module rule):** the YAML loader/node, the proxy, the binding coordinator, the folder
+  impls, the reference manager + preprocessor, and the reload subsystem.
+- **New, genuinely platform-specific:** the `Plugin` seam (data folder + resource
+  loading), the DI `@Configuration` wiring (injects the Bungee `Plugin`), the module +
+  marker, the reference lookup (delegates to the Bungee manager), and the Duration-only
+  serializer customizer.
+
+### The platform seam (the entire Bungee delta)
+
+config-spigot couples to the platform in exactly four spots; everything else is
+format/DI/reflection that is already platform-neutral.
+
+| config-spigot | config-bungee |
+|---|---|
+| injects `org.bukkit.plugin.Plugin` | injects `net.md_5.bungee.api.plugin.Plugin` (registered by `BungeeCoreModule`) |
+| `plugin.getResource(name)` | `plugin.getResourceAsStream(name)` |
+| `plugin.getDataFolder()`, `getLogger()`, `getClassLoader()`, `getMainClass()` | identical signatures on the Bungee `Plugin` |
+| `serialization/` Bukkit serializers + `core-spigot` `TypeUtil`/`SoundCompat` | dropped; only a ported `DurationSerializer` remains |
+
+## Architecture
+
+### Module & Maven structure (mirror config-spigot under platform-bungee)
+
+```
+platform-bungee/                 packaging: pom (existing; add config-bungee to <modules>)
+  pom.xml
+  config-bungee/                 artifactId: spigot-boot-config-bungee (new)
+    pom.xml
+    src/main/java/tech/guilhermekaua/spigotboot/config/bungee/...
+    src/main/resources/META-INF/spigot-boot/modules/<BungeeConfigModule FQCN>
+    src/test/java/...
+```
+
+`platform-bungee/pom.xml` is the **only aggregator edited** (add
+`<module>config-bungee</module>`). The sibling `commands-bungee` effort edits the same
+`<modules>` list, so a trivial merge conflict there is expected and benign. The root
+reactor already lists `platform-bungee`, so no root `pom.xml` edit is needed.
+
+### Package
+
+`tech.guilhermekaua.spigotboot.config.bungee` (mirrors `...config.spigot`), with the same
+subpackages: `configuration/`, `loader/`, `node/`, `proxy/`, `registry/`, `folder/`,
+`injector/`, `reference/`, `reload/`, `serialization/`.
+
+### Dependencies & DI wiring
+
+`config-bungee` dependencies:
+
+- `tech.guilhermekaua.spigot-boot:spigot-boot-config` (compile) — the generic SPI; brings
+  `spigot-boot-core` and `utils` transitively.
+- `tech.guilhermekaua.spigot-boot:spigot-boot-core-bungee` (compile) — runtime pairing and
+  ergonomic parity (a plugin adding config-bungee gets the Bungee bootstrap and the
+  `Plugin` bean producer). No direct compile symbol is required from it; the dependency is
+  intentional, not accidental.
+- `org.javassist:javassist:3.30.2-GA` (**provided**) — `ConfigProxy` uses the javassist
+  proxy API directly. Never bundled; the relocated copy is supplied at runtime by
+  `spigot-boot-core`, and this module's references are rewritten to the shaded package by
+  the shade execution (see "Shading & relocation safety").
+- `net.md-5:bungeecord-api:1.21-R0.3` (**provided**, version inherited from the
+  `platform-bungee` parent's `dependencyManagement`).
+- Lombok + `spigot-boot-annotation-processor-spigot` as annotation processors (provided/
+  optional), mirroring config-spigot and core-bungee.
+- JUnit 5 + Mockito inherited `test`-scoped from the root pom (do not redeclare).
+
+Compiler: main → Java **1.8**, tests → **17**, `-parameters`. **No `animal-sniffer`
+plugin** — config-bungee follows core-bungee (a Bungee module does not target the Spigot
+1.8.8 API). The `-Danimal.sniffer.skip=true` flag still appears in build commands because
+`-am` pulls in upstream Bukkit-facing modules that do run the check.
+
+DI wiring mirrors config-spigot's `ConfigConfiguration`: a `@Configuration` declares the
+`BungeeConfigManager` bean (constructor-injecting the Bungee `Plugin`, an optional
+`ConfigReferenceErrorHandler`, and the collected `List<TypeSerializerRegistryCustomizer>`),
+registers the three custom injectors via a `CustomInjectorRegistryCustomizer`, registers
+the `@OnConfigReload` post-processor via a `BeanPostProcessorRegistryCustomizer`, and
+registers the Duration serializer via a `TypeSerializerRegistryCustomizer`.
+
+## Components
+
+Full parity = a one-to-one port of config-spigot's classes into the
+`tech.guilhermekaua.spigotboot.config.bungee` package, renaming the `Spigot*` types to
+`Bungee*` and applying the platform seam. Classes marked **copy** are platform-neutral and
+ported near-verbatim (only the package statement and imports change); classes marked
+**seam** carry the Bungee delta.
+
+| config-spigot class | config-bungee class | kind | notes |
+|---|---|---|---|
+| `SpigotConfigModule` (`@Order(-500)`, `Module`) | `BungeeConfigModule` | seam | same `@Order(-500)`; `onInitialize` runs `ConfigRegistry.registerConfigs`; ships its own empty marker |
+| `SpigotConfigManager implements ConfigManager` | `BungeeConfigManager implements ConfigManager` | seam | injects Bungee `Plugin`; `register(...)` resolves `plugin.getDataFolder()` + default-copy via `plugin.getResourceAsStream(...)` |
+| `ConfigBindingCoordinator` (pkg-private) | `ConfigBindingCoordinator` | copy | bind/rebind orchestration over `ReferenceKey` |
+| `ConfigEntryAccessor` (pkg-private) | `ConfigEntryAccessor` | copy | encapsulation callback |
+| `configuration/ConfigConfiguration` | `configuration/ConfigConfiguration` | seam | `@Bean`s wire the manager + injectors + post-processor + Duration serializer |
+| `loader/YamlConfigLoader` | `loader/YamlConfigLoader` | copy | SnakeYAML `Yaml.load`/comment-aware writer/atomic temp-move |
+| `node/YamlConfigNode` | `node/YamlConfigNode` | copy | `MutableConfigNode` over `Map`/`List`/scalars + comments |
+| `proxy/ConfigProxy` | `proxy/ConfigProxy` | copy | javassist `ProxyFactory` + `MethodHandler`; the reason this module shades |
+| `registry/ConfigRegistry` (`@Component`) | `registry/ConfigRegistry` | copy | scans `@Config`/`@FolderConfig`, builds proxies, registers DI beans, `initializeAll()` |
+| `folder/FolderConfigEntry` | `folder/FolderConfigEntry` | seam | swap `Plugin` type + `getResourceAsStream`; folder scan/bind/reload/save/delete |
+| `folder/DefaultFolderConfigRef`/`Editor`/`Snapshot` | same names | copy | folder ref/editor/snapshot impls |
+| `injector/ConfigRefInjector`/`FolderConfigInjector`/`ConfigValueInjector`/`ConfigValueResolver` | same names | copy | resolve against `BungeeConfigManager` |
+| `reference/ConfigReferenceManager` | `reference/ConfigReferenceManager` | copy | parser/resolver/scanner + dependency graph + reload propagation |
+| `reference/ReferenceResolvingPreprocessor` | same name | copy | `ConfigNodePreprocessor` plugged into the `Binder` |
+| `reference/SpigotConfigReferenceLookup` | `reference/BungeeConfigReferenceLookup` | seam | delegates to `BungeeConfigManager`/`FolderConfigEntry` for roots/paths/keys |
+| `reload/OnConfigReloadProcessor`/`OnConfigReloadBinder`/`OnConfigReloadInvoker` | same names | copy | wires `@OnConfigReload` callbacks (uses `ProxyUtils.getRealClass`) |
+| `serialization/BukkitSerializers` + 5 serializers | `serialization/BungeeConfigSerializers` + `DurationSerializer` | seam | **only** Duration survives; Material/Sound/World/Location dropped |
+| `META-INF/spigot-boot/modules/...SpigotConfigModule` (empty) | `...BungeeConfigModule` (empty) | seam | filename is the FQCN; `ModuleDiscovery` reads the name |
+
+### `BungeeConfigManager implements ConfigManager`
+
+The heart of the adapter, mirroring `SpigotConfigManager`. It implements every
+`ConfigManager` method (`get`/`getRef`/`getFolderConfig`/`register`/`reload`/`reloadAll`/
+`save`/`generateDefaults`/`getSerializerRegistry` and the value-access overloads), and
+keeps the Spigot-side extras the injectors/registry/reference-lookup rely on
+(`registerFolderConfig`, `initializeAll`, `deserializeAt`, `coerceDefault`,
+`getConfigName`, `getConfigNode`, …). It constructs a `YamlConfigLoader`, a
+`TypeSerializerRegistry.defaults()` with applied customizers, a `Binder` built with the
+reference preprocessor as its `ConfigNodePreprocessor`, a `ConfigReferenceManager`, and a
+`ConfigBindingCoordinator`. **The only Bungee delta** is the `Plugin` type:
+`register(Class)` resolves `plugin.getDataFolder().toPath().resolve(filePath)` and, when
+generating defaults, copies from `plugin.getResourceAsStream(resource|value)`.
+
+### `serialization/BungeeConfigSerializers` + `DurationSerializer`
+
+`BungeeConfigSerializers` is the `TypeSerializerRegistryCustomizer` analogue of
+`BukkitSerializers`; its `getOrder()` matches (`-100`) and `registerAll` registers only the
+ported `DurationSerializer`. `DurationSerializer` is copied from config-spigot unchanged —
+it is platform-neutral (`java.time.Duration`, available on Java 8) and currently only
+rides into config-spigot via `BukkitSerializers`. The four Bukkit serializers are dropped:
+they depend on `org.bukkit.*` and `core-spigot` helpers (`TypeUtil`, `SoundCompat`) that
+have no BungeeCord meaning.
+
+### `BungeeConfigModule` + marker
+
+`implements Module`, `@Order(-500)` (after `BungeeCoreModule`'s `-1000`, which registers
+the `Plugin` bean, but before default-order modules — so `@Config` beans exist before any
+later module resolves a config-dependent component). `onInitialize` calls
+`context.getBean(ConfigRegistry.class).registerConfigs(context)` and registers a shutdown
+hook. Auto-discovered via the empty marker resource
+`META-INF/spigot-boot/modules/tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigModule`,
+exactly as config-spigot ships its marker.
+
+## Shading & relocation safety
+
+This is the heaviest part of the module and a first-class concern. `ConfigProxy` imports
+`javassist.util.proxy.{ProxyFactory, MethodHandler, ProxyObject}` and uses them directly
+(it is the **"creating proxies"** case from CLAUDE.md, not the detection-only case). Inside
+a downstream plugin jar the only javassist present is the copy `spigot-boot-core` bundles
+relocated to `tech.guilhermekaua.spigotboot.shaded.javassist`; the original `javassist.*`
+classes are never shipped. So config-bungee's own bytecode must reference the **shaded**
+names, or it throws `NoClassDefFoundError: javassist/util/proxy/...` on a real proxy server
+while passing tests (where the original javassist is still on the classpath).
+
+### Shade execution (mirror config-spigot exactly)
+
+A `maven-shade-plugin` execution `relocate-javassist-references`, phase `package`, goal
+`shade`:
+
+```xml
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-shade-plugin</artifactId>
+    <!-- version managed by the parent pluginManagement -->
+    <executions>
+        <execution>
+            <id>relocate-javassist-references</id>
+            <phase>package</phase>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+                <createDependencyReducedPom>true</createDependencyReducedPom>
+                <!-- include only this module's own classes so nothing is bundled; the execution
+                     exists purely to rewrite this module's javassist references to the shaded package. -->
+                <artifactSet>
+                    <includes>
+                        <include>tech.guilhermekaua.spigot-boot:spigot-boot-config-bungee</include>
+                    </includes>
+                </artifactSet>
+                <relocations>
+                    <relocation>
+                        <pattern>javassist</pattern>
+                        <shadedPattern>tech.guilhermekaua.spigotboot.shaded.javassist</shadedPattern>
+                    </relocation>
+                </relocations>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
+
+Bundling nothing (the `<artifactSet>` includes only this module's own coordinates) keeps
+`core` the sole owner of the bundled relocated javassist; the execution only rewrites this
+module's references. javassist stays `provided`.
+
+### Relocation guard (why surefire cannot catch this, and what does)
+
+The `utils` module's `ProxyUtilsTest#proxyUtilsClassMustNotReferenceUnrelocatedJavassistPackage`
+guards the *detection* case by asserting the compiled class carries **no** slashed
+`javassist/` reference — it works in the `test` phase because `ProxyUtils` never imports
+javassist. **That exact test would be wrong for `ConfigProxy`:** `ConfigProxy` *does*
+import javassist, so its pre-shade bytecode (in `target/classes`, which is what runs during
+`test`) legitimately contains `javassist/`. Only the **shaded jar** (produced in `package`,
+after tests) should be clean. A surefire test therefore cannot prove relocation safety.
+
+The guard is a `maven-failsafe-plugin` integration test, **`ConfigProxyRelocationIT`**,
+bound to the `verify` phase (after `package`/shade). It:
+
+1. Locates the shaded artifact `target/<finalName>.jar` (the `project.build.directory` and
+   `project.build.finalName` are passed in via failsafe `systemPropertyVariables`).
+2. Opens the `…/config/bungee/proxy/ConfigProxy.class` zip entry and reads its bytes.
+3. Decodes them as ISO-8859-1 (byte-preserving) so constant-pool type descriptors appear
+   verbatim as substrings.
+4. Asserts the bytes **contain** `tech/guilhermekaua/spigotboot/shaded/javassist/`
+   (relocation happened), then **strips that shaded prefix** and asserts the remainder
+   contains **no** `javassist/` (no un-relocated reference survives). The strip-first step
+   is essential: a naive `contains("javassist/")` would match the shaded form itself, since
+   `…/shaded/javassist/…` contains the substring `javassist/`.
+
+The IT reads a jar file and scans bytes only — it needs neither javassist nor
+bungeecord-api on its classpath. The plan's Done criteria additionally runs a packaging
+build (`mvnw … verify`/`install`) as the human-visible proof.
+
+## User-facing usage
+
+config beans are auto-discovered and injected; the only wiring an author does is what
+`core-bungee` already requires. Given a booted context (from `BungeeBoot.initialize(...)`),
+a `@Config` class is loaded and injectable:
+
+```java
+@Config("messages.yml")
+public class Messages {
+    private String prefix = "&7[Proxy]";
+    private Duration joinCooldown = Duration.ofSeconds(5);
+    // getters...
+}
+
+@Component
+public class JoinHandler {
+    private final Messages messages;          // a live-reloading proxy
+
+    @Inject
+    public JoinHandler(Messages messages) {
+        this.messages = messages;
+    }
+
+    @OnConfigReload(Messages.class)
+    public void onReload() {
+        // called after messages.yml reloads
+    }
+}
+```
+
+`@ConfigValue`, `@FolderConfig`/`FolderConfigRef`, and `${configName:path}` references all
+behave exactly as documented for config-spigot.
+
+## Testing strategy
+
+Pure JUnit 5 + Mockito (mock `net.md_5.bungee.api.plugin.Plugin`, `@TempDir` for data
+folders) — no MockBukkit (none exists for Bungee, and config-spigot does not use it
+either). Port config-spigot's ~15 test classes with the `Plugin` mock swapped to the Bungee
+type, covering: manager register/get/reload lifecycle and collision handling; YAML
+loader round-trips (tricky scalars, comments); node mutation; proxy
+`toString/hashCode/equals` interception + delegation; registry discovery and field-modifier
+validation; folder-config load/order/enabled/id-injection/reload/save/delete and
+path-traversal guards; the three injectors; the `@OnConfigReload` binder/invoker/processor;
+reference resolution + type-mismatch firing; and Duration serialization. Add:
+
+- `BungeeModuleDiscoveryTest` — proves the marker resource resolves `BungeeConfigModule`
+  (mirrors core-bungee's `BungeeModuleDiscoveryTest`).
+- `DurationSerializerTest` — deserialize/serialize/round-trip.
+- `ConfigProxyRelocationIT` — the failsafe packaging-phase relocation guard (above).
+
+## Open items to pin at plan time (not blockers)
+
+1. **javassist coordinates** — declared with an explicit version `3.30.2-GA` at `provided`
+   scope (not managed in any parent), exactly as config-spigot declares it.
+2. **bungeecord-api repository fallback** — if `1.21-R0.3` does not resolve from Maven
+   Central, fall back to the Sonatype snapshot repo + `1.21-R0.1-SNAPSHOT`, carried over
+   from the core-bungee plan.
+3. **`DurationSerializer` Java-8 cleanliness** — `java.time.Duration` is Java-8-safe; the
+   port must avoid any Java 9+ API it might reach for (none expected).
+4. **failsafe plugin version** — confirm whether `maven-failsafe-plugin` is managed in the
+   root `pluginManagement`; if not, pin a version in the module pom.
+
+## Roadmap (subsequent slices, each its own spec)
+
+1. **`config-platform-common`** — extract the platform-neutral classes now duplicated
+   between config-spigot and config-bungee (loader/node, proxy, binding coordinator, folder
+   impls, reference manager/preprocessor, reload subsystem) into a shared module both
+   adapters depend on. Deferred until the second adapter exists (this one), which reveals
+   the true shared shape; doing it now would also mean editing config-spigot, out of scope
+   for this effort.
+2. **Bungee-specific serializers** — e.g. `ServerInfo`, chat `BaseComponent`/`ChatColor`,
+   if demand appears.
+3. **On-proxy end-to-end validation** — exercise config-bungee inside a runnable BungeeCord
+   sample plugin (depends on the `bungee.yml` descriptor-generator slice).

--- a/platform-bungee/config-bungee/pom.xml
+++ b/platform-bungee/config-bungee/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>tech.guilhermekaua.spigot-boot</groupId>
+        <artifactId>spigot-boot-platform-bungee</artifactId>
+        <version>3.2.1-SNAPSHOT</version>
+    </parent>
+
+    <name>${project.artifactId}</name>
+    <description>BungeeCord implementation of Spigot Boot configuration system.</description>
+    <url>https://github.com/guikaua12/spigot-boot</url>
+    <artifactId>spigot-boot-config-bungee</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>1.18.36</version>
+                        </path>
+                        <path>
+                            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+                            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+                            <version>${project.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+
+            <!-- ConfigProxy uses the javassist proxy API directly. javassist ships only as the
+                 relocated copy bundled inside spigot-boot-core, so this module's own bytecode must
+                 reference the shaded names too; otherwise it throws NoClassDefFoundError:
+                 javassist/util/proxy/* at runtime. nothing is bundled here (core owns the shaded
+                 javassist) — this execution only rewrites this module's references. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <!-- version managed by the parent pluginManagement (3.5.1) -->
+                <executions>
+                    <execution>
+                        <id>relocate-javassist-references</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <!-- include only this module's own classes so nothing is bundled; the execution
+                                 exists purely to rewrite this module's javassist references to the shaded package. -->
+                            <artifactSet>
+                                <includes>
+                                    <include>tech.guilhermekaua.spigot-boot:spigot-boot-config-bungee</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>javassist</pattern>
+                                    <shadedPattern>tech.guilhermekaua.spigotboot.shaded.javassist</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- runs *IT tests in the integration-test phase (after package/shade) so the relocation
+                 guard can inspect the SHADED jar; surefire (test phase) excludes *IT by default. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.3</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <project.build.directory>${project.build.directory}</project.build.directory>
+                        <project.build.finalName>${project.build.finalName}</project.build.finalName>
+                    </systemPropertyVariables>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <!-- ConfigProxy uses the javassist proxy API; provided (never bundled) because the relocated
+             copy is supplied at runtime by spigot-boot-core and this module's references are rewritten
+             to the shaded package by the shade execution above. -->
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.30.2-GA</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.md-5</groupId>
+            <artifactId>bungeecord-api</artifactId>
+            <!-- version + provided scope inherited from the platform-bungee parent's dependencyManagement -->
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- runtime pairing: a plugin pulling in config-bungee also gets the Bungee bootstrap and the
+             Plugin bean producer (BungeeCoreModule). Mirrors config-spigot depending on core-spigot. -->
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-core-bungee</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>tech.guilhermekaua.spigot-boot</groupId>
+            <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+</project>

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeConfigManager.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeConfigManager.java
@@ -1,0 +1,1117 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee;
+
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.ConfigManager;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfig;
+import tech.guilhermekaua.spigotboot.config.binding.Binder;
+import tech.guilhermekaua.spigotboot.config.binding.NamingStrategy;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigRef;
+import tech.guilhermekaua.spigotboot.config.loader.ConfigSource;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceErrorHandler;
+import tech.guilhermekaua.spigotboot.config.reference.key.FolderConfigItemKey;
+import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
+import tech.guilhermekaua.spigotboot.config.reference.key.SingleConfigKey;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.reload.DefaultConfigRef;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistry;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.config.bungee.folder.FolderConfigEntry;
+import tech.guilhermekaua.spigotboot.config.bungee.loader.YamlConfigLoader;
+import tech.guilhermekaua.spigotboot.config.bungee.reference.ConfigReferenceManager;
+import tech.guilhermekaua.spigotboot.config.bungee.reference.BungeeConfigReferenceLookup;
+import tech.guilhermekaua.spigotboot.core.context.lifecycle.Ordered;
+import tech.guilhermekaua.spigotboot.core.exceptions.CycleDetectedException;
+import tech.guilhermekaua.spigotboot.core.validation.Validator;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+/**
+ * BungeeCord implementation of ConfigManager.
+ */
+public class BungeeConfigManager implements ConfigManager {
+
+    private final Plugin plugin;
+    private final YamlConfigLoader loader;
+    private final TypeSerializerRegistry serializers;
+    private final Binder binder;
+    private final ConfigReferenceManager referenceManager;
+    private final ConfigBindingCoordinator bindingCoordinator;
+
+    private final Map<Class<?>, ConfigEntry<?>> configs = new ConcurrentHashMap<>();
+    private final Map<String, Class<?>> configsByName = new ConcurrentHashMap<>();
+
+    private final Map<FolderConfigKey, FolderConfigEntry<?>> folderConfigs = new ConcurrentHashMap<>();
+
+    /**
+     * Tracks whether initializeAll() has been called
+     */
+    private volatile boolean initialized = false;
+
+    /**
+     * Creates a new config manager with default error handling.
+     *
+     * @param plugin the BungeeCord plugin
+     */
+    public BungeeConfigManager(@NotNull Plugin plugin) {
+        this(plugin, null, Collections.emptyList());
+    }
+
+    /**
+     * Creates a new config manager with optional custom error handling.
+     *
+     * @param plugin       the BungeeCord plugin
+     * @param errorHandler the optional custom error handler (null for default)
+     */
+    public BungeeConfigManager(@NotNull Plugin plugin, @Nullable ConfigReferenceErrorHandler errorHandler) {
+        this(plugin, errorHandler, Collections.emptyList());
+    }
+
+    /**
+     * Creates a new config manager with optional custom error handling and serializer customizers.
+     *
+     * @param plugin                the BungeeCord plugin
+     * @param errorHandler          the optional custom error handler (null for default)
+     * @param serializerCustomizers the list of serializer registry customizers to apply (may be empty)
+     */
+    public BungeeConfigManager(
+            @NotNull Plugin plugin,
+            @Nullable ConfigReferenceErrorHandler errorHandler,
+            @NotNull List<TypeSerializerRegistryCustomizer> serializerCustomizers
+    ) {
+        this.plugin = Objects.requireNonNull(plugin, "plugin cannot be null");
+        this.loader = new YamlConfigLoader();
+        this.serializers = TypeSerializerRegistry.defaults();
+        applySerializerCustomizers(serializerCustomizers);
+
+        if (errorHandler != null) {
+            this.referenceManager = new ConfigReferenceManager(this, errorHandler);
+        } else {
+            this.referenceManager = new ConfigReferenceManager(this, plugin.getLogger());
+        }
+
+        this.binder = Binder.builder()
+                .serializers(serializers)
+                .validator(Validator.create())
+                .implicitDefaults(true)
+                .useConstructorBinding(true)
+                .nodePreprocessor(referenceManager.getPreprocessor())
+                .build();
+
+        this.bindingCoordinator = new ConfigBindingCoordinator(
+                referenceManager,
+                binder,
+                plugin.getLogger(),
+                new ConfigEntryAccessor() {
+                    @Override
+                    public @Nullable Class<?> getConfigClassByName(@NotNull String configName) {
+                        return configsByName.get(configName);
+                    }
+
+                    @Override
+                    public @Nullable ConfigNode getConfigNode(@NotNull Class<?> configClass) {
+                        ConfigEntry<?> entry = configs.get(configClass);
+                        return entry != null ? entry.getNode() : null;
+                    }
+
+                    @Override
+                    public @Nullable NamingStrategy getNamingStrategy(@NotNull Class<?> configClass) {
+                        ConfigEntry<?> entry = configs.get(configClass);
+                        return entry != null ? entry.getNamingStrategy() : null;
+                    }
+
+                    @Override
+                    @SuppressWarnings("unchecked")
+                    public void setConfigInstance(@NotNull Class<?> configClass, @NotNull Object instance) {
+                        ConfigEntry<Object> entry = (ConfigEntry<Object>) configs.get(configClass);
+                        if (entry != null) {
+                            entry.setInstance(instance);
+                        }
+                    }
+
+                    @Override
+                    public @Nullable FolderConfigEntry<?> getFolderConfigEntryByName(@NotNull String folderConfigName) {
+                        return BungeeConfigManager.this.getFolderConfigEntryByName(folderConfigName);
+                    }
+                }
+        );
+    }
+
+    private void applySerializerCustomizers(@Nullable List<TypeSerializerRegistryCustomizer> customizers) {
+        if (customizers == null || customizers.isEmpty()) {
+            return;
+        }
+
+        List<TypeSerializerRegistryCustomizer> ordered = new ArrayList<>(customizers);
+        ordered.sort(Comparator.comparingInt(Ordered::getOrder));
+
+        for (TypeSerializerRegistryCustomizer customizer : ordered) {
+            try {
+                customizer.customize(this.serializers);
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.SEVERE, "Error applying TypeSerializerRegistryCustomizer: " + customizer.getClass().getName(), e);
+            }
+        }
+    }
+
+    /**
+     * Gets the serializer registry for registering custom serializers.
+     *
+     * @return the serializer registry
+     */
+    @Override
+    public @NotNull TypeSerializerRegistry getSerializerRegistry() {
+        return serializers;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> @NotNull T get(@NotNull Class<T> configClass) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        ConfigEntry<T> entry = (ConfigEntry<T>) configs.get(configClass);
+        if (entry == null) {
+            throw new ConfigException("Config not registered: " + configClass.getName());
+        }
+        T instance = entry.getInstance();
+        if (instance == null) {
+            throw new ConfigException("Config not loaded: " + configClass.getName());
+        }
+        return instance;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> @NotNull ConfigRef<T> getRef(@NotNull Class<T> configClass) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        ConfigEntry<T> entry = (ConfigEntry<T>) configs.get(configClass);
+        if (entry == null) {
+            throw new ConfigException("Config not registered: " + configClass.getName());
+        }
+        return entry.getRef();
+    }
+
+    // ==================== Folder Config API ====================
+
+    @Override
+    public <T> @NotNull Collection<T> getFolderConfig(@NotNull Class<T> configClass) {
+        return getFolderConfig(configClass, findSingleFolderConfigName(configClass));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> @NotNull Collection<T> getFolderConfig(@NotNull Class<T> configClass, @NotNull String folderConfigName) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+
+        FolderConfigEntry<T> entry = (FolderConfigEntry<T>) folderConfigs.get(new FolderConfigKey(configClass, folderConfigName));
+        if (entry == null) {
+            throw new ConfigException("Folder config not registered: " + configClass.getName() + " with name '" + folderConfigName + "'");
+        }
+        return entry.getRef().get().values();
+    }
+
+    @Override
+    public <T> @NotNull FolderConfigRef<T> getFolderConfigRef(@NotNull Class<T> configClass) {
+        return getFolderConfigRef(configClass, findSingleFolderConfigName(configClass));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> @NotNull FolderConfigRef<T> getFolderConfigRef(@NotNull Class<T> configClass, @NotNull String folderConfigName) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+
+        FolderConfigEntry<T> entry = (FolderConfigEntry<T>) folderConfigs.get(new FolderConfigKey(configClass, folderConfigName));
+        if (entry == null) {
+            throw new ConfigException("Folder config not registered: " + configClass.getName() + " with name '" + folderConfigName + "'");
+        }
+        return entry.getRef();
+    }
+
+    /**
+     * Registers a folder-based config (folder-config).
+     * <p>
+     * This only registers the folder config definition.
+     * Actual loading and binding happens in {@link #initializeAll()}.
+     *
+     * @param itemType   the item type class
+     * @param annotation the @FolderConfig annotation
+     * @param <T>        the item type
+     */
+    public <T> void registerFolderConfig(@NotNull Class<T> itemType, @NotNull FolderConfig annotation) {
+        Objects.requireNonNull(itemType, "itemType cannot be null");
+        Objects.requireNonNull(annotation, "annotation cannot be null");
+
+        FolderConfigEntry<T> entry = new FolderConfigEntry<>(itemType, annotation, plugin, loader, binder, annotation.naming());
+        String folderConfigName = entry.getFolderConfigName();
+
+        validateConfigName(folderConfigName, itemType.getName());
+
+        FolderConfigKey key = new FolderConfigKey(itemType, folderConfigName);
+        FolderConfigEntry<?> existingByKey = folderConfigs.get(key);
+        if (existingByKey != null) {
+            throw new ConfigException("Folder config already registered for itemType " + itemType.getName() +
+                    " with name '" + folderConfigName + "'. Existing entry: " + describeFolderConfigEntry(existingByKey));
+        }
+
+        FolderConfigEntry<?> existingByName = findFolderConfigNameCollision(folderConfigName, itemType);
+        if (existingByName != null) {
+            throw new ConfigException("Folder config name collision: '" + folderConfigName + "' is already registered for " +
+                    describeFolderConfigEntry(existingByName) + ", cannot register itemType " +
+                    itemType.getName() + " (folder=" + entry.getFolder() + ")");
+        }
+
+        entry.prepareFolder();
+
+        FolderConfigEntry<?> previousByKey = folderConfigs.putIfAbsent(key, entry);
+        if (previousByKey != null) {
+            throw new ConfigException("Folder config already registered for itemType " + itemType.getName() +
+                    " with name '" + folderConfigName + "'. Existing entry: " + describeFolderConfigEntry(previousByKey));
+        }
+
+        FolderConfigEntry<?> collisionAfterPut = findFolderConfigNameCollision(folderConfigName, itemType);
+        if (collisionAfterPut != null) {
+            folderConfigs.remove(key, entry);
+            throw new ConfigException("Folder config name collision: '" + folderConfigName + "' is already registered for " +
+                    describeFolderConfigEntry(collisionAfterPut) + ", cannot register itemType " +
+                    itemType.getName() + " (folder=" + entry.getFolder() + ")");
+        }
+
+        plugin.getLogger().info("Registered folder config definition: " + entry.getFolderConfigName() +
+                " (" + itemType.getSimpleName() + ") from " + entry.getFolder());
+    }
+
+    private @Nullable FolderConfigEntry<?> findFolderConfigNameCollision(@NotNull String folderConfigName, @NotNull Class<?> itemType) {
+        for (FolderConfigEntry<?> existing : folderConfigs.values()) {
+            if (existing.getFolderConfigName().equals(folderConfigName) && !existing.getItemType().equals(itemType)) {
+                return existing;
+            }
+        }
+        return null;
+    }
+
+    private @NotNull String describeFolderConfigEntry(@NotNull FolderConfigEntry<?> entry) {
+        return "itemType=" + entry.getItemType().getName() +
+                ", name='" + entry.getFolderConfigName() + "'" +
+                ", folder=" + entry.getFolder();
+    }
+
+    /**
+     * Gets a folder config entry by item type and name.
+     *
+     * @param itemType         the item type
+     * @param folderConfigName the folder config name
+     * @param <T>              the item type
+     * @return the entry, or null if not found
+     */
+    @SuppressWarnings("unchecked")
+    public <T> @Nullable FolderConfigEntry<T> getFolderConfigEntry(@NotNull Class<T> itemType, @NotNull String folderConfigName) {
+        return (FolderConfigEntry<T>) folderConfigs.get(new FolderConfigKey(itemType, folderConfigName));
+    }
+
+    /**
+     * Gets all folder config names for an item type.
+     *
+     * @param itemType the item type
+     * @return the set of folder config names
+     */
+    public @NotNull Set<String> getFolderConfigNames(@NotNull Class<?> itemType) {
+        Set<String> names = new LinkedHashSet<>();
+        for (FolderConfigKey key : folderConfigs.keySet()) {
+            if (key.itemType.equals(itemType)) {
+                names.add(key.folderConfigName);
+            }
+        }
+        return names;
+    }
+
+    private <T> String findSingleFolderConfigName(Class<T> itemType) {
+        List<String> names = new ArrayList<>();
+        for (FolderConfigKey key : folderConfigs.keySet()) {
+            if (key.itemType.equals(itemType)) {
+                names.add(key.folderConfigName);
+            }
+        }
+
+        if (names.isEmpty()) {
+            throw new ConfigException("No folder config registered for type: " + itemType.getName());
+        }
+        if (names.size() > 1) {
+            throw new ConfigException("Multiple folder configs exist for type " + itemType.getName() +
+                    ": " + names + ". Use the overload with folderConfigName parameter, or add @FolderConfigName on the injection point.");
+        }
+        return names.get(0);
+    }
+
+    /**
+     * Initializes all registered configs and folder configs in topological order.
+     * <p>
+     * This method must be called after all {@link #register(Class)} and
+     * {@link #registerFolderConfig(Class, FolderConfig)} calls are complete.
+     * It delegates to {@link #reloadAll()} after setting the initialized flag.
+     *
+     * @throws ConfigException if a cycle is detected in references
+     */
+    public void initializeAll() {
+        if (initialized) {
+            throw new ConfigException("initializeAll() called more than once");
+        }
+
+        initialized = true;
+        reloadAll();
+        plugin.getLogger().info("Config initialization complete.");
+    }
+
+    /**
+     * Checks if initialization has been completed.
+     *
+     * @return true if {@link #initializeAll()} has been called
+     */
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    /**
+     * Gets the reference manager for advanced operations.
+     *
+     * @return the reference manager
+     */
+    public @NotNull ConfigReferenceManager getReferenceManager() {
+        return referenceManager;
+    }
+
+    // ==================== Standard config methods ====================
+
+    @Override
+    public @Nullable Object get(@NotNull String path) {
+        return get(path, Object.class);
+    }
+
+    @Override
+    public <T> @Nullable T get(@NotNull String path, @NotNull Class<T> type) {
+        Objects.requireNonNull(path, "path cannot be null");
+        Objects.requireNonNull(type, "type cannot be null");
+
+        ConfigNode node = resolveNode(path);
+        return node == null ? null : node.get(type);
+    }
+
+    /**
+     * Resolves the raw {@link ConfigNode} at a {@code "configName:path"} (or bare {@code "path"})
+     * location.
+     *
+     * @param path the lookup path
+     * @return the node (which may be virtual when the path is absent), or null when the config name
+     *         is unknown / not loaded / no configs are registered
+     * @throws ConfigException if a bare path is given while multiple configs are registered
+     */
+    private @Nullable ConfigNode resolveNode(@NotNull String path) {
+        String configName;
+        String nodePath;
+
+        int colonIndex = path.indexOf(':');
+        if (colonIndex > 0) {
+            configName = path.substring(0, colonIndex);
+            nodePath = path.substring(colonIndex + 1);
+        } else {
+            if (configsByName.isEmpty()) {
+                return null;
+            }
+            if (configsByName.size() > 1) {
+                List<String> availableConfigs = new ArrayList<>(configsByName.keySet());
+                Collections.sort(availableConfigs);
+                throw new ConfigException("Ambiguous config path '" + path + "': multiple configs are registered " +
+                        availableConfigs + ". Use 'configName:path' format.");
+            }
+            configName = configsByName.keySet().iterator().next();
+            nodePath = path;
+        }
+
+        Class<?> configClass = configsByName.get(configName);
+        if (configClass == null) {
+            return null;
+        }
+
+        ConfigEntry<?> entry = configs.get(configClass);
+        if (entry == null || entry.getNode() == null) {
+            return null;
+        }
+
+        String[] parts = nodePath.split("\\.");
+        Object[] pathSegments = new Object[parts.length];
+        System.arraycopy(parts, 0, pathSegments, 0, parts.length);
+
+        return entry.getNode().node(pathSegments);
+    }
+
+    /**
+     * Returns the registered config name for a {@code @Config} class.
+     *
+     * @param configClass the config class
+     * @return the registered config name
+     * @throws ConfigException if the class is not a registered config
+     */
+    public @NotNull String getConfigName(@NotNull Class<?> configClass) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        ConfigEntry<?> entry = configs.get(configClass);
+        if (entry == null) {
+            throw new ConfigException("Config not registered: " + configClass.getName());
+        }
+        return entry.getConfigName();
+    }
+
+    /**
+     * Reads the value at a path and deserializes it to the target type using the serializer registry.
+     * Unlike {@link #get(String, Class)} (which uses the node's built-in scalar conversion), this
+     * supports every type with a registered {@link TypeSerializer}.
+     *
+     * @param path the {@code "configName:path"} (or bare {@code "path"}) location
+     * @param type the target type
+     * @param <T>  the target type parameter
+     * @return the deserialized value, or null when the path is absent / null
+     * @throws ConfigException if no serializer is registered for the type, or on a bad bare path
+     */
+    public <T> @Nullable T deserializeAt(@NotNull String path, @NotNull Class<T> type) {
+        Objects.requireNonNull(path, "path cannot be null");
+        Objects.requireNonNull(type, "type cannot be null");
+
+        ConfigNode node = resolveNode(path);
+        if (node == null || node.isVirtual() || node.isNull()) {
+            return null;
+        }
+
+        TypeSerializer<T> serializer = serializers.getWithInheritance(type);
+        if (serializer == null) {
+            throw new ConfigException("No serializer registered for type: " + type.getName());
+        }
+        return serializer.deserialize(node, type);
+    }
+
+    /**
+     * Coerces a raw string into the target type using the serializer registry (used for
+     * {@code @ConfigValue} defaults).
+     *
+     * @param raw  the raw string
+     * @param type the target type
+     * @param <T>  the target type parameter
+     * @return the coerced value
+     * @throws ConfigException if no serializer is registered for the type, or the value cannot be parsed
+     */
+    public <T> @NotNull T coerceDefault(@NotNull String raw, @NotNull Class<T> type) {
+        Objects.requireNonNull(raw, "raw cannot be null");
+        Objects.requireNonNull(type, "type cannot be null");
+
+        TypeSerializer<T> serializer = serializers.getWithInheritance(type);
+        if (serializer == null) {
+            throw new ConfigException("No serializer registered for type: " + type.getName());
+        }
+        MutableConfigNode node = loader.createNode();
+        node.set(raw);
+        return serializer.deserialize(node, type);
+    }
+
+    @Override
+    public @NotNull String getString(@NotNull String path, @NotNull String defaultValue) {
+        String result = get(path, String.class);
+        return result != null ? result : defaultValue;
+    }
+
+    @Override
+    public int getInt(@NotNull String path, int defaultValue) {
+        Integer result = get(path, Integer.class);
+        return result != null ? result : defaultValue;
+    }
+
+    @Override
+    public long getLong(@NotNull String path, long defaultValue) {
+        Long result = get(path, Long.class);
+        return result != null ? result : defaultValue;
+    }
+
+    @Override
+    public boolean getBoolean(@NotNull String path, boolean defaultValue) {
+        Boolean result = get(path, Boolean.class);
+        return result != null ? result : defaultValue;
+    }
+
+    @Override
+    public double getDouble(@NotNull String path, double defaultValue) {
+        Double result = get(path, Double.class);
+        return result != null ? result : defaultValue;
+    }
+
+    @Override
+    public @NotNull List<String> getStringList(@NotNull String path) {
+        Object result = get(path);
+        if (result instanceof List) {
+            List<String> strings = new ArrayList<>();
+            for (Object item : (List<?>) result) {
+                strings.add(String.valueOf(item));
+            }
+            return strings;
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public <T> void register(@NotNull Class<T> configClass) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+
+        Config annotation = configClass.getAnnotation(Config.class);
+        if (annotation == null) {
+            throw new ConfigException("Class is not annotated with @Config: " + configClass.getName());
+        }
+
+        String filePath = annotation.value();
+        if (filePath.isEmpty()) {
+            filePath = configClass.getSimpleName().toLowerCase() + ".yml";
+        }
+
+        Path path = plugin.getDataFolder().toPath().resolve(filePath);
+        register(configClass, ConfigSource.file(path));
+    }
+
+    @Override
+    public <T> void register(@NotNull Class<T> configClass, @NotNull ConfigSource source) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        Objects.requireNonNull(source, "source cannot be null");
+
+        Config annotation = configClass.getAnnotation(Config.class);
+        if (annotation == null) {
+            throw new ConfigException("Class is not annotated with @Config: " + configClass.getName());
+        }
+
+        String configName = annotation.name();
+        if (configName.isEmpty()) {
+            configName = configClass.getSimpleName().toLowerCase();
+        }
+        final String finalConfigName = configName;
+
+        validateConfigName(finalConfigName, configClass.getName());
+
+        ConfigEntry<?> existingEntryByClass = configs.get(configClass);
+        if (existingEntryByClass != null) {
+            throw new ConfigException("Config already registered: " + configClass.getName() +
+                    " (name=" + existingEntryByClass.getConfigName() + ")");
+        }
+
+        Class<?> existingClassByName = configsByName.get(finalConfigName);
+        if (existingClassByName != null && !existingClassByName.equals(configClass)) {
+            throw new ConfigException("Config name collision: '" + finalConfigName + "' is already registered for " +
+                    existingClassByName.getName() + ", cannot register " + configClass.getName());
+        }
+
+        if (annotation.generateDefaults() && !source.exists()) {
+            copyDefaultFromResources(configClass, annotation, source);
+        }
+
+        NamingStrategy namingStrategy = annotation.naming();
+
+        ConfigNode node = loader.load(source);
+
+        DefaultConfigRef<T> ref = new DefaultConfigRef<>(configClass, null, () -> {
+            ConfigNode reloadedNode = loader.load(source);
+            ReferenceKey sourceKey = ReferenceKey.singleConfig(finalConfigName);
+            referenceManager.setCurrentSourceKey(sourceKey);
+            try {
+                return binder.bind(reloadedNode, configClass, namingStrategy).get();
+            } finally {
+                referenceManager.clearCurrentSourceKey();
+            }
+        });
+
+        ConfigEntry<T> entry = new ConfigEntry<>(configClass, source, namingStrategy, null, ref, node, finalConfigName);
+        ConfigEntry<?> previousEntryByClass = configs.putIfAbsent(configClass, entry);
+        if (previousEntryByClass != null) {
+            throw new ConfigException("Config already registered: " + configClass.getName() +
+                    " (name=" + previousEntryByClass.getConfigName() + ")");
+        }
+
+        Class<?> previousClassByName = configsByName.putIfAbsent(finalConfigName, configClass);
+        if (previousClassByName != null) {
+            configs.remove(configClass, entry);
+            if (!previousClassByName.equals(configClass)) {
+                throw new ConfigException("Config name collision: '" + finalConfigName + "' is already registered for " +
+                        previousClassByName.getName() + ", cannot register " + configClass.getName());
+            }
+            throw new ConfigException("Config already registered: " + configClass.getName() +
+                    " (name=" + finalConfigName + ")");
+        }
+
+        plugin.getLogger().info("Registered config definition: " + configClass.getSimpleName() + " (name=" + finalConfigName + ")");
+    }
+
+    private void validateConfigName(@NotNull String name, @NotNull String contextInfo) {
+        if (name.contains(".")) {
+            throw new ConfigException("Config name '" + name + "' cannot contain '.'. Context: " + contextInfo);
+        }
+        if (name.contains(":")) {
+            throw new ConfigException("Config name '" + name + "' cannot contain ':'. Context: " + contextInfo);
+        }
+    }
+
+    private void copyDefaultFromResources(Class<?> configClass, Config annotation, ConfigSource target) {
+        String resourcePath = annotation.resource();
+        if (resourcePath.isEmpty()) {
+            resourcePath = annotation.value();
+            if (resourcePath.isEmpty()) {
+                resourcePath = configClass.getSimpleName().toLowerCase() + ".yml";
+            }
+        }
+
+        try (InputStream is = plugin.getResourceAsStream(resourcePath)) {
+            if (is != null) {
+                Path targetPath = target.path();
+                if (targetPath != null) {
+                    Path parent = targetPath.getParent();
+                    if (parent != null && !Files.exists(parent)) {
+                        Files.createDirectories(parent);
+                    }
+                    Files.copy(is, targetPath);
+                    plugin.getLogger().info("Created default config from resources: " + target.name());
+                }
+            } else {
+                generateDefaultsToSource(configClass, target, annotation.naming());
+            }
+        } catch (IOException e) {
+            plugin.getLogger().warning("Failed to copy default config: " + e.getMessage());
+        }
+    }
+
+    private void generateDefaultsToSource(Class<?> configClass, ConfigSource target, NamingStrategy namingStrategy) {
+        try {
+            Path targetPath = target.path();
+            if (targetPath != null) {
+                Path parent = targetPath.getParent();
+                if (parent != null && !Files.exists(parent)) {
+                    Files.createDirectories(parent);
+                }
+            }
+
+            Object defaultInstance = configClass.getDeclaredConstructor().newInstance();
+            MutableConfigNode node = loader.createNode();
+            binder.unbind(defaultInstance, node, namingStrategy);
+            loader.save(node, target);
+            plugin.getLogger().info("Generated default config from class: " + configClass.getSimpleName());
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to generate default config from class: " + e.getMessage());
+        }
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void reload(@NotNull Class<?> configClass) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+
+        ConfigEntry<?> entry = configs.get(configClass);
+        if (entry == null) {
+            throw new ConfigException("Config not registered: " + configClass.getName());
+        }
+
+        ReferenceKey key = ReferenceKey.singleConfig(entry.getConfigName());
+        reloadKeyWithPropagation(key);
+        plugin.getLogger().info("Reloaded config: " + configClass.getSimpleName());
+    }
+
+    @Override
+    public void reloadFolderConfigItem(@NotNull Class<?> configClass, @NotNull String itemId) {
+        reloadFolderConfigItem(configClass, findSingleFolderConfigName(configClass), itemId);
+    }
+
+    @Override
+    public void reloadFolderConfigItem(@NotNull Class<?> configClass, @NotNull String folderConfigName, @NotNull String itemId) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+        Objects.requireNonNull(itemId, "itemId cannot be null");
+
+        FolderConfigEntry<?> entry = folderConfigs.get(new FolderConfigKey(configClass, folderConfigName));
+        if (entry == null) {
+            throw new ConfigException("Folder config not registered: " + configClass.getName() + " with name '" + folderConfigName + "'");
+        }
+
+        ReferenceKey key = ReferenceKey.folderConfigItem(folderConfigName, itemId);
+        reloadKeyWithPropagation(key);
+        plugin.getLogger().info("Reloaded folder config item: " + folderConfigName + "." + itemId);
+    }
+
+    /**
+     * Reloads a single key and all its transitive dependents.
+     * <p>
+     * This performs:
+     * <ol>
+     *   <li>Reload the raw node from disk</li>
+     *   <li>Rescan for references and update graph edges</li>
+     *   <li>Compute impacted set (this key + all transitive dependents)</li>
+     *   <li>Rebind impacted keys in topological order</li>
+     * </ol>
+     *
+     * @param key the key to reload
+     */
+    private void reloadKeyWithPropagation(@NotNull ReferenceKey key) {
+        ConfigNode newNode = reloadRawNode(key);
+        if (newNode == null) {
+            return;
+        }
+
+        referenceManager.updateDependenciesForKey(key, newNode);
+
+        Set<ReferenceKey> impacted = referenceManager.getImpactedKeys(key);
+
+        List<ReferenceKey> reloadOrder;
+        try {
+            reloadOrder = referenceManager.getLoadOrderForSubset(impacted);
+        } catch (CycleDetectedException e) {
+            throw new ConfigException("Circular reference detected during reload: " + e.formatCycle(), e);
+        }
+
+        for (ReferenceKey impactedKey : reloadOrder) {
+            bindingCoordinator.bindKey(impactedKey, true);
+        }
+    }
+
+    /**
+     * Reloads the raw node for a key from disk.
+     *
+     * @param key the reference key
+     * @return the new raw node, or null if not found
+     */
+    @SuppressWarnings("unchecked")
+    private @Nullable ConfigNode reloadRawNode(@NotNull ReferenceKey key) {
+        if (key.isSingleConfig()) {
+            SingleConfigKey singleKey = (SingleConfigKey) key;
+            String configName = singleKey.getConfigName();
+            Class<?> configClass = configsByName.get(configName);
+            if (configClass == null) {
+                return null;
+            }
+
+            ConfigEntry<Object> entry = (ConfigEntry<Object>) configs.get(configClass);
+            if (entry == null) {
+                return null;
+            }
+
+            ConfigNode newNode = loader.load(entry.getSource());
+            entry.setNode(newNode);
+            return newNode;
+        } else {
+            FolderConfigItemKey itemKey = (FolderConfigItemKey) key;
+            String folderConfigName = itemKey.getFolderConfigName();
+            String itemId = itemKey.getItemId();
+
+            FolderConfigEntry<?> folderEntry = getFolderConfigEntryByName(folderConfigName);
+            if (folderEntry == null) {
+                return null;
+            }
+
+            folderEntry.reloadItemRawNode(itemId);
+            return folderEntry.getItemNode(itemId);
+        }
+    }
+
+    @Override
+    public void reloadAll() {
+        if (!initialized) {
+            plugin.getLogger().warning("reloadAll() called before initialization - calling initializeAll() instead");
+            initializeAll();
+            return;
+        }
+
+        plugin.getLogger().info("Loading all configs with reference resolution...");
+
+        referenceManager.resetDependencies();
+
+        for (ConfigEntry<?> entry : configs.values()) {
+            ConfigNode newNode = loader.load(entry.getSource());
+            entry.setNode(newNode);
+
+            ReferenceKey key = ReferenceKey.singleConfig(entry.getConfigName());
+            referenceManager.scanAndRegister(key, newNode);
+        }
+
+        Map<String, Set<String>> loadedItemIdsByFolderConfig = new HashMap<>();
+
+        for (FolderConfigEntry<?> folderEntry : folderConfigs.values()) {
+            String folderConfigName = folderEntry.getFolderConfigName();
+
+            Map<String, ConfigNode> rawNodes = folderEntry.loadRawNodesOnly();
+            loadedItemIdsByFolderConfig.put(folderConfigName, new LinkedHashSet<>(rawNodes.keySet()));
+
+            for (Map.Entry<String, ConfigNode> itemEntry : rawNodes.entrySet()) {
+                String itemId = itemEntry.getKey();
+                ConfigNode node = itemEntry.getValue();
+                if (node == null) {
+                    continue;
+                }
+
+                ReferenceKey key = ReferenceKey.folderConfigItem(folderConfigName, itemId);
+                referenceManager.scanAndRegister(key, node);
+            }
+        }
+
+        List<ReferenceKey> loadOrder;
+        try {
+            loadOrder = referenceManager.getLoadOrder();
+        } catch (CycleDetectedException e) {
+            throw new ConfigException("Circular config reference detected: " + e.formatCycle(), e);
+        }
+
+        Set<ReferenceKey> boundKeys = new HashSet<>(loadOrder);
+        for (ReferenceKey key : loadOrder) {
+            bindingCoordinator.bindKey(key, true);
+        }
+
+        for (FolderConfigEntry<?> folderEntry : folderConfigs.values()) {
+            String folderConfigName = folderEntry.getFolderConfigName();
+            Set<String> loadedItemIds = loadedItemIdsByFolderConfig.get(folderConfigName);
+            if (loadedItemIds == null) {
+                loadedItemIds = Collections.emptySet();
+            }
+
+            for (String itemId : loadedItemIds) {
+                ReferenceKey key = ReferenceKey.folderConfigItem(folderConfigName, itemId);
+                if (!boundKeys.contains(key)) {
+                    bindingCoordinator.bindKey(key, true);
+                }
+            }
+
+            Set<String> snapshotIds = new LinkedHashSet<>(folderEntry.getRef().get().ids());
+            for (String itemId : snapshotIds) {
+                if (!loadedItemIds.contains(itemId)) {
+                    folderEntry.rebindItem(itemId);
+                }
+            }
+        }
+
+        plugin.getLogger().info("Load complete.");
+    }
+
+    @Override
+    public void save(@NotNull Class<?> configClass) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+
+        ConfigEntry<?> entry = configs.get(configClass);
+        if (entry == null) {
+            throw new ConfigException("Config not registered: " + configClass.getName());
+        }
+
+        MutableConfigNode node = loader.createNode();
+        binder.unbind(entry.getInstance(), node, entry.getNamingStrategy());
+        loader.save(node, entry.getSource());
+        plugin.getLogger().info("Saved config: " + configClass.getSimpleName());
+    }
+
+    @Override
+    public void generateDefaults(@NotNull Class<?> configClass) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+
+        ConfigEntry<?> entry = configs.get(configClass);
+        if (entry == null) {
+            throw new ConfigException("Config not registered: " + configClass.getName());
+        }
+
+        try {
+            Object defaultInstance = configClass.getDeclaredConstructor().newInstance();
+            MutableConfigNode node = loader.createNode();
+            binder.unbind(defaultInstance, node, entry.getNamingStrategy());
+            loader.save(node, entry.getSource());
+            plugin.getLogger().info("Generated defaults for: " + configClass.getSimpleName());
+        } catch (Exception e) {
+            throw new ConfigException("Failed to generate defaults for " + configClass.getName(), e);
+        }
+    }
+
+    @Override
+    public boolean isRegistered(@NotNull Class<?> configClass) {
+        return configs.containsKey(configClass);
+    }
+
+    @Override
+    public @NotNull Set<Class<?>> getRegisteredConfigs() {
+        return Collections.unmodifiableSet(configs.keySet());
+    }
+
+    // ==================== Reference Lookup Support ====================
+
+    /**
+     * Gets the raw config node for a config by name.
+     * <p>
+     * Used by {@link tech.guilhermekaua.spigotboot.config.bungee.reference.BungeeConfigReferenceLookup}.
+     *
+     * @param configName the config name
+     * @return the config node, or null if not found
+     */
+    public @Nullable ConfigNode getConfigNode(@NotNull String configName) {
+        Objects.requireNonNull(configName, "configName cannot be null");
+
+        Class<?> configClass = configsByName.get(configName);
+        if (configClass == null) {
+            return null;
+        }
+
+        ConfigEntry<?> entry = configs.get(configClass);
+        return entry != null ? entry.getNode() : null;
+    }
+
+    /**
+     * Gets all registered config names.
+     *
+     * @return set of config names
+     */
+    public @NotNull Set<String> getConfigNames() {
+        return Collections.unmodifiableSet(configsByName.keySet());
+    }
+
+    /**
+     * Gets a folder config entry by name only (without item type).
+     * <p>
+     * Used by {@link BungeeConfigReferenceLookup}.
+     *
+     * @param folderConfigName the folder config name
+     * @return the folder config entry, or null if not found
+     */
+    public @Nullable FolderConfigEntry<?> getFolderConfigEntryByName(@NotNull String folderConfigName) {
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+
+        for (Map.Entry<FolderConfigKey, FolderConfigEntry<?>> entry : folderConfigs.entrySet()) {
+            if (entry.getKey().getFolderConfigName().equals(folderConfigName)) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets all folder config names across all item types.
+     *
+     * @return set of all folder config names
+     */
+    public @NotNull Set<String> getAllFolderConfigNames() {
+        Set<String> names = new LinkedHashSet<>();
+        for (FolderConfigKey key : folderConfigs.keySet()) {
+            names.add(key.getFolderConfigName());
+        }
+        return Collections.unmodifiableSet(names);
+    }
+
+    /**
+     * Returns the distinct item types across all registered folder configs.
+     *
+     * @return an unmodifiable set of folder-config item types, never null
+     */
+    public @NotNull Set<Class<?>> getRegisteredFolderConfigItemTypes() {
+        Set<Class<?>> types = new LinkedHashSet<>();
+        for (FolderConfigKey key : folderConfigs.keySet()) {
+            types.add(key.itemType);
+        }
+        return Collections.unmodifiableSet(types);
+    }
+
+    // ==================== Internal Classes ====================
+
+    /**
+     * Internal entry holding config state.
+     */
+    private static class ConfigEntry<T> {
+        private final Class<T> configClass;
+        private final ConfigSource source;
+        private final NamingStrategy namingStrategy;
+        private final String configName;
+        private volatile T instance;
+        private final DefaultConfigRef<T> ref;
+        private volatile ConfigNode node;
+
+        ConfigEntry(Class<T> configClass, ConfigSource source, NamingStrategy namingStrategy,
+                    T instance, DefaultConfigRef<T> ref, ConfigNode node, String configName) {
+            this.configClass = configClass;
+            this.source = source;
+            this.namingStrategy = namingStrategy;
+            this.configName = configName;
+            this.instance = instance;
+            this.ref = ref;
+            this.node = node;
+        }
+
+        T getInstance() {
+            return instance;
+        }
+
+        ConfigRef<T> getRef() {
+            return ref;
+        }
+
+        ConfigSource getSource() {
+            return source;
+        }
+
+        NamingStrategy getNamingStrategy() {
+            return namingStrategy;
+        }
+
+        String getConfigName() {
+            return configName;
+        }
+
+        ConfigNode getNode() {
+            return node;
+        }
+
+        void update(T newInstance, ConfigNode newNode) {
+            this.instance = newInstance;
+            this.node = newNode;
+            this.ref.update(newInstance);
+        }
+
+        void setInstance(T newInstance) {
+            this.instance = newInstance;
+            this.ref.update(newInstance);
+        }
+
+        void setNode(ConfigNode newNode) {
+            this.node = newNode;
+        }
+    }
+
+    @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+    @Data
+    private static class FolderConfigKey {
+        private final Class<?> itemType;
+        private final String folderConfigName;
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeConfigModule.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeConfigModule.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.bungee.registry.ConfigRegistry;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Order;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+
+import java.util.logging.Logger;
+
+/**
+ * Spigot Boot module providing configuration management on BungeeCord.
+ * <p>
+ * Scans for {@code @Config} and {@code @FolderConfig} annotated classes, loads configs, and
+ * registers them as beans. Mirrors the Spigot {@code SpigotConfigModule}.
+ * <p>
+ * Runs early (after {@code BungeeCoreModule}, which registers the plugin at {@code @Order(-1000)},
+ * but before default-order modules) so that {@code @Config} beans are registered before any later
+ * module resolves a component that depends on them.
+ */
+@Order(-500)
+public class BungeeConfigModule implements Module {
+
+    @Override
+    public void onInitialize(@NotNull Context context) throws Exception {
+        Logger logger = context.getPlugin().getLogger();
+
+        logger.info("Initializing Config Module...");
+
+        context.getBean(ConfigRegistry.class)
+                .registerConfigs(context);
+
+        logger.info("Config Module initialized.");
+
+        context.registerShutdownHook(() -> {
+            logger.info("Config Module shutting down...");
+        });
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/ConfigBindingCoordinator.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/ConfigBindingCoordinator.java
@@ -1,0 +1,134 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.binding.Binder;
+import tech.guilhermekaua.spigotboot.config.binding.BindingResult;
+import tech.guilhermekaua.spigotboot.config.binding.NamingStrategy;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.key.FolderConfigItemKey;
+import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
+import tech.guilhermekaua.spigotboot.config.reference.key.SingleConfigKey;
+import tech.guilhermekaua.spigotboot.config.bungee.folder.FolderConfigEntry;
+import tech.guilhermekaua.spigotboot.config.bungee.reference.ConfigReferenceManager;
+
+import java.util.Objects;
+import java.util.logging.Logger;
+
+/**
+ * Coordinates binding and rebinding of configs and folder config items.
+ * <p>
+ * This is a package-private helper for {@link BungeeConfigManager} that
+ * consolidates the logic for binding configs from their raw nodes.
+ * It handles both initial binding during initialization and rebinding
+ * during reload operations.
+ */
+final class ConfigBindingCoordinator {
+
+    private final ConfigReferenceManager referenceManager;
+    private final Binder binder;
+    private final Logger logger;
+    private final ConfigEntryAccessor entryAccessor;
+
+    /**
+     * Creates a new binding coordinator.
+     *
+     * @param referenceManager the reference manager for context tracking
+     * @param binder           the config binder
+     * @param logger           the logger for status messages
+     * @param entryAccessor    accessor for config entries
+     */
+    ConfigBindingCoordinator(
+            @NotNull ConfigReferenceManager referenceManager,
+            @NotNull Binder binder,
+            @NotNull Logger logger,
+            @NotNull ConfigEntryAccessor entryAccessor) {
+        this.referenceManager = Objects.requireNonNull(referenceManager, "referenceManager cannot be null");
+        this.binder = Objects.requireNonNull(binder, "binder cannot be null");
+        this.logger = Objects.requireNonNull(logger, "logger cannot be null");
+        this.entryAccessor = Objects.requireNonNull(entryAccessor, "entryAccessor cannot be null");
+    }
+
+    /**
+     * Binds or rebinds a config/folder config item from its current raw node.
+     * <p>
+     * This method sets the reference context, performs binding, and updates
+     * the config entry with the new instance.
+     *
+     * @param key      the reference key identifying the config or folder config item
+     * @param isRebind true if this is a rebind operation (affects log messages only)
+     */
+    void bindKey(@NotNull ReferenceKey key, boolean isRebind) {
+        Objects.requireNonNull(key, "key cannot be null");
+
+        referenceManager.setCurrentSourceKey(key);
+        try {
+            if (key.isSingleConfig()) {
+                bindSingleConfig((SingleConfigKey) key, isRebind);
+            } else {
+                bindFolderConfigItem((FolderConfigItemKey) key, isRebind);
+            }
+        } finally {
+            referenceManager.clearCurrentSourceKey();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void bindSingleConfig(SingleConfigKey key, boolean isRebind) {
+        String configName = key.getConfigName();
+        Class<?> configClass = entryAccessor.getConfigClassByName(configName);
+        if (configClass == null) {
+            logger.warning("Unknown config in dependency graph: " + configName);
+            return;
+        }
+
+        ConfigNode node = entryAccessor.getConfigNode(configClass);
+        NamingStrategy namingStrategy = entryAccessor.getNamingStrategy(configClass);
+        if (node == null) {
+            return;
+        }
+
+        BindingResult<Object> result = (BindingResult<Object>) binder.bind(node, configClass, namingStrategy);
+        Object instance = result.get();
+        entryAccessor.setConfigInstance(configClass, instance);
+
+        String action = isRebind ? "Rebound" : "Bound";
+        logger.fine(action + " config: " + configName);
+    }
+
+    private void bindFolderConfigItem(FolderConfigItemKey key, boolean isRebind) {
+        String folderConfigName = key.getFolderConfigName();
+        String itemId = key.getItemId();
+
+        FolderConfigEntry<?> folderEntry = entryAccessor.getFolderConfigEntryByName(folderConfigName);
+        if (folderEntry == null) {
+            return;
+        }
+
+        folderEntry.rebindItem(itemId);
+
+        String action = isRebind ? "Rebound" : "Bound";
+        logger.fine(action + " folder config item: " + folderConfigName + "." + itemId);
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/ConfigEntryAccessor.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/ConfigEntryAccessor.java
@@ -1,0 +1,78 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.binding.NamingStrategy;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.folder.FolderConfigEntry;
+
+/**
+ * Callback interface for accessing BungeeConfigManager's internal config entries.
+ * <p>
+ * This interface allows the coordinator to access config state without
+ * exposing the internal ConfigEntry class.
+ */
+interface ConfigEntryAccessor {
+
+    /**
+     * Gets the config class registered under the given name.
+     *
+     * @param configName the config name
+     * @return the config class, or null if not found
+     */
+    @Nullable Class<?> getConfigClassByName(@NotNull String configName);
+
+    /**
+     * Gets the raw config node for a config class.
+     *
+     * @param configClass the config class
+     * @return the config node, or null if not found
+     */
+    @Nullable ConfigNode getConfigNode(@NotNull Class<?> configClass);
+
+    /**
+     * Gets the naming strategy for a config class.
+     *
+     * @param configClass the config class
+     * @return the naming strategy, or null if not found
+     */
+    @Nullable NamingStrategy getNamingStrategy(@NotNull Class<?> configClass);
+
+    /**
+     * Updates the instance for a config class.
+     *
+     * @param configClass the config class
+     * @param instance    the new instance
+     */
+    void setConfigInstance(@NotNull Class<?> configClass, @NotNull Object instance);
+
+    /**
+     * Gets a folder config entry by name.
+     *
+     * @param folderConfigName the folder config name
+     * @return the folder config entry, or null if not found
+     */
+    @Nullable FolderConfigEntry<?> getFolderConfigEntryByName(@NotNull String folderConfigName);
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/configuration/ConfigConfiguration.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/configuration/ConfigConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.configuration;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceErrorHandler;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistry;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigRefInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigValueInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.FolderConfigInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadProcessor;
+import tech.guilhermekaua.spigotboot.config.bungee.serialization.BungeeConfigSerializers;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Bean;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Configuration;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjectorRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.core.context.dependency.postprocessor.BeanPostProcessorRegistryCustomizer;
+
+import java.util.List;
+
+@Configuration
+public class ConfigConfiguration {
+    @Bean
+    public BungeeConfigManager configManager(
+            Plugin plugin,
+            @Nullable ConfigReferenceErrorHandler errorHandler,
+            List<TypeSerializerRegistryCustomizer> serializerCustomizers
+    ) {
+        return new BungeeConfigManager(plugin, errorHandler, serializerCustomizers);
+    }
+
+    @Bean
+    public CustomInjectorRegistryCustomizer configInjectors(BungeeConfigManager configManager) {
+        return (registry) -> {
+            registry.register(new FolderConfigInjector(configManager));
+            registry.register(new ConfigRefInjector(configManager));
+            registry.register(new ConfigValueInjector(configManager));
+        };
+    }
+
+    @Bean
+    public BeanPostProcessorRegistryCustomizer onConfigReloadProcessor(BungeeConfigManager configManager, Plugin plugin) {
+        return registry -> registry.register(new OnConfigReloadProcessor(configManager, plugin.getLogger()));
+    }
+
+    @Bean
+    public TypeSerializerRegistryCustomizer bungeeTypeSerializers() {
+        return new TypeSerializerRegistryCustomizer() {
+            @Override
+            public void customize(@NotNull TypeSerializerRegistry registry) {
+                BungeeConfigSerializers.registerAll(registry);
+            }
+
+            @Override
+            public int getOrder() {
+                return -100;
+            }
+        };
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/DefaultFolderConfigEditor.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/DefaultFolderConfigEditor.java
@@ -1,0 +1,101 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.folder;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.folder.EditResult;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigEditor;
+
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
+/**
+ * Default implementation of {@link FolderConfigEditor}.
+ * <p>
+ * Delegates to {@link FolderConfigEntry} for actual persistence.
+ *
+ * @param <T> the item type
+ */
+public final class DefaultFolderConfigEditor<T> implements FolderConfigEditor<T> {
+
+    private final FolderConfigEntry<T> entry;
+
+    /**
+     * Creates a new editor.
+     *
+     * @param entry the folder config entry
+     */
+    public DefaultFolderConfigEditor(@NotNull FolderConfigEntry<T> entry) {
+        this.entry = Objects.requireNonNull(entry, "entry cannot be null");
+    }
+
+    @Override
+    public @NotNull EditResult<T> create(@NotNull String id, @NotNull T value) {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(value, "value cannot be null");
+
+        if (entry.getRef().get().contains(id)) {
+            return EditResult.failure("Item already exists: " + id);
+        }
+
+        return entry.saveItem(id, value);
+    }
+
+    @Override
+    public @NotNull EditResult<T> save(@NotNull String id, @NotNull T value) {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(value, "value cannot be null");
+
+        return entry.saveItem(id, value);
+    }
+
+    @Override
+    public @NotNull EditResult<T> update(@NotNull String id, @NotNull UnaryOperator<T> mutator) {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(mutator, "mutator cannot be null");
+
+        T existing = entry.getRef().get().find(id);
+        if (existing == null) {
+            return EditResult.failure("Item not found: " + id);
+        }
+
+        T copy = entry.copyItem(existing);
+        if (copy == null) {
+            return EditResult.failure("Failed to create copy of item for update");
+        }
+
+        T modified = mutator.apply(copy);
+        if (modified == null) {
+            return EditResult.failure("Mutator returned null");
+        }
+
+        return entry.saveItem(id, modified);
+    }
+
+    @Override
+    public @NotNull EditResult<Void> delete(@NotNull String id) {
+        Objects.requireNonNull(id, "id cannot be null");
+
+        return entry.deleteItem(id);
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/DefaultFolderConfigRef.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/DefaultFolderConfigRef.java
@@ -1,0 +1,159 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.folder;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.folder.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+/**
+ * Default implementation of {@link FolderConfigRef}.
+ * <p>
+ * This class provides thread-safe access to the folder config snapshot using
+ * atomic reference swapping. All reads are lock-free.
+ *
+ * @param <T> the item type
+ */
+public final class DefaultFolderConfigRef<T> implements FolderConfigRef<T> {
+
+    private final Class<T> itemType;
+    private final String folderConfigName;
+    private final AtomicReference<FolderConfigSnapshot<T>> snapshotRef;
+    private final List<FolderConfigChangeListener<T>> listeners = new CopyOnWriteArrayList<>();
+    private final FolderConfigEditor<T> editor;
+    private final Runnable reloadAllHandler;
+    private final Consumer<String> reloadItemHandler;
+
+    /**
+     * Creates a new folder config reference.
+     *
+     * @param itemType          the item type class
+     * @param folderConfigName  the folder config name
+     * @param editor            the folder config editor
+     * @param reloadAllHandler  handler for reloading all items
+     * @param reloadItemHandler handler for reloading a single item
+     */
+    public DefaultFolderConfigRef(
+            @NotNull Class<T> itemType,
+            @NotNull String folderConfigName,
+            @NotNull FolderConfigEditor<T> editor,
+            @NotNull Runnable reloadAllHandler,
+            @NotNull Consumer<String> reloadItemHandler) {
+        this.itemType = Objects.requireNonNull(itemType, "itemType cannot be null");
+        this.folderConfigName = Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+        this.editor = Objects.requireNonNull(editor, "editor cannot be null");
+        this.reloadAllHandler = Objects.requireNonNull(reloadAllHandler, "reloadAllHandler cannot be null");
+        this.reloadItemHandler = Objects.requireNonNull(reloadItemHandler, "reloadItemHandler cannot be null");
+        this.snapshotRef = new AtomicReference<>(
+                DefaultFolderConfigSnapshot.empty(itemType, folderConfigName)
+        );
+    }
+
+    @Override
+    public @NotNull FolderConfigSnapshot<T> get() {
+        return snapshotRef.get();
+    }
+
+    @Override
+    public @NotNull FolderConfigEditor<T> edit() {
+        return editor;
+    }
+
+    @Override
+    public void reloadAll() {
+        reloadAllHandler.run();
+    }
+
+    @Override
+    public void reloadItem(@NotNull String id) {
+        Objects.requireNonNull(id, "id cannot be null");
+        reloadItemHandler.accept(id);
+    }
+
+    @Override
+    public void addListener(@NotNull FolderConfigChangeListener<T> listener) {
+        Objects.requireNonNull(listener, "listener cannot be null");
+        listeners.add(listener);
+    }
+
+    @Override
+    public void removeListener(@NotNull FolderConfigChangeListener<T> listener) {
+        Objects.requireNonNull(listener, "listener cannot be null");
+        listeners.remove(listener);
+    }
+
+    @Override
+    public @NotNull Class<T> getItemType() {
+        return itemType;
+    }
+
+    @Override
+    public @NotNull String getFolderConfigName() {
+        return folderConfigName;
+    }
+
+    /**
+     * Updates the snapshot and notifies listeners of changes.
+     *
+     * @param newSnapshot the new snapshot
+     * @param changes     the list of changes
+     */
+    public void updateSnapshot(
+            @NotNull FolderConfigSnapshot<T> newSnapshot,
+            @NotNull List<FolderConfigItemChange<T>> changes) {
+        snapshotRef.set(newSnapshot);
+
+        for (FolderConfigItemChange<T> change : changes) {
+            notifyListeners(change);
+        }
+    }
+
+    /**
+     * Updates the snapshot without notifying listeners.
+     *
+     * @param newSnapshot the new snapshot
+     */
+    public void setSnapshot(@NotNull FolderConfigSnapshot<T> newSnapshot) {
+        snapshotRef.set(newSnapshot);
+    }
+
+    /**
+     * Notifies listeners of a single change.
+     *
+     * @param change the change
+     */
+    public void notifyListeners(@NotNull FolderConfigItemChange<T> change) {
+        for (FolderConfigChangeListener<T> listener : listeners) {
+            try {
+                listener.onItemChange(change);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/DefaultFolderConfigSnapshot.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/DefaultFolderConfigSnapshot.java
@@ -1,0 +1,152 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.folder;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigSnapshot;
+
+import java.util.*;
+
+/**
+ * Default implementation of {@link FolderConfigSnapshot}.
+ * <p>
+ * This is an immutable snapshot that is swapped atomically on reload.
+ *
+ * @param <T> the item type
+ */
+public final class DefaultFolderConfigSnapshot<T> implements FolderConfigSnapshot<T> {
+
+    private final Class<T> itemType;
+    private final String folderConfigName;
+    private final Map<String, T> itemsById;
+    private final List<T> orderedValues;
+    private final List<T> enabledValues;
+
+    /**
+     * Creates a new snapshot.
+     *
+     * @param itemType         the item type class
+     * @param folderConfigName the folder config name
+     * @param itemsById        map of items by ID
+     * @param orderedValues    ordered list of all values
+     * @param enabledValues    list of enabled values
+     */
+    public DefaultFolderConfigSnapshot(
+            @NotNull Class<T> itemType,
+            @NotNull String folderConfigName,
+            @NotNull Map<String, T> itemsById,
+            @NotNull List<T> orderedValues,
+            @Nullable List<T> enabledValues) {
+        this.itemType = Objects.requireNonNull(itemType, "itemType cannot be null");
+        this.folderConfigName = Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+        this.itemsById = Collections.unmodifiableMap(new LinkedHashMap<>(itemsById));
+        this.orderedValues = Collections.unmodifiableList(new ArrayList<>(orderedValues));
+        this.enabledValues = enabledValues != null
+                ? Collections.unmodifiableList(new ArrayList<>(enabledValues))
+                : this.orderedValues;
+    }
+
+    /**
+     * Creates an empty snapshot.
+     *
+     * @param itemType         the item type class
+     * @param folderConfigName the folder config name
+     * @param <T>              the item type
+     * @return an empty snapshot
+     */
+    public static <T> DefaultFolderConfigSnapshot<T> empty(
+            @NotNull Class<T> itemType,
+            @NotNull String folderConfigName) {
+        return new DefaultFolderConfigSnapshot<>(
+                itemType,
+                folderConfigName,
+                Collections.emptyMap(),
+                Collections.emptyList(),
+                null
+        );
+    }
+
+    @Override
+    public @NotNull T get(@NotNull String id) {
+        T item = itemsById.get(id);
+        if (item == null) {
+            throw new IllegalArgumentException("No item with ID '" + id + "' in folder config '" + folderConfigName + "'");
+        }
+        return item;
+    }
+
+    @Override
+    public @Nullable T find(@NotNull String id) {
+        return itemsById.get(id);
+    }
+
+    @Override
+    public @NotNull Collection<T> values() {
+        return orderedValues;
+    }
+
+    @Override
+    public @NotNull Set<String> ids() {
+        return itemsById.keySet();
+    }
+
+    @Override
+    public @NotNull Collection<T> enabled() {
+        return enabledValues;
+    }
+
+    @Override
+    public boolean contains(@NotNull String id) {
+        return itemsById.containsKey(id);
+    }
+
+    @Override
+    public int size() {
+        return itemsById.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return itemsById.isEmpty();
+    }
+
+    @Override
+    public @NotNull Class<T> getItemType() {
+        return itemType;
+    }
+
+    @Override
+    public @NotNull String getFolderConfigName() {
+        return folderConfigName;
+    }
+
+    /**
+     * Gets the internal items map for building diffs.
+     *
+     * @return the items map
+     */
+    public @NotNull Map<String, T> getItemsMap() {
+        return itemsById;
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/FolderConfigEntry.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/folder/FolderConfigEntry.java
@@ -1,0 +1,1013 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.folder;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfig;
+import tech.guilhermekaua.spigotboot.config.annotation.NodeKey;
+import tech.guilhermekaua.spigotboot.config.binding.Binder;
+import tech.guilhermekaua.spigotboot.config.binding.BindingResult;
+import tech.guilhermekaua.spigotboot.config.binding.NamingStrategy;
+import tech.guilhermekaua.spigotboot.config.folder.ConfigNodeHash;
+import tech.guilhermekaua.spigotboot.config.folder.EditResult;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigItemChange;
+import tech.guilhermekaua.spigotboot.config.loader.ConfigSource;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.loader.YamlConfigLoader;
+import tech.guilhermekaua.spigotboot.core.scanner.ResourceScanUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Internal entry holding folder config state for BungeeConfigManager.
+ * <p>
+ * Each {@link FolderConfigEntry} manages one folder-based folder config.
+ *
+ * @param <T> the item type
+ */
+public final class FolderConfigEntry<T> {
+    private static final String[] EXTENSIONS = {"yml", "yaml"};
+    private static final Pattern SAFE_ID_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
+
+    private final Class<T> itemType;
+    private final String folderConfigName;
+    private final Path folder;
+    private final FolderConfig annotation;
+    private final YamlConfigLoader loader;
+    private final Binder binder;
+    private final NamingStrategy namingStrategy;
+    private final Plugin plugin;
+    private final Logger logger;
+
+    private final DefaultFolderConfigRef<T> ref;
+    private final DefaultFolderConfigEditor<T> editor;
+
+    private final Map<String, ItemMeta> itemMetadata = new ConcurrentHashMap<>();
+    private final Map<String, ConfigNode> itemNodes = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new folder config entry.
+     *
+     * @param itemType       the item type class
+     * @param annotation     the @{@link FolderConfig} annotation
+     * @param plugin         the owning plugin
+     * @param loader         the YAML loader
+     * @param binder         the config binder
+     * @param namingStrategy the naming strategy for field to config key conversion
+     */
+    public FolderConfigEntry(
+            @NotNull Class<T> itemType,
+            @NotNull FolderConfig annotation,
+            @NotNull Plugin plugin,
+            @NotNull YamlConfigLoader loader,
+            @NotNull Binder binder,
+            @NotNull NamingStrategy namingStrategy) {
+        this.itemType = Objects.requireNonNull(itemType, "itemType cannot be null");
+        this.annotation = Objects.requireNonNull(annotation, "annotation cannot be null");
+        this.plugin = Objects.requireNonNull(plugin, "plugin cannot be null");
+        this.loader = Objects.requireNonNull(loader, "loader cannot be null");
+        this.binder = Objects.requireNonNull(binder, "binder cannot be null");
+        this.namingStrategy = Objects.requireNonNull(namingStrategy, "namingStrategy cannot be null");
+        this.logger = plugin.getLogger();
+
+        String name = annotation.name();
+        if (name.isEmpty()) {
+            name = deriveNameFromFolder(annotation.folder());
+        }
+        this.folderConfigName = name;
+
+        this.folder = plugin.getDataFolder().toPath().resolve(annotation.folder());
+
+        this.editor = new DefaultFolderConfigEditor<>(this);
+        this.ref = new DefaultFolderConfigRef<>(
+                itemType,
+                folderConfigName,
+                editor,
+                this::reloadAll,
+                this::reloadItem
+        );
+    }
+
+    private String deriveNameFromFolder(@NotNull String folderPath) {
+        String normalized = folderPath.replace('\\', '/');
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        int lastSlash = normalized.lastIndexOf('/');
+        return lastSlash >= 0 ? normalized.substring(lastSlash + 1) : normalized;
+    }
+
+    public @NotNull Class<T> getItemType() {
+        return itemType;
+    }
+
+    public @NotNull String getFolderConfigName() {
+        return folderConfigName;
+    }
+
+    public @NotNull Path getFolder() {
+        return folder;
+    }
+
+    public @NotNull DefaultFolderConfigRef<T> getRef() {
+        return ref;
+    }
+
+    /**
+     * Gets the raw config node for a specific item.
+     *
+     * @param itemId the item ID
+     * @return the raw config node, or null if item not found
+     */
+    public @Nullable ConfigNode getItemNode(@NotNull String itemId) {
+        return itemNodes.get(itemId);
+    }
+
+    /**
+     * Gets all item IDs that have raw nodes.
+     *
+     * @return set of item IDs
+     */
+    public @NotNull Set<String> getItemIds() {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(itemNodes.keySet()));
+    }
+
+    public void initialize() {
+        prepareFolder();
+        loadAll();
+    }
+
+    public void prepareFolder() {
+        ensureFolderExists();
+        copyDefaultsFromResources();
+    }
+
+    /**
+     * Loads all items from the folder with filename ordering.
+     */
+    public void loadAll() {
+        if (!Files.exists(folder)) {
+            ref.setSnapshot(DefaultFolderConfigSnapshot.empty(itemType, folderConfigName));
+            return;
+        }
+
+        Map<String, ConfigNode> rawNodes = scanAndLoadRawNodes();
+        List<String> bindOrder = sortedKeys(rawNodes);
+
+        Map<String, T> itemsById = new LinkedHashMap<>();
+        Map<String, ItemMeta> newMetadata = new LinkedHashMap<>();
+
+        for (String id : bindOrder) {
+            ConfigNode node = rawNodes.get(id);
+            if (node == null) {
+                continue;
+            }
+            T item = bindItem(id, node);
+            if (item != null) {
+                itemsById.put(id, item);
+                newMetadata.put(id, createItemMeta(node));
+            }
+        }
+
+        finalizeSnapshot(itemsById, newMetadata);
+    }
+
+    /**
+     * Loads raw nodes from disk without binding them.
+     * <p>
+     * Used when reference scanning needs to happen across all folder configs
+     * before determining binding order. After calling this, use
+     * {@link #getItemIds()} and {@link #getItemNode(String)} to access the nodes,
+     * then call {@link #bindFromLoadedNodes(List)} to bind them.
+     *
+     * @return map of item ID to raw config node
+     */
+    public @NotNull Map<String, ConfigNode> loadRawNodesOnly() {
+        if (!Files.exists(folder)) {
+            return Collections.emptyMap();
+        }
+        return scanAndLoadRawNodes();
+    }
+
+    /**
+     * Binds items from already-loaded raw nodes in the specified order.
+     * <p>
+     * Raw nodes must have been loaded via {@link #loadRawNodesOnly()} first.
+     * If no raw nodes are loaded, this creates an empty snapshot.
+     *
+     * @param bindOrder the order in which to bind items
+     */
+    public void bindFromLoadedNodes(@NotNull List<String> bindOrder) {
+        Objects.requireNonNull(bindOrder, "bindOrder cannot be null");
+
+        Map<String, T> itemsById = new LinkedHashMap<>();
+        Map<String, ItemMeta> newMetadata = new LinkedHashMap<>();
+
+        Set<String> bound = new HashSet<>();
+
+        for (String id : bindOrder) {
+            if (!bound.add(id)) {
+                continue;
+            }
+            ConfigNode node = itemNodes.get(id);
+            if (node == null) {
+                continue;
+            }
+            T item = bindItem(id, node);
+            if (item != null) {
+                itemsById.put(id, item);
+                newMetadata.put(id, createItemMeta(node));
+            }
+        }
+
+        List<String> remainingIds = new ArrayList<>(itemNodes.keySet());
+        remainingIds.removeAll(bound);
+        remainingIds.sort(String::compareTo);
+
+        for (String id : remainingIds) {
+            ConfigNode node = itemNodes.get(id);
+            if (node == null) {
+                continue;
+            }
+            T item = bindItem(id, node);
+            if (item != null) {
+                itemsById.put(id, item);
+                newMetadata.put(id, createItemMeta(node));
+            }
+        }
+
+        finalizeSnapshot(itemsById, newMetadata);
+    }
+
+    private @NotNull Map<String, ConfigNode> scanAndLoadRawNodes() {
+        Map<String, ConfigNode> rawNodes = new LinkedHashMap<>();
+
+        itemNodes.clear();
+
+        if (!Files.exists(folder)) {
+            return rawNodes;
+        }
+
+        String excludePrefix = annotation.excludePrefix();
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(folder)) {
+            List<Path> files = collectMatchingFiles(stream, excludePrefix);
+            files.sort(Comparator.comparing(p -> p.getFileName().toString()));
+
+            for (Path path : files) {
+                String id = getIdFromPath(path);
+                try {
+                    ConfigNode node = loader.load(ConfigSource.file(path));
+                    rawNodes.put(id, node);
+                    itemNodes.put(id, node);
+                } catch (Exception e) {
+                    logger.warning("Failed to load: " + path + ": " + e.getMessage());
+                }
+            }
+        } catch (IOException e) {
+            logger.warning("Failed to scan folder " + folder + ": " + e.getMessage());
+        }
+
+        return rawNodes;
+    }
+
+    private @NotNull List<Path> collectMatchingFiles(
+            @NotNull DirectoryStream<Path> stream,
+            @NotNull String excludePrefix) {
+        List<Path> files = new ArrayList<>();
+        for (Path path : stream) {
+            if (!Files.isRegularFile(path)) {
+                continue;
+            }
+            String fileName = path.getFileName().toString();
+            if (!excludePrefix.isEmpty() && fileName.startsWith(excludePrefix)) {
+                continue;
+            }
+            if (!matchesPattern(fileName)) {
+                continue;
+            }
+            files.add(path);
+        }
+        return files;
+    }
+
+    private @NotNull List<String> sortedKeys(@NotNull Map<String, ConfigNode> rawNodes) {
+        List<String> keys = new ArrayList<>(rawNodes.keySet());
+        keys.sort(String::compareTo);
+        return keys;
+    }
+
+    private void finalizeSnapshot(
+            @NotNull Map<String, T> itemsById,
+            @NotNull Map<String, ItemMeta> newMetadata) {
+
+        List<T> orderedValues = new ArrayList<>(itemsById.values());
+
+        String orderBy = annotation.orderBy();
+        if (!orderBy.isEmpty() && !"filename".equals(orderBy)) {
+            orderByField(orderedValues, orderBy);
+        }
+
+        List<T> enabledItems = computeEnabledItems(orderedValues);
+
+        itemMetadata.clear();
+        itemMetadata.putAll(newMetadata);
+
+        ref.setSnapshot(new DefaultFolderConfigSnapshot<>(
+                itemType, folderConfigName, itemsById, orderedValues, enabledItems
+        ));
+
+        logger.fine("Loaded " + itemsById.size() + " items in '" + folderConfigName + "'");
+    }
+
+    public @Nullable T bindItem(@NotNull String id, @NotNull ConfigNode node) {
+        Objects.requireNonNull(id, "id cannot be null");
+        Objects.requireNonNull(node, "node cannot be null");
+
+        try {
+            BindingResult<T> result = binder.bind(node, itemType, namingStrategy);
+
+            if (result.hasErrors()) {
+                logger.warning("Binding errors for " + id + ": " + result.errors());
+                return null;
+            }
+            if (result.hasValidationErrors()) {
+                logger.warning("Validation errors for " + id + ": " + result.validationErrors());
+                return null;
+            }
+
+            T item = result.get();
+            injectId(item, id);
+            return item;
+        } catch (Exception e) {
+            logger.warning("Failed to bind item " + id + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Reloads the raw node for a single item from disk.
+     * <p>
+     * Used during reload propagation to update the raw node before rebinding.
+     *
+     * @param itemId the item ID
+     */
+    public void reloadItemRawNode(@NotNull String itemId) {
+        Path itemPath = resolveItemPath(itemId);
+        if (!Files.exists(itemPath)) {
+            itemNodes.remove(itemId);
+            return;
+        }
+
+        try {
+            ConfigNode node = loader.load(ConfigSource.file(itemPath));
+            itemNodes.put(itemId, node);
+        } catch (Exception e) {
+            logger.warning("Failed to reload raw node for " + itemId + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Rebinds a single item from its raw node and updates the snapshot.
+     * <p>
+     * The raw node must already be loaded. Used during reload propagation
+     * when only specific items need rebinding.
+     *
+     * @param itemId the item ID to rebind
+     */
+    public void rebindItem(@NotNull String itemId) {
+        ConfigNode node = itemNodes.get(itemId);
+        if (node == null) {
+            removeItemFromSnapshot(itemId);
+            return;
+        }
+
+        T item = bindItem(itemId, node);
+        if (item != null) {
+            updateItemInSnapshot(itemId, item);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void updateItemInSnapshot(@NotNull String itemId, @NotNull T item) {
+        DefaultFolderConfigSnapshot<T> oldSnapshot =
+                (DefaultFolderConfigSnapshot<T>) ref.get();
+        if (oldSnapshot == null) {
+            oldSnapshot = DefaultFolderConfigSnapshot.empty(itemType, folderConfigName);
+        }
+        Map<String, T> items = new LinkedHashMap<>(oldSnapshot.getItemsMap());
+        T oldItem = items.put(itemId, item);
+        itemMetadata.put(itemId, createItemMetaFromRegisteredNode(itemId));
+        rebuildSnapshot(items);
+
+        if (oldItem == null) {
+            notifyItemAdded(itemId, item);
+        } else {
+            notifyItemModified(itemId, oldItem, item);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void removeItemFromSnapshot(@NotNull String itemId) {
+        DefaultFolderConfigSnapshot<T> oldSnapshot =
+                (DefaultFolderConfigSnapshot<T>) ref.get();
+        if (oldSnapshot == null) {
+            oldSnapshot = DefaultFolderConfigSnapshot.empty(itemType, folderConfigName);
+        }
+        Map<String, T> items = new LinkedHashMap<>(oldSnapshot.getItemsMap());
+        T oldItem = items.remove(itemId);
+        if (oldItem != null) {
+            itemMetadata.remove(itemId);
+            itemNodes.remove(itemId);
+            rebuildSnapshot(items);
+            notifyItemRemoved(itemId, oldItem);
+        }
+    }
+
+    private void notifyItemAdded(@NotNull String id, @NotNull T item) {
+        ref.notifyListeners(FolderConfigItemChange.added(folderConfigName, itemType, id, item));
+    }
+
+    private void notifyItemModified(@NotNull String id, @NotNull T oldItem, @NotNull T newItem) {
+        ref.notifyListeners(FolderConfigItemChange.modified(folderConfigName, itemType, id, oldItem, newItem));
+    }
+
+    private void notifyItemRemoved(@NotNull String id, @NotNull T oldItem) {
+        ref.notifyListeners(FolderConfigItemChange.removed(folderConfigName, itemType, id, oldItem));
+    }
+
+    private ItemMeta createItemMetaFromRegisteredNode(String id) {
+        try {
+            ConfigNode node = itemNodes.get(id);
+            if (node == null) {
+                return new ItemMeta("");
+            }
+
+            return createItemMeta(node);
+        } catch (Exception e) {
+            logger.log(Level.FINE, "Failed to create metadata for: " + id, e);
+            return new ItemMeta("");
+        }
+    }
+
+    private void ensureFolderExists() {
+        try {
+            if (!Files.exists(folder)) {
+                Files.createDirectories(folder);
+                logger.info("Created folder config folder: " + folder);
+            }
+        } catch (IOException e) {
+            logger.warning("Failed to create folder config folder: " + folder + " - " + e.getMessage());
+        }
+    }
+
+    /**
+     * Copies default YAML files from resources if the folder is empty.
+     * Automatically discovers all .yml/.yaml files in the resource path.
+     */
+    private void copyDefaultsFromResources() {
+        String resourcePath = annotation.resource();
+        if (resourcePath.isEmpty()) {
+            return;
+        }
+
+        try {
+            try (Stream<Path> files = Files.list(folder)) {
+                if (files.findFirst().isPresent()) {
+                    return;
+                }
+            }
+
+            String normalizedPath = ResourceScanUtils.normalizePath(resourcePath);
+
+            // Object-typed on purpose: the 1.8.8 sniffer signature lacks JDK supertypes, so
+            // getClass() must resolve via the java.* ignore (see root pom)
+            Object pluginObject = plugin;
+            URL jarUrl = pluginObject.getClass().getProtectionDomain()
+                    .getCodeSource().getLocation();
+
+            if (jarUrl != null && jarUrl.getPath().endsWith(".jar")) {
+                copyFromJar(jarUrl, normalizedPath);
+            } else {
+                copyFromFilesystem(normalizedPath);
+            }
+        } catch (IOException e) {
+            logger.warning("Failed to copy defaults from resources: " + e.getMessage());
+        }
+    }
+
+    private void copyFromJar(URL jarUrl, String resourcePath) {
+        try {
+            File jarFile = new File(jarUrl.toURI());
+            try (JarFile jar = new JarFile(jarFile)) {
+                List<String> entries = ResourceScanUtils.scanJar(jar, resourcePath,
+                        entry -> ResourceScanUtils.hasExtension(entry.getName(), EXTENSIONS));
+
+                for (String entryName : entries) {
+                    String fileName = entryName.substring(resourcePath.length());
+                    copyResourceFile(entryName, fileName);
+                }
+            }
+        } catch (URISyntaxException | IOException e) {
+            logger.warning("Failed to scan JAR for resources: " + e.getMessage());
+        }
+    }
+
+    private void copyFromFilesystem(String resourcePath) {
+        // Object-typed on purpose: the 1.8.8 sniffer signature lacks JDK supertypes, so
+        // getClass() must resolve via the java.* ignore (see root pom)
+        Object pluginObject = plugin;
+        URL resourceUrl = pluginObject.getClass().getClassLoader().getResource(resourcePath);
+        if (resourceUrl == null) {
+            return;
+        }
+
+        try {
+            Path resourceDir = Paths.get(resourceUrl.toURI());
+            List<Path> files = ResourceScanUtils.scanDirectory(resourceDir,
+                    p -> ResourceScanUtils.hasExtension(p.getFileName().toString(), EXTENSIONS));
+
+            for (Path file : files) {
+                String fileName = file.getFileName().toString();
+                copyResourceFile(resourcePath + fileName, fileName);
+            }
+        } catch (URISyntaxException | IOException e) {
+            logger.warning("Failed to scan filesystem for resources: " + e.getMessage());
+        }
+    }
+
+    private void copyResourceFile(String resourcePath, String fileName) {
+        try (InputStream is = plugin.getResourceAsStream(resourcePath)) {
+            if (is != null) {
+                Path normalizedFolder = folder.toAbsolutePath().normalize();
+                Path targetPath = normalizedFolder.resolve(fileName).normalize();
+                if (!targetPath.startsWith(normalizedFolder)) {
+                    logger.warning("Skipping suspicious resource path outside target folder: " + fileName);
+                    return;
+                }
+
+                Files.copy(is, targetPath);
+                logger.info("Copied default: " + fileName);
+            }
+        } catch (IOException e) {
+            logger.warning("Failed to copy resource " + fileName + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Reloads all items and computes changes.
+     */
+    public void reloadAll() {
+        DefaultFolderConfigSnapshot<T> oldSnapshot =
+                (DefaultFolderConfigSnapshot<T>) ref.get();
+        Map<String, T> oldItems = oldSnapshot.getItemsMap();
+        Map<String, ItemMeta> oldMetadata = new HashMap<>(itemMetadata);
+
+        loadAll();
+
+        DefaultFolderConfigSnapshot<T> newSnapshot =
+                (DefaultFolderConfigSnapshot<T>) ref.get();
+        Map<String, T> newItems = newSnapshot.getItemsMap();
+
+        List<FolderConfigItemChange<T>> changes = computeChanges(oldItems, newItems, oldMetadata);
+        for (FolderConfigItemChange<T> change : changes) {
+            ref.notifyListeners(change);
+        }
+    }
+
+    public void reloadItem(@NotNull String id) {
+        Path itemPath = resolveItemPath(id);
+        DefaultFolderConfigSnapshot<T> oldSnapshot =
+                (DefaultFolderConfigSnapshot<T>) ref.get();
+        Map<String, T> oldItems = new LinkedHashMap<>(oldSnapshot.getItemsMap());
+        T oldItem = oldItems.get(id);
+
+        if (!Files.exists(itemPath)) {
+            if (oldItem != null) {
+                oldItems.remove(id);
+                itemMetadata.remove(id);
+                rebuildSnapshot(oldItems);
+                notifyItemRemoved(id, oldItem);
+            }
+            return;
+        }
+
+        T newItem = loadItem(itemPath, id);
+        if (newItem == null) {
+            return;
+        }
+
+        if (oldItem == null) {
+            oldItems.put(id, newItem);
+            itemMetadata.put(id, createItemMeta(itemPath));
+            rebuildSnapshot(oldItems);
+            notifyItemAdded(id, newItem);
+        } else {
+            ItemMeta oldMeta = itemMetadata.get(id);
+            ItemMeta newMeta = createItemMeta(itemPath);
+
+            if (oldMeta == null || !oldMeta.hash.equals(newMeta.hash)) {
+                oldItems.put(id, newItem);
+                itemMetadata.put(id, newMeta);
+                rebuildSnapshot(oldItems);
+                notifyItemModified(id, oldItem, newItem);
+            }
+        }
+    }
+
+    /**
+     * Saves an item to disk.
+     *
+     * @param id    the item ID
+     * @param value the item value
+     * @return the edit result
+     */
+    public @NotNull EditResult<T> saveItem(@NotNull String id, @NotNull T value) {
+        if (!isValidId(id)) {
+            return EditResult.failure("Invalid item ID: '" + id + "'. " +
+                    "ID must contain only letters, numbers, dots, underscores, and hyphens.");
+        }
+
+        Path itemPath = resolveItemPath(id);
+        try {
+            MutableConfigNode node = loader.createNode();
+            binder.unbind(value, node, namingStrategy);
+            loader.save(node, ConfigSource.file(itemPath));
+
+            T loadedItem = loadItem(itemPath, id);
+            if (loadedItem == null) {
+                return EditResult.failure("Failed to reload saved item");
+            }
+
+            DefaultFolderConfigSnapshot<T> oldSnapshot =
+                    (DefaultFolderConfigSnapshot<T>) ref.get();
+            Map<String, T> items = new LinkedHashMap<>(oldSnapshot.getItemsMap());
+            boolean isNew = !items.containsKey(id);
+            T oldItem = items.put(id, loadedItem);
+            itemMetadata.put(id, createItemMeta(itemPath));
+            rebuildSnapshot(items);
+
+            if (isNew) {
+                notifyItemAdded(id, loadedItem);
+            } else {
+                notifyItemModified(id, oldItem, loadedItem);
+            }
+
+            return EditResult.success(loadedItem);
+        } catch (Exception e) {
+            logger.warning("Failed to save item " + id + ": " + e.getMessage());
+            return EditResult.failure("Failed to save: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Deletes an item from disk.
+     *
+     * @param id the item ID
+     * @return the edit result
+     */
+    public @NotNull EditResult<Void> deleteItem(@NotNull String id) {
+        Path itemPath = resolveItemPath(id);
+
+        DefaultFolderConfigSnapshot<T> oldSnapshot =
+                (DefaultFolderConfigSnapshot<T>) ref.get();
+        T oldItem = oldSnapshot.find(id);
+
+        if (oldItem == null) {
+            return EditResult.failure("Item not found: " + id);
+        }
+
+        try {
+            Files.deleteIfExists(itemPath);
+
+            Map<String, T> items = new LinkedHashMap<>(oldSnapshot.getItemsMap());
+            items.remove(id);
+            itemMetadata.remove(id);
+            rebuildSnapshot(items);
+
+            notifyItemRemoved(id, oldItem);
+
+            return EditResult.success();
+        } catch (IOException e) {
+            logger.warning("Failed to delete item " + id + ": " + e.getMessage());
+            return EditResult.failure("Failed to delete: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Creates a copy of an item for safe mutation.
+     *
+     * @param item the item to copy
+     * @return the copy
+     */
+    public @Nullable T copyItem(@NotNull T item) {
+        try {
+            MutableConfigNode node = loader.createNode();
+            binder.unbind(item, node, namingStrategy);
+            BindingResult<T> result = binder.bind(node, itemType, namingStrategy);
+            if (result.hasErrors() || result.hasValidationErrors()) {
+                return null;
+            }
+            return result.get();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private boolean matchesPattern(String fileName) {
+        for (String extension : EXTENSIONS) {
+            if (fileName.endsWith("." + extension)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private String getIdFromPath(Path path) {
+        String fileName = path.getFileName().toString();
+        int dotIndex = fileName.lastIndexOf('.');
+        return dotIndex > 0 ? fileName.substring(0, dotIndex) : fileName;
+    }
+
+    private Path resolveItemPath(String id) {
+        Path ymlPath = folder.resolve(id + ".yml");
+        Path yamlPath = folder.resolve(id + ".yaml");
+        if (Files.exists(yamlPath)) {
+            return yamlPath;
+        }
+        return ymlPath;
+    }
+
+    private boolean isValidId(String id) {
+        if (id == null || id.isEmpty()) {
+            return false;
+        }
+        if (id.contains("..") || id.contains("/") || id.contains("\\")) {
+            return false;
+        }
+        return SAFE_ID_PATTERN.matcher(id).matches();
+    }
+
+    private @Nullable T loadItem(Path path, String id) {
+        try {
+            ConfigNode node = loader.load(ConfigSource.file(path));
+
+            T item = bindItem(id, node);
+
+            itemNodes.put(id, node);
+
+            return item;
+        } catch (Exception e) {
+            logger.warning("Failed to load item from " + path + ": " + e.getMessage());
+            return null;
+        }
+    }
+
+    private void injectId(T item, String id) {
+        String idField = annotation.idField();
+        if (!idField.isEmpty()) {
+            setFieldValue(item, idField, id);
+            return;
+        }
+
+        Field field = findAnnotatedField(itemType, NodeKey.class);
+        if (field != null) {
+            field.setAccessible(true);
+            try {
+                field.set(item, id);
+            } catch (Exception e) {
+                logger.log(Level.FINE, "Failed to inject ID into @NodeKey field: " + field.getName(), e);
+            }
+        }
+    }
+
+    private void setFieldValue(Object obj, String fieldName, Object value) {
+        Field field = findField(obj.getClass(), fieldName);
+        if (field != null) {
+            field.setAccessible(true);
+            try {
+                field.set(obj, value);
+            } catch (Exception e) {
+                logger.log(Level.FINE, "Failed to set field value: " + fieldName, e);
+            }
+        } else {
+            logger.log(Level.FINE, "Field not found: " + fieldName);
+        }
+    }
+
+    private void orderByField(List<T> items, String fieldName) {
+        Field field = findField(itemType, fieldName);
+        if (field == null) {
+            logger.log(Level.FINE, "Order-by field not found: " + fieldName);
+            return;
+        }
+        field.setAccessible(true);
+
+        items.sort((a, b) -> {
+            try {
+                Object va = field.get(a);
+                Object vb = field.get(b);
+                if (va instanceof Comparable && vb instanceof Comparable) {
+                    @SuppressWarnings("unchecked")
+                    Comparable<Object> ca = (Comparable<Object>) va;
+                    return ca.compareTo(vb);
+                }
+            } catch (Exception e) {
+                logger.log(Level.FINE, "Failed to compare field values for ordering", e);
+            }
+            return 0;
+        });
+    }
+
+    private @Nullable List<T> computeEnabledItems(List<T> items) {
+        String enabledField = annotation.enabledField();
+        if (enabledField.isEmpty()) {
+            return null;
+        }
+
+        Field field = findField(itemType, enabledField);
+        if (field == null) {
+            logger.log(Level.FINE, "Enabled field not found: " + enabledField);
+            return null;
+        }
+        field.setAccessible(true);
+
+        if (field.getType() != boolean.class && field.getType() != Boolean.class) {
+            return null;
+        }
+
+        List<T> enabled = new ArrayList<>();
+        for (T item : items) {
+            try {
+                Object value = field.get(item);
+                if (Boolean.TRUE.equals(value)) {
+                    enabled.add(item);
+                }
+            } catch (Exception e) {
+                logger.log(Level.FINE, "Failed to read enabled field, assuming enabled", e);
+                enabled.add(item);
+            }
+        }
+        return enabled;
+    }
+
+    private ItemMeta createItemMeta(Path path) {
+        try {
+            ConfigNode node = loader.load(ConfigSource.file(path));
+
+            return createItemMeta(node);
+        } catch (Exception e) {
+            logger.log(Level.FINE, "Failed to create metadata for: " + path, e);
+            return new ItemMeta("");
+        }
+    }
+
+    private ItemMeta createItemMeta(ConfigNode node) {
+        try {
+            String hash = ConfigNodeHash.sha256(node);
+            return new ItemMeta(hash);
+        } catch (Exception e) {
+            logger.log(Level.FINE, "Failed to create metadata for: " + node.path().asString(), e);
+            return new ItemMeta("");
+        }
+    }
+
+    private List<FolderConfigItemChange<T>> computeChanges(
+            Map<String, T> oldItems,
+            Map<String, T> newItems,
+            Map<String, ItemMeta> oldMetadata) {
+        List<FolderConfigItemChange<T>> changes = new ArrayList<>();
+
+        for (Map.Entry<String, T> entry : oldItems.entrySet()) {
+            if (!newItems.containsKey(entry.getKey())) {
+                changes.add(FolderConfigItemChange.removed(
+                        folderConfigName, itemType, entry.getKey(), entry.getValue()
+                ));
+            }
+        }
+
+        for (Map.Entry<String, T> entry : newItems.entrySet()) {
+            String id = entry.getKey();
+            T newItem = entry.getValue();
+            T oldItem = oldItems.get(id);
+
+            if (oldItem == null) {
+                changes.add(FolderConfigItemChange.added(
+                        folderConfigName, itemType, id, newItem
+                ));
+            } else {
+                ItemMeta oldMeta = oldMetadata.get(id);
+                ItemMeta newMeta = itemMetadata.get(id);
+                if (oldMeta == null || newMeta == null || !oldMeta.hash.equals(newMeta.hash)) {
+                    changes.add(FolderConfigItemChange.modified(
+                            folderConfigName, itemType, id, oldItem, newItem
+                    ));
+                }
+            }
+        }
+
+        return changes;
+    }
+
+    private void rebuildSnapshot(Map<String, T> items) {
+        List<T> orderedValues = new ArrayList<>(items.values());
+
+        String orderBy = annotation.orderBy();
+        if (!orderBy.isEmpty() && !"filename".equals(orderBy)) {
+            orderByField(orderedValues, orderBy);
+        }
+
+        List<T> enabledItems = computeEnabledItems(orderedValues);
+
+        ref.setSnapshot(new DefaultFolderConfigSnapshot<>(
+                itemType, folderConfigName, items, orderedValues, enabledItems
+        ));
+    }
+
+    /**
+     * Finds a field by name, traversing the class hierarchy.
+     *
+     * @param clazz     the class to search
+     * @param fieldName the name of the field to find
+     * @return the Field if found, or null if not found in this class or any superclass
+     */
+    private @Nullable Field findField(Class<?> clazz, String fieldName) {
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            try {
+                return current.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                current = current.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds a field by annotation type, traversing the class hierarchy.
+     *
+     * @param clazz          the class to search
+     * @param annotationType the annotation type to look for
+     * @return the first Field annotated with the given annotation type, or null if none found
+     */
+    private @Nullable Field findAnnotatedField(Class<?> clazz, Class<? extends java.lang.annotation.Annotation> annotationType) {
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            for (Field field : current.getDeclaredFields()) {
+                if (field.isAnnotationPresent(annotationType)) {
+                    return field;
+                }
+            }
+            current = current.getSuperclass();
+        }
+        return null;
+    }
+
+    private static final class ItemMeta {
+        final String hash;
+
+        public ItemMeta(String hash) {
+            this.hash = hash;
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/ConfigRefInjector.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/ConfigRefInjector.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.injector;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjector;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+public class ConfigRefInjector implements CustomInjector {
+
+    private final BungeeConfigManager configManager;
+
+    public ConfigRefInjector(@NotNull BungeeConfigManager configManager) {
+        this.configManager = Objects.requireNonNull(configManager, "configManager cannot be null");
+    }
+
+    @Override
+    public boolean supports(@NotNull InjectionPoint injectionPoint) {
+        return injectionPoint.getRawType() == ConfigRef.class;
+    }
+
+    @Override
+    public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+        Type type = injectionPoint.getType();
+        Class<?> configClass = extractConfigType(type);
+        if (configClass == null) {
+            return InjectionResult.notHandled();
+        }
+
+        try {
+            ConfigRef<?> ref = configManager.getRef(configClass);
+            return InjectionResult.handled(ref);
+        } catch (Exception e) {
+            return InjectionResult.notHandled();
+        }
+    }
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+
+    private Class<?> extractConfigType(Type type) {
+        if (!(type instanceof ParameterizedType)) {
+            return null;
+        }
+
+        ParameterizedType paramType = (ParameterizedType) type;
+        Type[] typeArgs = paramType.getActualTypeArguments();
+        if (typeArgs.length == 0) {
+            return null;
+        }
+
+        Type configType = typeArgs[0];
+        if (configType instanceof Class) {
+            return (Class<?>) configType;
+        }
+
+        return null;
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/ConfigValueInjector.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/ConfigValueInjector.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.injector;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.annotation.ConfigValue;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjector;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
+
+import java.util.Objects;
+
+/**
+ * Custom injector that wires {@link ConfigValue} onto fields and constructor parameters of
+ * DI-managed beans.
+ * <p>
+ * {@link #supports(InjectionPoint)} matches strictly on the presence of {@link ConfigValue} so it
+ * never hijacks unrelated injection points. {@link #resolve(InjectionPoint)} always returns a
+ * {@linkplain InjectionResult#handled(Object) handled} result (or throws) — it never returns
+ * {@linkplain InjectionResult#notHandled() not-handled}, because that would let the framework fall
+ * back to by-type bean resolution and silently mis-inject or null the field.
+ */
+public class ConfigValueInjector implements CustomInjector {
+
+    private final ConfigValueResolver resolver;
+
+    /**
+     * Creates the injector.
+     *
+     * @param configManager the config manager, not null
+     */
+    public ConfigValueInjector(@NotNull BungeeConfigManager configManager) {
+        Objects.requireNonNull(configManager, "configManager cannot be null");
+        this.resolver = new ConfigValueResolver(configManager);
+    }
+
+    @Override
+    public boolean supports(@NotNull InjectionPoint injectionPoint) {
+        Objects.requireNonNull(injectionPoint, "injectionPoint cannot be null");
+        return injectionPoint.getAnnotatedElement().isAnnotationPresent(ConfigValue.class);
+    }
+
+    @Override
+    public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+        Objects.requireNonNull(injectionPoint, "injectionPoint cannot be null");
+        return InjectionResult.handled(resolver.resolve(injectionPoint));
+    }
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/ConfigValueResolver.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/ConfigValueResolver.java
@@ -1,0 +1,148 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.injector;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.annotation.ConfigValue;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Parameter;
+import java.util.Objects;
+
+/**
+ * Resolves the value for a {@code @ConfigValue}-annotated injection point.
+ * <p>
+ * Holds all resolution logic so {@link ConfigValueInjector} stays a thin adapter. Detects the
+ * addressing mode, builds the lookup path, reads the value (or the default) through
+ * {@link BungeeConfigManager}, and fails fast with a {@link ConfigException} naming the injection
+ * site on any misconfiguration.
+ */
+public class ConfigValueResolver {
+
+    private final BungeeConfigManager configManager;
+
+    /**
+     * Creates a resolver.
+     *
+     * @param configManager the config manager, not null
+     */
+    public ConfigValueResolver(@NotNull BungeeConfigManager configManager) {
+        this.configManager = Objects.requireNonNull(configManager, "configManager cannot be null");
+    }
+
+    /**
+     * Resolves the value to inject for the given {@code @ConfigValue} injection point.
+     *
+     * @param injectionPoint the injection point, not null
+     * @return the resolved value (may be null only if a registered serializer yields null)
+     * @throws ConfigException on any misconfiguration or missing required value
+     */
+    public @Nullable Object resolve(@NotNull InjectionPoint injectionPoint) {
+        Objects.requireNonNull(injectionPoint, "injectionPoint cannot be null");
+
+        ConfigValue annotation = injectionPoint.getAnnotatedElement().getAnnotation(ConfigValue.class);
+        if (annotation == null) {
+            throw new ConfigException("ConfigValueResolver invoked for an element without @ConfigValue");
+        }
+
+        String site = describeSite(injectionPoint);
+
+        Class<?> targetType = injectionPoint.getRawType();
+        if (targetType == null || targetType.isArray()) {
+            throw new ConfigException("@ConfigValue on " + site +
+                    ": unsupported target type (type variables, wildcards and arrays are not supported)");
+        }
+
+        if (!configManager.isInitialized()) {
+            throw new ConfigException("@ConfigValue on " + site +
+                    ": the config system is not initialized yet. Beans using @ConfigValue must be " +
+                    "constructed at or after BungeeConfigModule (@Order(-500)).");
+        }
+
+        String combinedPath = buildPath(annotation, site);
+
+        Object value;
+        try {
+            value = configManager.deserializeAt(combinedPath, targetType);
+        } catch (ConfigException e) {
+            throw new ConfigException("@ConfigValue on " + site + ": " + e.getMessage(), e);
+        }
+
+        if (value != null) {
+            return value;
+        }
+
+        if (annotation.defaultValue().equals(ConfigValue.DEFAULT_NONE)) {
+            throw new ConfigException("@ConfigValue on " + site +
+                    ": no value found for config path '" + combinedPath + "' and no defaultValue was provided");
+        }
+
+        try {
+            return configManager.coerceDefault(annotation.defaultValue(), targetType);
+        } catch (ConfigException e) {
+            throw new ConfigException("@ConfigValue on " + site + ": cannot coerce defaultValue '" +
+                    annotation.defaultValue() + "' to " + targetType.getName() + ": " + e.getMessage(), e);
+        }
+    }
+
+    // builds the "configName:path" lookup string; config() takes precedence over value()
+    private @NotNull String buildPath(@NotNull ConfigValue annotation, @NotNull String site) {
+        if (annotation.config() != Void.class) {
+            if (annotation.path().isEmpty()) {
+                throw new ConfigException("@ConfigValue on " + site + ": config() is set but path() is empty");
+            }
+            String configName;
+            try {
+                configName = configManager.getConfigName(annotation.config());
+            } catch (ConfigException e) {
+                throw new ConfigException("@ConfigValue on " + site + ": config class " +
+                        annotation.config().getName() + " is not a registered @Config", e);
+            }
+            return configName + ":" + annotation.path();
+        }
+        if (!annotation.value().isEmpty()) {
+            return annotation.value();
+        }
+        throw new ConfigException("@ConfigValue on " + site + ": must specify either value() or config()");
+    }
+
+    // renders the injection site as ClassName#field or ClassName#method(param) for error messages
+    private @NotNull String describeSite(@NotNull InjectionPoint injectionPoint) {
+        AnnotatedElement element = injectionPoint.getAnnotatedElement();
+        if (element instanceof Field) {
+            Field field = (Field) element;
+            return field.getDeclaringClass().getName() + "#" + field.getName();
+        }
+        if (element instanceof Parameter) {
+            Parameter parameter = (Parameter) element;
+            return parameter.getDeclaringExecutable().getDeclaringClass().getName() + "#" +
+                    parameter.getDeclaringExecutable().getName() + "(" + parameter.getName() + ")";
+        }
+        return element.toString();
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/FolderConfigInjector.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/injector/FolderConfigInjector.java
@@ -1,0 +1,170 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.injector;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfigName;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigRef;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigSnapshot;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjector;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Custom injector for {@link FolderConfigRef} injection.
+ * <p>
+ * This injector enables dependency injection for folder configs without
+ * requiring @Inject annotation. It resolves {@code FolderConfigRef<T>} types
+ * and uses {@link FolderConfigName} for disambiguation when multiple folder configs of
+ * the same item type exist.
+ * <p>
+ * Supported injection types:
+ * <ul>
+ *   <li>{@code FolderConfigRef<T>}</li>
+ *   <li>{@code FolderConfigSnapshot<T>} (returns current snapshot)</li>
+ * </ul>
+ */
+public class FolderConfigInjector implements CustomInjector {
+
+    private final BungeeConfigManager configManager;
+
+    /**
+     * Creates a new folder config injector.
+     *
+     * @param configManager the config manager
+     */
+    public FolderConfigInjector(@NotNull BungeeConfigManager configManager) {
+        this.configManager = Objects.requireNonNull(configManager, "configManager cannot be null");
+    }
+
+    @Override
+    public boolean supports(@NotNull InjectionPoint injectionPoint) {
+        Class<?> rawType = injectionPoint.getRawType();
+        if (rawType == null) {
+            return false;
+        }
+
+        return rawType == FolderConfigRef.class || rawType == FolderConfigSnapshot.class;
+    }
+
+    @Override
+    public @NotNull InjectionResult resolve(@NotNull InjectionPoint injectionPoint) {
+        Type type = injectionPoint.getType();
+        Class<?> rawType = injectionPoint.getRawType();
+
+        if (rawType == null) {
+            return InjectionResult.notHandled();
+        }
+
+        Class<?> itemType = extractItemType(type);
+        if (itemType == null) {
+            return InjectionResult.notHandled();
+        }
+
+        String folderConfigName = resolveFolderConfigName(injectionPoint.getAnnotatedElement(), itemType);
+        if (folderConfigName == null) {
+            return InjectionResult.notHandled();
+        }
+
+        try {
+            if (rawType == FolderConfigRef.class) {
+                FolderConfigRef<?> ref = configManager.getFolderConfigRef(itemType, folderConfigName);
+                return InjectionResult.handled(ref);
+            } else if (rawType == FolderConfigSnapshot.class) {
+                FolderConfigRef<?> ref = configManager.getFolderConfigRef(itemType, folderConfigName);
+                return InjectionResult.handled(ref.get());
+            }
+        } catch (Exception e) {
+            return InjectionResult.notHandled();
+        }
+
+        return InjectionResult.notHandled();
+    }
+
+    @Override
+    public int getOrder() {
+        return -100;
+    }
+
+    /**
+     * Extracts the item type from a parameterized type like {@code FolderConfigRef<T>}.
+     *
+     * @param type the type
+     * @return the item type class, or null if not extractable
+     */
+    private Class<?> extractItemType(Type type) {
+        if (!(type instanceof ParameterizedType)) {
+            return null;
+        }
+
+        ParameterizedType paramType = (ParameterizedType) type;
+        Type[] typeArgs = paramType.getActualTypeArguments();
+        if (typeArgs.length == 0) {
+            return null;
+        }
+
+        Type itemType = typeArgs[0];
+        if (itemType instanceof Class) {
+            return (Class<?>) itemType;
+        } else if (itemType instanceof ParameterizedType) {
+            // nested generic like FolderConfigRef<List<String>>
+            Type rawType = ((ParameterizedType) itemType).getRawType();
+            if (rawType instanceof Class) {
+                return (Class<?>) rawType;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Resolves the folder config name from the annotated element.
+     *
+     * @param element  the annotated element (field, parameter, or method)
+     * @param itemType the item type
+     * @return the folder config name, or null if cannot be resolved
+     */
+    private String resolveFolderConfigName(AnnotatedElement element, Class<?> itemType) {
+        FolderConfigName refName = element.getAnnotation(FolderConfigName.class);
+        if (refName != null && !refName.value().isEmpty()) {
+            return refName.value();
+        }
+
+        Set<String> names = configManager.getFolderConfigNames(itemType);
+        if (names.isEmpty()) {
+            return null;
+        }
+        if (names.size() == 1) {
+            return names.iterator().next();
+        }
+
+        return null;
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/loader/YamlConfigLoader.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/loader/YamlConfigLoader.java
@@ -1,0 +1,304 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.loader;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.loader.ConfigLoader;
+import tech.guilhermekaua.spigotboot.config.loader.ConfigSource;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.node.YamlConfigNode;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * YAML configuration loader using SnakeYAML (bundled with BungeeCord).
+ */
+public class YamlConfigLoader implements ConfigLoader {
+
+    private static final String[] EXTENSIONS = {"yml", "yaml"};
+
+    private final Yaml yaml;
+
+    public YamlConfigLoader() {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(DumperOptions.FlowStyle.BLOCK);
+        options.setPrettyFlow(true);
+        options.setIndent(2);
+        options.setDefaultScalarStyle(DumperOptions.ScalarStyle.PLAIN);
+        this.yaml = new Yaml(options);
+    }
+
+    @Override
+    public @NotNull ConfigNode load(@NotNull ConfigSource source) throws ConfigException {
+        if (!source.exists()) {
+            return new YamlConfigNode();
+        }
+
+        try (InputStream is = source.openRead();
+             Reader reader = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+
+            Object data = yaml.load(reader);
+            if (data == null) {
+                return new YamlConfigNode();
+            }
+            return new YamlConfigNode(data);
+
+        } catch (IOException e) {
+            throw new ConfigException("Failed to load config from " + source.name(), e);
+        } catch (Exception e) {
+            throw new ConfigException("Failed to parse YAML from " + source.name(), e);
+        }
+    }
+
+    @Override
+    public void save(@NotNull ConfigNode node, @NotNull ConfigSource target) throws ConfigException {
+        Path targetPath = target.path();
+        if (targetPath == null) {
+            throw new ConfigException("Cannot save to non-file source: " + target.name());
+        }
+
+        try {
+            Path parent = targetPath.getParent();
+            if (parent != null && !Files.exists(parent)) {
+                Files.createDirectories(parent);
+            }
+
+            Path tempFile = targetPath.resolveSibling(targetPath.getFileName() + ".tmp");
+
+            try (OutputStream os = Files.newOutputStream(tempFile);
+                 Writer writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)) {
+
+                if (node instanceof YamlConfigNode) {
+                    YamlConfigNode yamlNode = (YamlConfigNode) node;
+                    writeNodeWithComments(writer, yamlNode, 0);
+                } else {
+                    Object rawData = node.raw();
+                    if (rawData != null) {
+                        yaml.dump(rawData, writer);
+                    }
+                }
+            }
+
+            Files.move(tempFile, targetPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            throw new ConfigException("Failed to save config to " + target.name(), e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void writeNodeWithComments(@NotNull Writer writer, @NotNull YamlConfigNode node, int indent) throws IOException {
+        Object value = node.raw();
+        if (!(value instanceof Map)) {
+            if (value != null) {
+                yaml.dump(value, writer);
+            }
+            return;
+        }
+
+        Map<String, Object> map = (Map<String, Object>) value;
+        String indentStr = repeat(" ", indent);
+
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object val = entry.getValue();
+
+            List<String> comments = node.getChildComments(key);
+
+            if (comments != null && !comments.isEmpty()) {
+                for (String line : comments) {
+                    writer.write(indentStr);
+                    writer.write("# ");
+                    writer.write(line);
+                    writer.write("\n");
+                }
+            }
+
+            writer.write(indentStr);
+            writer.write(key);
+            writer.write(":");
+
+            if (val instanceof Map) {
+                writer.write("\n");
+                YamlConfigNode childNode = (YamlConfigNode) node.node(key);
+                writeNodeWithComments(writer, childNode, indent + 2);
+
+            } else if (val instanceof List) {
+                writer.write("\n");
+                writeList(writer, (List<?>) val, indent + 2);
+            } else {
+                writer.write(" ");
+                writeScalar(writer, val);
+                writer.write("\n");
+            }
+        }
+    }
+
+    private void writeList(@NotNull Writer writer, @NotNull List<?> list, int indent) throws IOException {
+        String indentStr = repeat(" ", indent);
+        for (Object item : list) {
+            writer.write(indentStr);
+            writer.write("- ");
+            if (item instanceof Map) {
+                writer.write("\n");
+                writeMapInList(writer, (Map<?, ?>) item, indent + 2);
+            } else if (item instanceof List) {
+                writer.write("\n");
+                writeList(writer, (List<?>) item, indent + 2);
+            } else {
+                writeScalar(writer, item);
+                writer.write("\n");
+            }
+        }
+    }
+
+    private void writeMapInList(@NotNull Writer writer, @NotNull Map<?, ?> map, int indent) throws IOException {
+        String indentStr = repeat(" ", indent);
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            String key = String.valueOf(entry.getKey());
+            Object val = entry.getValue();
+
+            writer.write(indentStr);
+            writer.write(key);
+            writer.write(":");
+
+            if (val instanceof Map) {
+                writer.write("\n");
+                writeMapInList(writer, (Map<?, ?>) val, indent + 2);
+            } else if (val instanceof List) {
+                writer.write("\n");
+                writeList(writer, (List<?>) val, indent + 2);
+            } else {
+                writer.write(" ");
+                writeScalar(writer, val);
+                writer.write("\n");
+            }
+        }
+    }
+
+    private void writeScalar(@NotNull Writer writer, @Nullable Object value) throws IOException {
+        if (value == null) {
+            writer.write("null");
+        } else if (value instanceof String) {
+            String str = (String) value;
+            if (needsQuoting(str)) {
+                writer.write("\"");
+                writer.write(escapeString(str));
+                writer.write("\"");
+            } else {
+                writer.write(str);
+            }
+        } else if (value instanceof Boolean || value instanceof Number) {
+            writer.write(String.valueOf(value));
+        } else {
+            String str = String.valueOf(value);
+            if (needsQuoting(str)) {
+                writer.write("\"");
+                writer.write(escapeString(str));
+                writer.write("\"");
+            } else {
+                writer.write(str);
+            }
+        }
+    }
+
+    private boolean needsQuoting(@NotNull String str) {
+        if (str.isEmpty()) {
+            return true;
+        }
+        char first = str.charAt(0);
+        char last = str.charAt(str.length() - 1);
+
+        if (Character.isWhitespace(first) || Character.isWhitespace(last)) {
+            return true;
+        }
+
+        if (first == '#' || first == '&' || first == '*' || first == '!' ||
+                first == '|' || first == '>' || first == '\'' || first == '"' ||
+                first == '%' || first == '@' || first == '`' ||
+                first == '[' || first == ']' || first == '{' || first == '}' ||
+                first == ',') {
+            return true;
+        }
+        if (str.endsWith(":")) {
+            return true;
+        }
+        if (str.contains(": ") || str.contains("\n") || str.contains("\r")) {
+            return true;
+        }
+        if (str.contains(" #")) {
+            return true;
+        }
+        if (str.indexOf('[') >= 0 || str.indexOf(']') >= 0 ||
+                str.indexOf('{') >= 0 || str.indexOf('}') >= 0 ||
+                str.indexOf(',') >= 0) {
+            return true;
+        }
+        String lower = str.toLowerCase(Locale.ROOT);
+
+        if (lower.equals("true") || lower.equals("false") ||
+                lower.equals("yes") || lower.equals("no") ||
+                lower.equals("on") || lower.equals("off") ||
+                lower.equals("null") || lower.equals("~")) {
+            return true;
+        }
+        return false;
+    }
+
+    private String escapeString(@NotNull String str) {
+        return str.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+    private String repeat(@NotNull String str, int times) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < times; i++) {
+            sb.append(str);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public @NotNull MutableConfigNode createNode() {
+        return new YamlConfigNode();
+    }
+
+    @Override
+    public @NotNull String[] extensions() {
+        return EXTENSIONS;
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/node/YamlConfigNode.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/node/YamlConfigNode.java
@@ -1,0 +1,267 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.node;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.node.AbstractValueConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.core.validation.ConfigPath;
+import tech.guilhermekaua.spigotboot.core.validation.PropertyPath;
+
+import java.util.*;
+
+/**
+ * YAML-backed implementation of ConfigNode using SnakeYAML.
+ */
+public class YamlConfigNode extends AbstractValueConfigNode implements MutableConfigNode {
+
+    private final ConfigPath path;
+    private final YamlConfigNode parent;
+    private Object value;
+    private List<String> comments;
+    private boolean virtual;
+    private final Map<String, List<String>> childComments = new LinkedHashMap<>();
+
+    /**
+     * Creates a root node.
+     */
+    public YamlConfigNode() {
+        this(ConfigPath.root(), null, null, false);
+    }
+
+    /**
+     * Creates a node from existing data.
+     *
+     * @param data the raw data
+     */
+    public YamlConfigNode(@Nullable Object data) {
+        this(ConfigPath.root(), null, data, false);
+    }
+
+    private YamlConfigNode(@NotNull ConfigPath path, @Nullable YamlConfigNode parent, @Nullable Object value, boolean virtual) {
+        this.path = path;
+        this.parent = parent;
+        this.value = value;
+        this.virtual = virtual;
+        this.comments = null;
+    }
+
+    @Override
+    protected @Nullable Object currentValue() {
+        return value;
+    }
+
+    @Override
+    protected @NotNull PropertyPath currentPath() {
+        return path;
+    }
+
+    @Override
+    protected boolean currentVirtual() {
+        return virtual;
+    }
+
+    @Override
+    protected @NotNull ConfigNode createChildNode(
+            @Nullable Object value,
+            @NotNull PropertyPath path,
+            boolean virtual) {
+        return new YamlConfigNode(toConfigPath(path), this, value, virtual);
+    }
+
+    @Override
+    public @NotNull MutableConfigNode node(@NotNull Object... pathSegments) {
+        Objects.requireNonNull(pathSegments, "path cannot be null");
+        if (pathSegments.length == 0) {
+            return this;
+        }
+
+        YamlConfigNode current = this;
+        for (Object segment : pathSegments) {
+            current = current.getOrCreateChild(segment);
+        }
+        return current;
+    }
+
+    @Override
+    public @NotNull ConfigNode node(@NotNull PropertyPath path) {
+        return node(path.elements());
+    }
+
+    private static @NotNull ConfigPath toConfigPath(@NotNull PropertyPath path) {
+        if (path instanceof ConfigPath) {
+            return (ConfigPath) path;
+        }
+        return ConfigPath.of(path.elements());
+    }
+
+    @SuppressWarnings("unchecked")
+    private YamlConfigNode getOrCreateChild(@NotNull Object key) {
+        if (key instanceof Integer) {
+            int index = (Integer) key;
+            if (value instanceof List) {
+                List<Object> list = (List<Object>) value;
+                if (index >= 0 && index < list.size()) {
+                    Object childValue = list.get(index);
+                    return new YamlConfigNode(path.child(key), this, childValue, false);
+                }
+            }
+            return new YamlConfigNode(path.child(key), this, null, true);
+        }
+
+        String keyStr = String.valueOf(key);
+        if (value instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) value;
+            if (map.containsKey(keyStr)) {
+                return new YamlConfigNode(path.child(keyStr), this, map.get(keyStr), false);
+            }
+        }
+
+        return new YamlConfigNode(path.child(keyStr), this, null, true);
+
+    }
+
+    @Override
+    public boolean hasChild(@NotNull Object... pathSegments) {
+        ConfigNode child = node(pathSegments);
+        return !child.isVirtual() && !child.isNull();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public @NotNull MutableConfigNode set(@Nullable Object newValue) {
+        this.value = newValue;
+        this.virtual = false;
+
+        if (parent != null) {
+            Object lastKey = path.last();
+            if (lastKey instanceof Integer) {
+                int index = (Integer) lastKey;
+                if (!(parent.value instanceof List)) {
+                    parent.value = new ArrayList<>();
+                }
+                List<Object> list = (List<Object>) parent.value;
+                while (list.size() <= index) {
+                    list.add(null);
+                }
+                list.set(index, newValue);
+            } else {
+                String key = String.valueOf(lastKey);
+                if (!(parent.value instanceof Map)) {
+                    parent.value = new LinkedHashMap<>();
+                }
+                Map<String, Object> map = (Map<String, Object>) parent.value;
+                map.put(key, newValue);
+            }
+            parent.virtual = false;
+        }
+
+        return this;
+    }
+
+    @Override
+    public @NotNull MutableConfigNode setComment(@Nullable String... lines) {
+        if (lines == null || lines.length == 0) {
+            this.comments = null;
+        } else {
+            this.comments = Arrays.asList(lines);
+        }
+        if (parent != null && !path.isEmpty()) {
+            Object lastKey = path.last();
+            if (lastKey != null) {
+                String key = String.valueOf(lastKey);
+                if (this.comments != null) {
+                    parent.childComments.put(key, this.comments);
+                } else {
+                    parent.childComments.remove(key);
+                }
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Gets the comments for this node.
+     *
+     * @return the comments, or null
+     */
+    public @Nullable List<String> getComments() {
+        return comments;
+    }
+
+    /**
+     * Gets comments for a specific child key.
+     *
+     * @param key the child key
+     * @return the comments, or null
+     */
+    public @Nullable List<String> getChildComments(@NotNull String key) {
+        return childComments.get(key);
+    }
+
+    /**
+     * Gets all child comments.
+     *
+     * @return map of key to comment lines
+     */
+    public @NotNull Map<String, List<String>> getAllChildComments() {
+        return Collections.unmodifiableMap(childComments);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public @NotNull MutableConfigNode remove() {
+        if (parent != null) {
+            Object lastKey = path.last();
+            if (lastKey != null) {
+                if (parent.value instanceof Map) {
+                    ((Map<String, Object>) parent.value).remove(String.valueOf(lastKey));
+                } else if (parent.value instanceof List && lastKey instanceof Integer) {
+                    int index = (Integer) lastKey;
+                    List<Object> list = (List<Object>) parent.value;
+                    if (index >= 0 && index < list.size()) {
+                        list.remove(index);
+                    }
+                }
+            }
+        }
+        this.value = null;
+        this.virtual = true;
+        return this;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public @NotNull MutableConfigNode appendListItem() {
+        if (!(value instanceof List)) {
+            set(new ArrayList<>());
+        }
+        List<Object> list = (List<Object>) value;
+        int index = list.size();
+        list.add(null);
+        return new YamlConfigNode(path.child(index), this, null, false);
+    }
+
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxy.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxy.java
@@ -1,0 +1,119 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.proxy;
+
+import javassist.util.proxy.MethodHandler;
+import javassist.util.proxy.ProxyFactory;
+import javassist.util.proxy.ProxyObject;
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * A proxy that intercepts all method calls on a config class and delegates to
+ * the current config instance from {@link ConfigRef#get()}.
+ * <p>
+ * This ensures that injected config instances always return fresh values after reload,
+ * without requiring developers to use {@code ConfigRef<T>.get()} explicitly.
+ * <p>
+ * <b>Important:</b> Config classes must have all fields private to ensure proper
+ * proxying. Direct field access bypasses the proxy and will return stale/default values.
+ *
+ * @param <T> the config type
+ */
+public final class ConfigProxy<T> implements MethodHandler {
+
+    private final ConfigRef<T> configRef;
+
+    private ConfigProxy(@NotNull ConfigRef<T> configRef) {
+        this.configRef = Objects.requireNonNull(configRef, "configRef cannot be null");
+    }
+
+    /**
+     * Creates a proxy for the given config class that delegates all method calls
+     * to the current config instance from the ConfigRef.
+     *
+     * @param configClass the config class to proxy
+     * @param configRef   the config ref providing the current instance
+     * @param <T>         the config type
+     * @return a proxy instance that appears as the config class
+     * @throws ConfigException if proxy creation fails
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> @NotNull T createProxy(@NotNull Class<T> configClass, @NotNull ConfigRef<T> configRef) {
+        Objects.requireNonNull(configClass, "configClass cannot be null");
+        Objects.requireNonNull(configRef, "configRef cannot be null");
+
+        ProxyFactory factory = new ProxyFactory();
+        factory.setSuperclass(configClass);
+        factory.setUseWriteReplace(false);
+
+        try {
+            return (T) factory.create(new Class<?>[0], new Object[0], new ConfigProxy<>(configRef));
+        } catch (NoSuchMethodException e) {
+            throw new ConfigException(
+                    "Config class " + configClass.getName() + " must have a no-arg constructor for proxying. " +
+                            "Add a default constructor or use @Inject on an existing constructor.", e);
+        } catch (Exception e) {
+            throw new ConfigException(
+                    "Failed to create config proxy for " + configClass.getName() + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Object invoke(Object self, Method thisMethod, Method proceed, Object[] args) throws Throwable {
+        String methodName = thisMethod.getName();
+
+        if (thisMethod.getDeclaringClass() == Object.class) {
+            switch (methodName) {
+                case "toString":
+                    return "ConfigProxy[" + configRef.getConfigClass().getSimpleName() + "]@" +
+                            Integer.toHexString(System.identityHashCode(self));
+                case "hashCode":
+                    return System.identityHashCode(self);
+                case "equals":
+                    if (args == null || args.length != 1 || args[0] == null) {
+                        return false;
+                    }
+
+                    Object other = args[0];
+                    if (other == self) {
+                        return true;
+                    }
+
+                    if (other instanceof ProxyObject) {
+                        return ((ProxyObject) other).getHandler() == this;
+                    }
+                    return false;
+                default:
+                    return proceed.invoke(self, args);
+            }
+        }
+
+        T currentConfig = configRef.get();
+        return thisMethod.invoke(currentConfig, args);
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reference/BungeeConfigReferenceLookup.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reference/BungeeConfigReferenceLookup.java
@@ -1,0 +1,193 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.reference;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceLookup;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.folder.FolderConfigEntry;
+import tech.guilhermekaua.spigotboot.core.validation.ConfigPath;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * BungeeCord implementation of {@link ConfigReferenceLookup}.
+ * <p>
+ * Provides lookup capabilities for resolving config references by delegating
+ * to {@link BungeeConfigManager} for single configs and {@link FolderConfigEntry}
+ * for folder config items.
+ */
+public class BungeeConfigReferenceLookup implements ConfigReferenceLookup {
+
+    private final BungeeConfigManager configManager;
+
+    /**
+     * Creates a new lookup instance.
+     *
+     * @param configManager the config manager providing access to configs and folder configs
+     */
+    public BungeeConfigReferenceLookup(@NotNull BungeeConfigManager configManager) {
+        this.configManager = Objects.requireNonNull(configManager, "configManager cannot be null");
+    }
+
+    @Override
+    public @Nullable ConfigNode findSingleConfigRoot(@NotNull String configName) {
+        Objects.requireNonNull(configName, "configName cannot be null");
+        return configManager.getConfigNode(configName);
+    }
+
+    @Override
+    public @Nullable ConfigNode findSingleConfigPath(@NotNull String configName, @NotNull String path) {
+        Objects.requireNonNull(configName, "configName cannot be null");
+        Objects.requireNonNull(path, "path cannot be null");
+
+        ConfigNode root = findSingleConfigRoot(configName);
+        if (root == null) {
+            return null;
+        }
+
+        return navigateToPath(root, path);
+    }
+
+    @Override
+    public @Nullable ConfigNode findFolderConfigItemRoot(@NotNull String folderConfigName, @NotNull String itemId) {
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+        Objects.requireNonNull(itemId, "itemId cannot be null");
+
+        FolderConfigEntry<?> entry = configManager.getFolderConfigEntryByName(folderConfigName);
+        if (entry == null) {
+            return null;
+        }
+
+        return entry.getItemNode(itemId);
+    }
+
+    @Override
+    public @Nullable ConfigNode findFolderConfigItemPath(
+            @NotNull String folderConfigName,
+            @NotNull String itemId,
+            @NotNull String path) {
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+        Objects.requireNonNull(itemId, "itemId cannot be null");
+        Objects.requireNonNull(path, "path cannot be null");
+
+        ConfigNode root = findFolderConfigItemRoot(folderConfigName, itemId);
+        if (root == null) {
+            return null;
+        }
+
+        return navigateToPath(root, path);
+    }
+
+    @Override
+    public @NotNull Set<String> getAvailableConfigNames() {
+        return configManager.getConfigNames();
+    }
+
+    @Override
+    public @NotNull Set<String> getAvailableFolderConfigNames() {
+        return configManager.getAllFolderConfigNames();
+    }
+
+    @Override
+    public @NotNull Set<String> getAvailableItemIds(@NotNull String folderConfigName) {
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+
+        FolderConfigEntry<?> entry = configManager.getFolderConfigEntryByName(folderConfigName);
+        if (entry == null) {
+            return Collections.emptySet();
+        }
+
+        return entry.getItemIds();
+    }
+
+    @Override
+    public @NotNull Set<String> getAvailableKeysAt(@NotNull String configName, @Nullable String path) {
+        Objects.requireNonNull(configName, "configName cannot be null");
+
+        ConfigNode root = findSingleConfigRoot(configName);
+        if (root == null) {
+            return Collections.emptySet();
+        }
+
+        ConfigNode targetNode = path == null || path.isEmpty() ? root : navigateToPath(root, path);
+        if (targetNode == null || targetNode.isVirtual() || !targetNode.isMap()) {
+            return Collections.emptySet();
+        }
+
+        return targetNode.childrenMap().keySet();
+    }
+
+    @Override
+    public boolean hasConfig(@NotNull String configName) {
+        Objects.requireNonNull(configName, "configName cannot be null");
+        return configManager.getConfigNode(configName) != null;
+    }
+
+    @Override
+    public boolean hasFolderConfig(@NotNull String folderConfigName) {
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+        return configManager.getFolderConfigEntryByName(folderConfigName) != null;
+    }
+
+    @Override
+    public boolean hasFolderConfigItem(@NotNull String folderConfigName, @NotNull String itemId) {
+        Objects.requireNonNull(folderConfigName, "folderConfigName cannot be null");
+        Objects.requireNonNull(itemId, "itemId cannot be null");
+
+        FolderConfigEntry<?> entry = configManager.getFolderConfigEntryByName(folderConfigName);
+        if (entry == null) {
+            return false;
+        }
+
+        return entry.getItemNode(itemId) != null;
+    }
+
+    /**
+     * Navigates to a path within a config node.
+     * <p>
+     * Supports dot-separated paths (e.g., "database.host").
+     * Returns null if the path doesn't exist (node is virtual).
+     *
+     * @param root the root node
+     * @param path the dot-separated path
+     * @return the node at the path, or null if not found
+     */
+    private @Nullable ConfigNode navigateToPath(@NotNull ConfigNode root, @NotNull String path) {
+        if (path.isEmpty()) {
+            return root;
+        }
+
+        ConfigNode node = root.node(ConfigPath.parse(path));
+
+        if (node.isVirtual()) {
+            return null;
+        }
+
+        return node;
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reference/ConfigReferenceManager.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reference/ConfigReferenceManager.java
@@ -1,0 +1,266 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.reference;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.*;
+import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.core.exceptions.CycleDetectedException;
+import tech.guilhermekaua.spigotboot.core.utils.DependencyGraph;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Manages config reference resolution infrastructure.
+ */
+public class ConfigReferenceManager {
+
+    private final BungeeConfigReferenceLookup lookup;
+    private final ConfigReferenceParser parser;
+    private final ConfigReferenceErrorHandler errorHandler;
+    private final ConfigReferenceResolver resolver;
+    private final ConfigReferenceDependencyScanner scanner;
+    private final ReferenceResolvingPreprocessor preprocessor;
+    private final DependencyGraph<ReferenceKey> dependencyGraph;
+
+    /**
+     * Creates a new reference manager with default error handling.
+     *
+     * @param configManager the config manager for lookups
+     * @param logger        the logger for error messages
+     */
+    public ConfigReferenceManager(@NotNull BungeeConfigManager configManager, @NotNull Logger logger) {
+        this(configManager, new DefaultConfigReferenceErrorHandler(logger));
+    }
+
+    /**
+     * Creates a new reference manager with custom error handling.
+     *
+     * @param configManager the config manager for lookups
+     * @param errorHandler  the error handler for reference resolution errors
+     */
+    public ConfigReferenceManager(@NotNull BungeeConfigManager configManager,
+                                  @NotNull ConfigReferenceErrorHandler errorHandler) {
+        Objects.requireNonNull(configManager, "configManager cannot be null");
+        Objects.requireNonNull(errorHandler, "errorHandler cannot be null");
+
+        this.lookup = new BungeeConfigReferenceLookup(configManager);
+        this.parser = new ConfigReferenceParser();
+        this.errorHandler = errorHandler;
+        this.resolver = new ConfigReferenceResolver(lookup, parser, errorHandler);
+        this.scanner = new ConfigReferenceDependencyScanner(parser);
+        this.preprocessor = new ReferenceResolvingPreprocessor(resolver);
+        this.dependencyGraph = new DependencyGraph<>();
+    }
+
+    /**
+     * Gets the preprocessor for binder integration.
+     * <p>
+     * This preprocessor resolves {@code ${...}} references during binding.
+     *
+     * @return the preprocessor
+     */
+    public @NotNull ReferenceResolvingPreprocessor getPreprocessor() {
+        return preprocessor;
+    }
+
+    /**
+     * Gets the reference resolver.
+     *
+     * @return the resolver
+     */
+    public @NotNull ConfigReferenceResolver getResolver() {
+        return resolver;
+    }
+
+    /**
+     * Gets the dependency graph.
+     *
+     * @return the graph
+     */
+    public @NotNull DependencyGraph<ReferenceKey> getDependencyGraph() {
+        return dependencyGraph;
+    }
+
+    /**
+     * Scans a config node for references and registers them in the graph.
+     *
+     * @param sourceKey the key of the config being scanned
+     * @param node      the config node to scan
+     */
+    public void scanAndRegister(@NotNull ReferenceKey sourceKey, @NotNull ConfigNode node) {
+        scanner.scanAndAddToGraph(sourceKey, node, dependencyGraph);
+    }
+
+    /**
+     * Gets the topological load order for all registered configs.
+     * <p>
+     * Configs that are depended upon come first.
+     *
+     * @return the load order
+     * @throws CycleDetectedException if a cycle is detected
+     */
+    public @NotNull List<ReferenceKey> getLoadOrder() throws CycleDetectedException {
+        return dependencyGraph.topologicalOrder();
+    }
+
+    /**
+     * Checks if the dependency graph has a cycle.
+     *
+     * @return the cycle chain if exists, empty otherwise
+     */
+    public @NotNull Optional<List<ReferenceKey>> detectCycle() {
+        return dependencyGraph.detectCycle();
+    }
+
+    /**
+     * Gets all configs that depend (transitively) on the given config.
+     * <p>
+     * Used for reload propagation - when config X changes, all its
+     * dependents need to be re-resolved.
+     *
+     * @param key the config key
+     * @return set of dependent config keys
+     */
+    public @NotNull Set<ReferenceKey> getDependentsOf(@NotNull ReferenceKey key) {
+        return dependencyGraph.getTransitiveDependents(key);
+    }
+
+    /**
+     * Gets the reverse dependencies map.
+     *
+     * @return map from each key to its dependents
+     */
+    public @NotNull Map<ReferenceKey, Set<ReferenceKey>> getReverseDependencies() {
+        return dependencyGraph.getReverseDependencies();
+    }
+
+    /**
+     * Clears all dependency tracking.
+     * <p>
+     * Call this before a full reload to rebuild the graph.
+     */
+    public void clearDependencies() {
+        dependencyGraph.clear();
+    }
+
+    /**
+     * Prepares for full reload by clearing all dependencies.
+     * <p>
+     * Alias for {@link #clearDependencies()} with a more descriptive name.
+     */
+    public void resetDependencies() {
+        dependencyGraph.clear();
+    }
+
+    /**
+     * Updates dependencies for a key after its node changed.
+     * <p>
+     * Removes old outgoing edges and scans for new references.
+     *
+     * @param key     the key that changed
+     * @param newNode the new node to scan for references
+     */
+    public void updateDependenciesForKey(@NotNull ReferenceKey key, @NotNull ConfigNode newNode) {
+        Objects.requireNonNull(key, "key cannot be null");
+        Objects.requireNonNull(newNode, "newNode cannot be null");
+        dependencyGraph.removeOutgoingEdges(key);
+        scanner.scanAndAddToGraph(key, newNode, dependencyGraph);
+    }
+
+    /**
+     * Gets keys impacted by a change to the given key.
+     * <p>
+     * Includes the key itself plus all transitive dependents.
+     *
+     * @param changedKey the key that changed
+     * @return set of impacted keys (includes changedKey)
+     */
+    public @NotNull Set<ReferenceKey> getImpactedKeys(@NotNull ReferenceKey changedKey) {
+        Objects.requireNonNull(changedKey, "changedKey cannot be null");
+        Set<ReferenceKey> impacted = new LinkedHashSet<>();
+        impacted.add(changedKey);
+        impacted.addAll(dependencyGraph.getTransitiveDependents(changedKey));
+        return impacted;
+    }
+
+    /**
+     * Gets topological order for a subset of keys.
+     *
+     * @param keys the keys to order
+     * @return ordered list (dependencies first)
+     * @throws CycleDetectedException if a cycle exists in the subset
+     */
+    public @NotNull List<ReferenceKey> getLoadOrderForSubset(@NotNull Set<ReferenceKey> keys)
+            throws CycleDetectedException {
+        Objects.requireNonNull(keys, "keys cannot be null");
+        return dependencyGraph.topologicalOrderSubset(keys);
+    }
+
+    /**
+     * Sets the current source key for resolution context.
+     * <p>
+     * Call this before binding a config to provide context for error messages.
+     *
+     * @param sourceKey the key of the config being bound
+     */
+    public void setCurrentSourceKey(@NotNull ReferenceKey sourceKey) {
+        preprocessor.setCurrentSourceKey(sourceKey);
+    }
+
+    /**
+     * Clears the current source key.
+     */
+    public void clearCurrentSourceKey() {
+        preprocessor.clearCurrentSourceKey();
+    }
+
+    /**
+     * Resolves a reference string to its target node.
+     *
+     * @param reference the reference string (e.g., "${items:custom_item}")
+     * @param sourceKey the key of the config containing the reference
+     * @return the resolved node, or null if not found
+     */
+    public @Nullable ConfigNode resolveReference(@NotNull String reference, @NotNull ReferenceKey sourceKey) {
+        Optional<ConfigReference> parsed = parser.tryParse(reference);
+        if (!parsed.isPresent()) {
+            return null;
+        }
+        return lookup.resolve(parsed.get());
+    }
+
+    /**
+     * Checks if a string is a reference pattern.
+     *
+     * @param value the string to check
+     * @return true if it matches the reference pattern
+     */
+    public boolean isReference(@Nullable String value) {
+        return resolver.isReference(value);
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reference/ReferenceResolvingPreprocessor.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reference/ReferenceResolvingPreprocessor.java
@@ -1,0 +1,131 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.reference;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.binding.ConfigNodePreprocessor;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceResolver;
+import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
+import tech.guilhermekaua.spigotboot.config.bungee.node.YamlConfigNode;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+/**
+ * A {@link ConfigNodePreprocessor} that resolves config references ({@code ${...}}).
+ * <p>
+ * This preprocessor wraps a {@link ConfigReferenceResolver} and adapts it to the
+ * binder's preprocessor API. It is used during config binding to resolve any
+ * reference values before they are deserialized.
+ * <p>
+ * The preprocessor maintains a "current source key" which identifies the config
+ * or folder config item currently being bound. This is used for cycle detection
+ * and error reporting.
+ */
+public class ReferenceResolvingPreprocessor implements ConfigNodePreprocessor {
+
+    private final ConfigReferenceResolver resolver;
+    private final ThreadLocal<ReferenceKey> currentSourceKey = new ThreadLocal<>();
+
+    /**
+     * Creates a new preprocessor.
+     *
+     * @param resolver the reference resolver
+     */
+    public ReferenceResolvingPreprocessor(@NotNull ConfigReferenceResolver resolver) {
+        this.resolver = Objects.requireNonNull(resolver, "resolver cannot be null");
+    }
+
+    /**
+     * Sets the current source key for binding context.
+     * <p>
+     * This should be called before binding each config or folder config item
+     * to provide context for error reporting and cycle detection.
+     *
+     * @param sourceKey the key of the config being bound
+     */
+    public void setCurrentSourceKey(@NotNull ReferenceKey sourceKey) {
+        currentSourceKey.set(Objects.requireNonNull(sourceKey, "sourceKey cannot be null"));
+    }
+
+    /**
+     * Clears the current source key.
+     */
+    public void clearCurrentSourceKey() {
+        currentSourceKey.remove();
+    }
+
+    /**
+     * Gets the current source key.
+     *
+     * @return the current source key, or null if not set
+     */
+    public @Nullable ReferenceKey getCurrentSourceKey() {
+        return currentSourceKey.get();
+    }
+
+    @Override
+    public @Nullable ConfigNode preprocess(
+            @NotNull ConfigNode node,
+            @Nullable Field field,
+            @NotNull Type expectedType) {
+
+        if (!node.isScalar()) {
+            return null;
+        }
+
+        String value = node.get(String.class);
+        if (value == null) {
+            return null;
+        }
+
+        if (!resolver.isReference(value)) {
+            return null;
+        }
+
+        ReferenceKey sourceKey = currentSourceKey.get();
+        if (sourceKey == null) {
+            // shouldn't happen in normal usage
+            sourceKey = ReferenceKey.singleConfig("unknown");
+        }
+
+        ConfigNode resolved = resolver.resolveIfReference(node, sourceKey, field, expectedType);
+
+        // if resolver returns null, it means the reference was not found
+        // we must return a "null node" (not java null) so the binder binds to null.
+        // returning java null from preprocess() means "use original node" which would
+        // leave the "${...}" string in place, that is not what we want for missing references
+        if (resolved == null) {
+            return createNullNode();
+        }
+
+        return resolved;
+    }
+
+    private static @NotNull ConfigNode createNullNode() {
+        return new YamlConfigNode(null);
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/registry/ConfigRegistry.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/registry/ConfigRegistry.java
@@ -1,0 +1,251 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.registry;
+
+import tech.guilhermekaua.spigotboot.config.ConfigManager;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.annotation.ConfigValue;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfig;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfigs;
+import tech.guilhermekaua.spigotboot.config.annotation.OnConfigReload;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.proxy.ConfigProxy;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
+import tech.guilhermekaua.spigotboot.core.context.discovery.DiscoveryCategories;
+import tech.guilhermekaua.spigotboot.core.context.discovery.DiscoveryIndexReader;
+import tech.guilhermekaua.spigotboot.core.scanner.ClassPathScanner;
+import tech.guilhermekaua.spigotboot.core.utils.BeanUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.util.*;
+import java.util.logging.Logger;
+
+@Component
+public class ConfigRegistry {
+
+    /**
+     * Scans for and registers all @Config and @FolderConfig annotated classes.
+     * <p>
+     * After all classes are registered, calls {@link BungeeConfigManager#initializeAll()}
+     * to bind configs in topological order (respecting {@code ${...}} references).
+     *
+     * @param context the context
+     */
+    public void registerConfigs(Context context) {
+        String basePackage = context.getPlugin().getMainClass().getPackage().getName();
+        ClassLoader classLoader = context.getPlugin().getClassLoader();
+
+        ConfigManager configManager = context.getBean(ConfigManager.class);
+        if (configManager == null) {
+            throw new IllegalStateException("ConfigManager is null");
+        }
+
+        Logger logger = context.getPlugin().getLogger();
+
+        ClassPathScanner scanner = new ClassPathScanner(classLoader, basePackage);
+        LinkedHashSet<Class<?>> configAnnotatedClasses = new LinkedHashSet<>(
+                scanner.getTypesAnnotatedWith(Config.class));
+        LinkedHashSet<Class<?>> folderAnnotatedClasses = new LinkedHashSet<>(
+                scanner.getTypesAnnotatedWith(FolderConfig.class));
+        LinkedHashSet<Class<?>> foldersContainerAnnotatedClasses = new LinkedHashSet<>(
+                scanner.getTypesAnnotatedWith(FolderConfigs.class));
+
+        DiscoveryIndexReader reader = new DiscoveryIndexReader(classLoader);
+        if (reader.hasAnyIndex()) {
+            List<Class<?>> indexed = reader.classesInCategory(DiscoveryCategories.CONFIG, basePackage);
+            configAnnotatedClasses.addAll(filterByAnnotation(indexed, Config.class));
+            folderAnnotatedClasses.addAll(filterByAnnotation(indexed, FolderConfig.class));
+            foldersContainerAnnotatedClasses.addAll(filterByAnnotation(indexed, FolderConfigs.class));
+        }
+
+        for (Class<?> configClass : configAnnotatedClasses) {
+            processConfigClass(configClass, context, configManager);
+        }
+
+        if (configManager instanceof BungeeConfigManager) {
+            BungeeConfigManager bungeeConfigManager = (BungeeConfigManager) configManager;
+
+            for (Class<?> itemClass : folderAnnotatedClasses) {
+                processFolderConfigClass(itemClass, bungeeConfigManager, logger);
+            }
+
+            for (Class<?> itemClass : foldersContainerAnnotatedClasses) {
+                processFolderConfigClass(itemClass, bungeeConfigManager, logger);
+            }
+
+            bungeeConfigManager.initializeAll();
+        }
+    }
+
+    private static List<Class<?>> filterByAnnotation(Collection<Class<?>> classes,
+                                                    Class<? extends Annotation> annotation) {
+        List<Class<?>> out = new ArrayList<>();
+        for (Class<?> c : classes) {
+            if (c.isAnnotationPresent(annotation)) {
+                out.add(c);
+            }
+        }
+        return out;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void processConfigClass(Class<?> configClass, Context context, ConfigManager configManager) {
+        try {
+            validateConfigClass(configClass);
+
+            configManager.register(configClass);
+
+            Object configProxy = createConfigProxy(configClass, configManager);
+
+            context.getDependencyManager().registerDependency(
+                    (Class<Object>) configClass,
+                    configProxy,
+                    BeanUtils.getQualifier(configClass),
+                    BeanUtils.getIsPrimary(configClass)
+            );
+        } catch (ConfigException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to register config: " + configClass.getName(), e);
+        }
+    }
+
+    /**
+     * Processes a class annotated with @FolderConfig.
+     *
+     * @param itemClass            the folder config item class
+     * @param bungeeConfigManager  the config manager
+     * @param logger               the logger
+     */
+    @SuppressWarnings("unchecked")
+    public <T> void processFolderConfigClass(
+            Class<T> itemClass,
+            BungeeConfigManager bungeeConfigManager,
+            Logger logger) {
+        try {
+            rejectConfigValueUsage(itemClass, "@FolderConfig item");
+            rejectOnConfigReloadUsage(itemClass);
+
+            List<FolderConfig> annotations = getFolderConfigAnnotations(itemClass);
+
+            if (annotations.isEmpty()) {
+                return;
+            }
+
+            for (FolderConfig annotation : annotations) {
+                bungeeConfigManager.registerFolderConfig(itemClass, annotation);
+            }
+        } catch (ConfigException e) {
+            throw e;
+        } catch (Exception e) {
+            logger.warning("Failed to register folder config for " + itemClass.getName() + ": " + e.getMessage());
+        }
+    }
+
+    private List<FolderConfig> getFolderConfigAnnotations(Class<?> itemClass) {
+        List<FolderConfig> result = new ArrayList<>();
+
+        FolderConfig single = itemClass.getAnnotation(FolderConfig.class);
+        if (single != null) {
+            result.add(single);
+        }
+
+        FolderConfigs container = itemClass.getAnnotation(FolderConfigs.class);
+        if (container != null) {
+            result.addAll(Arrays.asList(container.value()));
+        }
+
+        return result;
+    }
+
+    private <T> T createConfigProxy(Class<T> configClass, ConfigManager configManager) {
+        ConfigRef<T> configRef = configManager.getRef(configClass);
+        return ConfigProxy.createProxy(configClass, configRef);
+    }
+
+    private void validateConfigClass(Class<?> configClass) {
+        rejectConfigValueUsage(configClass, "@Config");
+        for (Field field : configClass.getDeclaredFields()) {
+            if (!Modifier.isPrivate(field.getModifiers())) {
+                throw new ConfigException(
+                        "Config class " + configClass.getName() +
+                                " has non-private field '" + field.getName() + "'. " +
+                                "All fields must be private to ensure reload safety."
+                );
+            }
+        }
+
+        rejectOnConfigReloadUsage(configClass);
+    }
+
+    private void rejectOnConfigReloadUsage(Class<?> configClass) {
+        for (Class<?> current = configClass; current != null && current != Object.class; current = current.getSuperclass()) {
+            for (Method method : current.getDeclaredMethods()) {
+                if (method.isAnnotationPresent(OnConfigReload.class)) {
+                    throw new ConfigException(
+                            "Config class " + configClass.getName() +
+                                    " declares @OnConfigReload on method '" + method.getName() + "'. " +
+                                    "@OnConfigReload is only processed on DI-managed beans, not on @Config/@FolderConfig classes."
+                    );
+                }
+            }
+        }
+    }
+
+    // @ConfigValue is never honored on @Config/@FolderConfig POJOs (they are bound by the config binder,
+    // not the DI container), so reject it on every supported target: declared and inherited fields, and
+    // constructor parameters (config binding supports constructor binding).
+    private void rejectConfigValueUsage(Class<?> targetClass, String kind) {
+        for (Class<?> current = targetClass; current != null && current != Object.class; current = current.getSuperclass()) {
+            for (Field field : current.getDeclaredFields()) {
+                if (field.isAnnotationPresent(ConfigValue.class)) {
+                    throw new ConfigException(
+                            kind + " class " + targetClass.getName() + " has a @ConfigValue field '" +
+                                    field.getName() + "'. @ConfigValue is only honored on DI-managed beans " +
+                                    "(@Component/@Bean), not on " + kind + " classes."
+                    );
+                }
+            }
+        }
+        for (Constructor<?> constructor : targetClass.getDeclaredConstructors()) {
+            for (Parameter parameter : constructor.getParameters()) {
+                if (parameter.isAnnotationPresent(ConfigValue.class)) {
+                    throw new ConfigException(
+                            kind + " class " + targetClass.getName() + " has a @ConfigValue constructor parameter '" +
+                                    parameter.getName() + "'. @ConfigValue is only honored on DI-managed beans " +
+                                    "(@Component/@Bean), not on " + kind + " classes."
+                    );
+                }
+            }
+        }
+    }
+
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reload/OnConfigReloadBinder.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reload/OnConfigReloadBinder.java
@@ -1,0 +1,247 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.reload;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.config.annotation.OnConfigReload;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigItemChange;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigRef;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigSnapshot;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Validates a single {@code @OnConfigReload} method and registers the reload listener(s) it implies
+ * on the {@link BungeeConfigManager}.
+ */
+public class OnConfigReloadBinder {
+
+    private static final Object[] NO_ARGS = new Object[0];
+
+    private enum PayloadType { NONE, SIMPLE_INSTANCE, FOLDER_CHANGE, FOLDER_SNAPSHOT }
+
+    private enum ConfigKind { SIMPLE, FOLDER }
+
+    private final BungeeConfigManager configManager;
+    private final OnConfigReloadInvoker invoker;
+
+    /**
+     * Creates the binder.
+     *
+     * @param configManager the config manager, not null
+     * @param invoker       the reflective invoker, not null
+     */
+    public OnConfigReloadBinder(@NotNull BungeeConfigManager configManager, @NotNull OnConfigReloadInvoker invoker) {
+        this.configManager = Objects.requireNonNull(configManager, "configManager cannot be null");
+        this.invoker = Objects.requireNonNull(invoker, "invoker cannot be null");
+    }
+
+    /**
+     * Validates the method and registers reload listeners for every target config it declares.
+     *
+     * @param bean   the owning bean instance, not null
+     * @param method a method annotated with {@link OnConfigReload}, not null
+     * @throws ConfigException if the method signature or targets are invalid
+     */
+    public void bind(@NotNull Object bean, @NotNull Method method) {
+        validateSignature(bean, method);
+
+        PayloadType payload = resolvePayloadType(method);
+        Class<?> paramItemType = (payload == PayloadType.FOLDER_CHANGE || payload == PayloadType.FOLDER_SNAPSHOT)
+                ? extractItemType(method) : null;
+        Class<?> simpleParamType = (payload == PayloadType.SIMPLE_INSTANCE)
+                ? method.getParameterTypes()[0] : null;
+
+        Set<Class<?>> targets = resolveTargets(bean, method, payload, simpleParamType, paramItemType);
+
+        // validate every target before registering any listener, so a later invalid target never
+        // leaves earlier targets partially bound
+        List<Class<?>> simpleTargets = new ArrayList<>();
+        List<Class<?>> folderTargets = new ArrayList<>();
+        for (Class<?> target : targets) {
+            ConfigKind kind = configKind(target);
+            if (kind == null) {
+                throw fail(bean, method, "targets unregistered config " + target.getName());
+            }
+            validatePayloadForKind(bean, method, payload, kind, target, simpleParamType, paramItemType);
+            if (kind == ConfigKind.SIMPLE) {
+                simpleTargets.add(target);
+            } else {
+                folderTargets.add(target);
+            }
+        }
+
+        for (Class<?> target : simpleTargets) {
+            bindSimple(bean, method, payload, target);
+        }
+        for (Class<?> target : folderTargets) {
+            bindFolder(bean, method, payload, target);
+        }
+    }
+
+    private void validateSignature(Object bean, Method method) {
+        if (Modifier.isStatic(method.getModifiers())) {
+            throw fail(bean, method, "must be a non-static instance method");
+        }
+        if (!void.class.equals(method.getReturnType())) {
+            throw fail(bean, method, "must return void");
+        }
+        if (method.getParameterCount() > 1) {
+            throw fail(bean, method, "must declare zero or one parameter");
+        }
+    }
+
+    private PayloadType resolvePayloadType(Method method) {
+        if (method.getParameterCount() == 0) {
+            return PayloadType.NONE;
+        }
+        Class<?> p = method.getParameterTypes()[0];
+        if (FolderConfigItemChange.class.equals(p)) {
+            return PayloadType.FOLDER_CHANGE;
+        }
+        if (FolderConfigSnapshot.class.equals(p)) {
+            return PayloadType.FOLDER_SNAPSHOT;
+        }
+        return PayloadType.SIMPLE_INSTANCE;
+    }
+
+    private Set<Class<?>> resolveTargets(Object bean, Method method, PayloadType payload,
+                                         @Nullable Class<?> simpleParamType, @Nullable Class<?> paramItemType) {
+        Class<?>[] declared = method.getAnnotation(OnConfigReload.class).value();
+        if (declared.length > 0) {
+            return new LinkedHashSet<>(Arrays.asList(declared));
+        }
+        switch (payload) {
+            case SIMPLE_INSTANCE:
+                return Set.of(simpleParamType);
+            case FOLDER_CHANGE:
+            case FOLDER_SNAPSHOT:
+                if (paramItemType == null) {
+                    throw fail(bean, method, "cannot infer the folder item type from a raw parameter; specify value()");
+                }
+                return Set.of(paramItemType);
+            case NONE:
+            default:
+                Set<Class<?>> all = new LinkedHashSet<>(configManager.getRegisteredConfigs());
+                all.addAll(configManager.getRegisteredFolderConfigItemTypes());
+                return all;
+        }
+    }
+
+    private @Nullable ConfigKind configKind(Class<?> target) {
+        if (configManager.getRegisteredConfigs().contains(target)) {
+            return ConfigKind.SIMPLE;
+        }
+        if (configManager.getRegisteredFolderConfigItemTypes().contains(target)) {
+            return ConfigKind.FOLDER;
+        }
+        return null;
+    }
+
+    private void validatePayloadForKind(Object bean, Method method, PayloadType payload, ConfigKind kind,
+                                        Class<?> target, @Nullable Class<?> simpleParamType, @Nullable Class<?> paramItemType) {
+        if (kind == ConfigKind.SIMPLE) {
+            if (payload == PayloadType.FOLDER_CHANGE || payload == PayloadType.FOLDER_SNAPSHOT) {
+                throw fail(bean, method, "simple config " + target.getName()
+                        + " cannot be received as FolderConfigItemChange/FolderConfigSnapshot");
+            }
+            if (payload == PayloadType.SIMPLE_INSTANCE && !simpleParamType.isAssignableFrom(target)) {
+                throw fail(bean, method, "parameter type " + simpleParamType.getName()
+                        + " is not assignable from config " + target.getName());
+            }
+        } else {
+            if (payload == PayloadType.SIMPLE_INSTANCE) {
+                throw fail(bean, method, "folder config " + target.getName()
+                        + " must be received via no parameter, FolderConfigItemChange<" + target.getSimpleName()
+                        + "> or FolderConfigSnapshot<" + target.getSimpleName() + ">");
+            }
+            if (paramItemType != null && !paramItemType.equals(target)) {
+                throw fail(bean, method, "parameter item type " + paramItemType.getName()
+                        + " does not match folder config " + target.getName());
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void bindSimple(Object bean, Method method, PayloadType payload, Class<?> target) {
+        ConfigRef<Object> ref = (ConfigRef<Object>) configManager.getRef((Class<Object>) target);
+        ref.addListener(newValue -> {
+            Object[] args = (payload == PayloadType.NONE) ? NO_ARGS : new Object[]{newValue};
+            invoker.invoke(bean, method, args);
+        });
+    }
+
+    @SuppressWarnings("unchecked")
+    private void bindFolder(Object bean, Method method, PayloadType payload, Class<?> target) {
+        for (String name : configManager.getFolderConfigNames(target)) {
+            FolderConfigRef<Object> ref =
+                    (FolderConfigRef<Object>) configManager.getFolderConfigRef((Class<Object>) target, name);
+            ref.addListener(change -> {
+                Object[] args;
+                switch (payload) {
+                    case FOLDER_CHANGE:
+                        args = new Object[]{change};
+                        break;
+                    case FOLDER_SNAPSHOT:
+                        args = new Object[]{ref.get()};
+                        break;
+                    case NONE:
+                        args = NO_ARGS;
+                        break;
+                    default:
+                        return;
+                }
+                invoker.invoke(bean, method, args);
+            });
+        }
+    }
+
+    private static @Nullable Class<?> extractItemType(Method method) {
+        Type t = method.getGenericParameterTypes()[0];
+        if (t instanceof ParameterizedType) {
+            Type[] args = ((ParameterizedType) t).getActualTypeArguments();
+            if (args.length == 1 && args[0] instanceof Class) {
+                return (Class<?>) args[0];
+            }
+        }
+        return null;
+    }
+
+    private static ConfigException fail(Object bean, Method method, String reason) {
+        return new ConfigException("@OnConfigReload method " + method.getName()
+                + " on " + bean.getClass().getName() + " " + reason);
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reload/OnConfigReloadInvoker.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reload/OnConfigReloadInvoker.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.reload;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Invokes {@code @OnConfigReload} callback methods reflectively, isolating any failure so it never
+ * escapes a config reload listener.
+ */
+public class OnConfigReloadInvoker {
+
+    private final Logger logger;
+
+    /**
+     * Creates the invoker.
+     *
+     * @param logger the plugin logger, not null
+     */
+    public OnConfigReloadInvoker(@NotNull Logger logger) {
+        this.logger = Objects.requireNonNull(logger, "logger cannot be null");
+    }
+
+    /**
+     * Invokes the given callback. Exceptions thrown by the callback are logged, not rethrown.
+     *
+     * @param bean   the bean instance to invoke on, not null
+     * @param method the callback method, not null
+     * @param args   the arguments to pass, not null (may be empty)
+     */
+    public void invoke(@NotNull Object bean, @NotNull Method method, @NotNull Object[] args) {
+        Objects.requireNonNull(bean, "bean cannot be null");
+        Objects.requireNonNull(method, "method cannot be null");
+        Objects.requireNonNull(args, "args cannot be null");
+        try {
+            method.setAccessible(true);
+            method.invoke(bean, args);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            logger.log(Level.SEVERE, describe(bean, method), cause);
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, describe(bean, method), e);
+        }
+    }
+
+    private static String describe(Object bean, Method method) {
+        return "Error invoking @OnConfigReload method " + method.getName()
+                + " on bean " + bean.getClass().getName();
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reload/OnConfigReloadProcessor.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/reload/OnConfigReloadProcessor.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.reload;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.annotation.OnConfigReload;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+import tech.guilhermekaua.spigotboot.core.context.dependency.postprocessor.BeanPostProcessor;
+import tech.guilhermekaua.spigotboot.utils.ProxyUtils;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+/**
+ * {@link BeanPostProcessor} that wires {@link OnConfigReload} methods of DI-managed beans to config
+ * reload listeners. Runs after {@code MethodHandlerProxyBeanPostProcessor} so it binds to the final
+ * (possibly proxied) bean instance.
+ */
+public class OnConfigReloadProcessor implements BeanPostProcessor {
+
+    private final OnConfigReloadBinder binder;
+
+    /**
+     * Creates the processor.
+     *
+     * @param configManager the config manager, not null
+     * @param logger        the plugin logger, not null
+     */
+    public OnConfigReloadProcessor(@NotNull BungeeConfigManager configManager, @NotNull Logger logger) {
+        Objects.requireNonNull(configManager, "configManager cannot be null");
+        Objects.requireNonNull(logger, "logger cannot be null");
+        this.binder = new OnConfigReloadBinder(configManager, new OnConfigReloadInvoker(logger));
+    }
+
+    @Override
+    public @NotNull Object postProcess(@NotNull BeanDefinition definition,
+                                       @NotNull Object instance,
+                                       @NotNull DependencyManager dependencyManager) {
+        Class<?> realClass = ProxyUtils.getRealClass(instance);
+        for (Method method : collectMethods(realClass)) {
+            if (method.isAnnotationPresent(OnConfigReload.class)) {
+                binder.bind(instance, method);
+            }
+        }
+        return instance;
+    }
+
+    @Override
+    public int getOrder() {
+        // after MethodHandlerProxyBeanPostProcessor (default Ordered order 0) so we bind to the proxy
+        return 100;
+    }
+
+    // scans the whole class hierarchy so an @OnConfigReload method declared protected or
+    // package-private on a superclass is still discovered (getMethods alone only sees public
+    // inherited ones, getDeclaredMethods only the concrete class). dedupes by signature keeping the
+    // most-derived declaration, so an overridden + re-annotated callback is registered only once.
+    private static Collection<Method> collectMethods(Class<?> realClass) {
+        Map<String, Method> bySignature = new LinkedHashMap<>();
+        for (Method method : realClass.getMethods()) {
+            bySignature.putIfAbsent(signatureOf(method), method);
+        }
+        for (Class<?> current = realClass; current != null && current != Object.class; current = current.getSuperclass()) {
+            for (Method method : current.getDeclaredMethods()) {
+                bySignature.putIfAbsent(signatureOf(method), method);
+            }
+        }
+        return bySignature.values();
+    }
+
+    private static String signatureOf(Method method) {
+        StringBuilder signature = new StringBuilder(method.getName());
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            signature.append('|').append(parameterType.getName());
+        }
+        return signature.toString();
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/BungeeConfigSerializers.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/BungeeConfigSerializers.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.serialization;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistry;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Registers BungeeCord-appropriate type serializers. BungeeCord has no Material/Sound/World/Location
+ * equivalents, so unlike the Spigot {@code BukkitSerializers} only the platform-neutral
+ * {@link Duration} serializer is registered.
+ */
+public final class BungeeConfigSerializers {
+
+    private BungeeConfigSerializers() {
+    }
+
+    /**
+     * Registers all BungeeCord serializers to the given registry.
+     *
+     * @param registry the registry to populate
+     */
+    public static void registerAll(@NotNull TypeSerializerRegistry registry) {
+        Objects.requireNonNull(registry, "registry cannot be null");
+
+        registry.register(Duration.class, new DurationSerializer());
+    }
+}

--- a/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/DurationSerializer.java
+++ b/platform-bungee/config-bungee/src/main/java/tech/guilhermekaua/spigotboot/config/bungee/serialization/DurationSerializer.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.serialization;
+
+import org.jetbrains.annotations.NotNull;
+import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
+
+import java.time.Duration;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Serializer for Duration values.
+ * <p>
+ * Parses human-readable formats: "30s", "5m", "2h", "1d", "1w"
+ */
+public class DurationSerializer implements TypeSerializer<Duration> {
+
+    private static final Pattern PATTERN = Pattern.compile(
+            "(\\d+)\\s*(ms|s|m|h|d|w)", Pattern.CASE_INSENSITIVE
+    );
+
+    @Override
+    public Duration deserialize(@NotNull ConfigNode node, @NotNull Class<Duration> type) throws SerializationException {
+        Object raw = node.raw();
+        if (raw == null) {
+            return null;
+        }
+
+        if (raw instanceof Number) {
+            return Duration.ofSeconds(((Number) raw).longValue());
+        }
+
+        String value = String.valueOf(raw).trim();
+        if (value.isEmpty()) {
+            return Duration.ZERO;
+        }
+
+        Matcher matcher = PATTERN.matcher(value);
+        if (!matcher.matches()) {
+            throw new SerializationException("Invalid duration format: " + value +
+                    ". Expected: <number><unit> (e.g., 30s, 5m, 2h, 1d, 1w)");
+        }
+
+        long amount = Long.parseLong(matcher.group(1));
+        String unit = matcher.group(2).toLowerCase();
+
+        switch (unit) {
+            case "ms":
+                return Duration.ofMillis(amount);
+            case "s":
+                return Duration.ofSeconds(amount);
+            case "m":
+                return Duration.ofMinutes(amount);
+            case "h":
+                return Duration.ofHours(amount);
+            case "d":
+                return Duration.ofDays(amount);
+            case "w":
+                return Duration.ofDays(amount * 7);
+            default:
+                throw new SerializationException("Unknown duration unit: " + unit);
+        }
+    }
+
+    @Override
+    public void serialize(@NotNull Duration value, @NotNull MutableConfigNode node) throws SerializationException {
+        long millis = value.toMillis();
+        if (millis < 1000) {
+            node.set(millis + "ms");
+        } else if (value.getSeconds() < 60) {
+            node.set(value.getSeconds() + "s");
+        } else if (value.toMinutes() < 60) {
+            node.set(value.toMinutes() + "m");
+        } else if (value.toHours() < 24) {
+            node.set(value.toHours() + "h");
+        } else if (value.toDays() < 7) {
+            node.set(value.toDays() + "d");
+        } else {
+            node.set(value.toDays() / 7 + "w");
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeModuleDiscoveryTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/BungeeModuleDiscoveryTest.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.module.Module;
+import tech.guilhermekaua.spigotboot.core.module.ModuleDiscovery;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BungeeModuleDiscoveryTest {
+
+    // proves the META-INF/spigot-boot/modules marker resource is present and names the module correctly,
+    // so SpigotBootBuilder.autoDiscover() picks it up exactly as it does SpigotConfigModule on Spigot.
+    @Test
+    void bungeeConfigModuleIsAutoDiscoverable() {
+        List<Class<? extends Module>> modules =
+                new ModuleDiscovery(getClass().getClassLoader()).discover();
+
+        assertTrue(modules.contains(BungeeConfigModule.class),
+                "BungeeConfigModule must be discoverable via its META-INF/spigot-boot/modules marker");
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxyRelocationIT.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxyRelocationIT.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.proxy;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression guard for the shaded-javassist NoClassDefFoundError. {@code ConfigProxy} uses the
+ * javassist proxy API directly, so its pre-shade bytecode legitimately references {@code javassist/};
+ * only the PACKAGED (shaded) jar must be clean. A normal surefire test runs against the un-shaded
+ * {@code target/classes} and cannot catch this — so this is a failsafe {@code *IT} bound to the
+ * {@code verify} phase (after {@code package}/shade), inspecting the produced jar.
+ */
+class ConfigProxyRelocationIT {
+
+    private static final String SHADED_PREFIX = "tech/guilhermekaua/spigotboot/shaded/javassist/";
+    private static final String CONFIG_PROXY_ENTRY =
+            "tech/guilhermekaua/spigotboot/config/bungee/proxy/ConfigProxy.class";
+
+    @Test
+    void packagedConfigProxyReferencesOnlyShadedJavassist() throws IOException {
+        String buildDir = System.getProperty("project.build.directory");
+        String finalName = System.getProperty("project.build.finalName");
+        assertNotNull(buildDir, "project.build.directory must be supplied by the failsafe plugin");
+        assertNotNull(finalName, "project.build.finalName must be supplied by the failsafe plugin");
+
+        Path jar = Path.of(buildDir, finalName + ".jar");
+        assertTrue(Files.exists(jar),
+                "shaded jar not found at " + jar + " — run the package/verify phase, not just test");
+
+        byte[] bytes;
+        try (ZipFile zip = new ZipFile(jar.toFile())) {
+            ZipEntry entry = zip.getEntry(CONFIG_PROXY_ENTRY);
+            assertNotNull(entry, CONFIG_PROXY_ENTRY + " not found inside " + jar);
+            try (InputStream in = zip.getInputStream(entry)) {
+                bytes = in.readAllBytes();
+            }
+        }
+
+        // constant-pool type references use the slashed internal form (javassist/util/proxy/...);
+        // decode byte-preserving so they appear verbatim as substrings.
+        String pool = new String(bytes, StandardCharsets.ISO_8859_1);
+
+        assertTrue(pool.contains(SHADED_PREFIX),
+                "ConfigProxy.class must reference the relocated javassist package " + SHADED_PREFIX
+                        + " in the packaged jar (relocation did not run)");
+
+        // strip the shaded prefix first: the relocated form ITSELF contains the substring "javassist/",
+        // so a naive contains("javassist/") would false-match. what must not remain is any un-relocated ref.
+        String withoutShaded = pool.replace(SHADED_PREFIX, "");
+        assertFalse(withoutShaded.contains("javassist/"),
+                "ConfigProxy.class still references the un-relocated javassist package in the packaged jar");
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/binding/ConfigEnumListBindingTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/binding/ConfigEnumListBindingTest.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License
+ * Copyright © 2026 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.binding;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializer;
+import tech.guilhermekaua.spigotboot.config.serialization.TypeSerializerRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * reproduces binding of a {@code List} whose element type is an enum that has a
+ * registered {@link TypeSerializer}.
+ */
+@ExtendWith(MockitoExtension.class)
+class ConfigEnumListBindingTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private BungeeConfigManager configManager;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = Logger.getLogger(ConfigEnumListBindingTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+
+        TypeSerializerRegistryCustomizer colorSerializer =
+                registry -> registry.register(Color.class, new ColorSerializer());
+
+        configManager = new BungeeConfigManager(plugin, null, Collections.singletonList(colorSerializer));
+    }
+
+    @Test
+    void bindsScalarEnumWithRegisteredSerializer() throws IOException {
+        writeYaml("scalar.yml", "favorite: GREEN\n");
+        configManager.register(ScalarEnumConfig.class);
+        configManager.initializeAll();
+
+        ScalarEnumConfig config = configManager.get(ScalarEnumConfig.class);
+
+        assertEquals(Color.GREEN, config.getFavorite());
+    }
+
+    @Test
+    void bindsListOfEnumWithRegisteredSerializer() throws IOException {
+        writeYaml("list.yml", "palette:\n  - RED\n  - BLUE\n");
+        configManager.register(ListEnumConfig.class);
+        configManager.initializeAll();
+
+        ListEnumConfig config = configManager.get(ListEnumConfig.class);
+
+        assertEquals(Arrays.asList(Color.RED, Color.BLUE), config.getPalette());
+    }
+
+    private void writeYaml(String fileName, String content) throws IOException {
+        Files.writeString(tempDir.resolve(fileName), content);
+    }
+
+    public enum Color {
+        RED, GREEN, BLUE
+    }
+
+    /**
+     * simple serializer that maps a scalar string to a {@link Color} constant by name.
+     */
+    public static class ColorSerializer implements TypeSerializer<Color> {
+        @Override
+        public Color deserialize(ConfigNode node, Class<Color> type) {
+            String value = node.get(String.class);
+            return value == null ? null : Color.valueOf(value);
+        }
+
+        @Override
+        public void serialize(Color value, MutableConfigNode node) {
+            node.set(value.name());
+        }
+    }
+
+    @Config(value = "scalar.yml", name = "scalar", generateDefaults = false)
+    public static class ScalarEnumConfig {
+        private Color favorite = Color.RED;
+
+        public ScalarEnumConfig() {
+        }
+
+        public Color getFavorite() {
+            return favorite;
+        }
+    }
+
+    @Config(value = "list.yml", name = "list", generateDefaults = false)
+    public static class ListEnumConfig {
+        private List<Color> palette = new ArrayList<>();
+
+        public ListEnumConfig() {
+        }
+
+        public List<Color> getPalette() {
+            return palette;
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/configuration/ConfigConfigurationTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/configuration/ConfigConfigurationTest.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.configuration;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.configuration.ConfigConfiguration;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigRefInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigValueInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.FolderConfigInjector;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadProcessor;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.CustomInjectorRegistryCustomizer;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.DefaultCustomInjectorRegistry;
+import tech.guilhermekaua.spigotboot.core.context.dependency.postprocessor.BeanPostProcessor;
+import tech.guilhermekaua.spigotboot.core.context.dependency.postprocessor.BeanPostProcessorRegistryCustomizer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigConfigurationTest {
+
+    @Mock
+    Plugin plugin;
+
+    @Test
+    void onConfigReloadProcessor_registersProcessor() {
+        when(plugin.getLogger()).thenReturn(Logger.getLogger("test"));
+        BungeeConfigManager configManager = mock(BungeeConfigManager.class);
+
+        ConfigConfiguration configuration = new ConfigConfiguration();
+        BeanPostProcessorRegistryCustomizer customizer = configuration.onConfigReloadProcessor(configManager, plugin);
+
+        List<BeanPostProcessor> registered = new ArrayList<>();
+        customizer.customize(registered::add);
+
+        assertEquals(1, registered.size());
+        assertTrue(registered.get(0) instanceof OnConfigReloadProcessor);
+    }
+
+    @Test
+    void configInjectors_registersConfigValueInjector() {
+        lenient().when(plugin.getLogger()).thenReturn(Logger.getLogger(ConfigConfigurationTest.class.getName()));
+        BungeeConfigManager configManager = new BungeeConfigManager(plugin);
+
+        CustomInjectorRegistryCustomizer customizer = new ConfigConfiguration().configInjectors(configManager);
+        DefaultCustomInjectorRegistry registry = new DefaultCustomInjectorRegistry();
+        customizer.customize(registry);
+
+        assertEquals(3, registry.getInjectors().size());
+        assertTrue(registry.getInjectors().stream().anyMatch(i -> i instanceof FolderConfigInjector));
+        assertTrue(registry.getInjectors().stream().anyMatch(i -> i instanceof ConfigRefInjector));
+        assertTrue(registry.getInjectors().stream().anyMatch(i -> i instanceof ConfigValueInjector));
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/folder/FolderConfigEntryTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/folder/FolderConfigEntryTest.java
@@ -1,0 +1,1082 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.folder;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfig;
+import tech.guilhermekaua.spigotboot.config.annotation.NodeKey;
+import tech.guilhermekaua.spigotboot.config.binding.Binder;
+import tech.guilhermekaua.spigotboot.config.binding.NamingStrategy;
+import tech.guilhermekaua.spigotboot.config.folder.EditResult;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigChangeListener;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigItemChange;
+import tech.guilhermekaua.spigotboot.config.folder.ItemChangeType;
+import tech.guilhermekaua.spigotboot.config.bungee.folder.FolderConfigEntry;
+import tech.guilhermekaua.spigotboot.config.bungee.loader.YamlConfigLoader;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class FolderConfigEntryTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private Logger logger;
+    private YamlConfigLoader loader;
+    private Binder binder;
+    private Path itemsFolder;
+
+    // ========== Test Fixtures ==========
+
+    public static class TestItem {
+        private String name;
+        private int priority;
+
+        public TestItem() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
+    }
+
+    public static class TestItemWithNodeKey {
+        @NodeKey
+        private String id;
+        private String name;
+
+        public TestItemWithNodeKey() {
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class TestItemWithIdField {
+        private String itemId;
+        private String name;
+
+        public TestItemWithIdField() {
+        }
+
+        public String getItemId() {
+            return itemId;
+        }
+
+        public void setItemId(String itemId) {
+            this.itemId = itemId;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class TestItemWithEnabled {
+        private String name;
+        private boolean enabled;
+        private int priority;
+
+        public TestItemWithEnabled() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public int getPriority() {
+            return priority;
+        }
+
+        public void setPriority(int priority) {
+            this.priority = priority;
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    @SuppressWarnings("unchecked")
+    private FolderConfig createAnnotation(
+            String name,
+            String folder,
+            String idField,
+            String orderBy,
+            String enabledField,
+            String resource,
+            String excludePrefix) {
+        Map<String, Object> values = Map.of(
+                "name", name,
+                "folder", folder,
+                "idField", idField,
+                "orderBy", orderBy,
+                "enabledField", enabledField,
+                "resource", resource,
+                "excludePrefix", excludePrefix
+        );
+
+        InvocationHandler handler = (proxy, method, args) -> {
+            String methodName = method.getName();
+            if ("annotationType".equals(methodName)) {
+                return FolderConfig.class;
+            }
+            if ("toString".equals(methodName)) {
+                return "@FolderConfig(folder=" + folder + ")";
+            }
+            if ("hashCode".equals(methodName)) {
+                return values.hashCode();
+            }
+            if ("equals".equals(methodName)) {
+                return proxy == args[0];
+            }
+            return values.get(methodName);
+        };
+
+        return (FolderConfig) Proxy.newProxyInstance(
+                FolderConfig.class.getClassLoader(),
+                new Class<?>[]{FolderConfig.class},
+                handler
+        );
+    }
+
+    private FolderConfig createDefaultAnnotation() {
+        return createAnnotation("", "items", "", "filename", "", "", "_");
+    }
+
+    private Path createTestFile(String name, String content) throws IOException {
+        Files.createDirectories(itemsFolder);
+        Path file = itemsFolder.resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+
+    @BeforeEach
+    void setUp() {
+        logger = Logger.getLogger(FolderConfigEntryTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+        itemsFolder = tempDir.resolve("items");
+        loader = new YamlConfigLoader();
+        binder = Binder.create();
+    }
+
+    // ========== Constructor Tests ==========
+
+    @Test
+    void constructor_WithValidParameters_CreatesEntry() {
+        FolderConfig annotation = createDefaultAnnotation();
+
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        assertNotNull(entry);
+        assertEquals(TestItem.class, entry.getItemType());
+        assertEquals("items", entry.getFolderConfigName());
+        assertEquals(itemsFolder, entry.getFolder());
+    }
+
+    @Test
+    void constructor_WithNullItemType_ThrowsNPE() {
+        FolderConfig annotation = createDefaultAnnotation();
+
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                new FolderConfigEntry<>(null, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE));
+
+        assertTrue(exception.getMessage().contains("itemType"));
+    }
+
+    @Test
+    void constructor_WithNullAnnotation_ThrowsNPE() {
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                new FolderConfigEntry<>(TestItem.class, null, plugin, loader, binder, NamingStrategy.SNAKE_CASE));
+
+        assertTrue(exception.getMessage().contains("annotation"));
+    }
+
+    @Test
+    void constructor_WithNullPlugin_ThrowsNPE() {
+        FolderConfig annotation = createDefaultAnnotation();
+
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                new FolderConfigEntry<>(TestItem.class, annotation, null, loader, binder, NamingStrategy.SNAKE_CASE));
+
+        assertTrue(exception.getMessage().contains("plugin"));
+    }
+
+    @Test
+    void constructor_WithNullLoader_ThrowsNPE() {
+        FolderConfig annotation = createDefaultAnnotation();
+
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                new FolderConfigEntry<>(TestItem.class, annotation, plugin, null, binder, NamingStrategy.SNAKE_CASE));
+
+        assertTrue(exception.getMessage().contains("loader"));
+    }
+
+    @Test
+    void constructor_WithNullBinder_ThrowsNPE() {
+        FolderConfig annotation = createDefaultAnnotation();
+
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                new FolderConfigEntry<>(TestItem.class, annotation, plugin, loader, null, NamingStrategy.SNAKE_CASE));
+
+        assertTrue(exception.getMessage().contains("binder"));
+    }
+
+    @Test
+    void constructor_WithEmptyName_DerivesNameFromFolder() {
+        FolderConfig annotation = createAnnotation("", "boosters", "", "filename", "", "", "_");
+
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        assertEquals("boosters", entry.getFolderConfigName());
+    }
+
+    @Test
+    void constructor_WithExplicitName_UsesProvidedName() {
+        FolderConfig annotation = createAnnotation("my-collection", "items", "", "filename", "", "", "_");
+
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        assertEquals("my-collection", entry.getFolderConfigName());
+    }
+
+    @Test
+    void constructor_WithNestedFolder_DerivesNameFromLastSegment() {
+        FolderConfig annotation = createAnnotation("", "configs/items/boosters", "", "filename", "", "", "_");
+
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        assertEquals("boosters", entry.getFolderConfigName());
+    }
+
+    @Test
+    void constructor_WithTrailingSlash_IgnoresSlash() {
+        FolderConfig annotation = createAnnotation("", "items/", "", "filename", "", "", "_");
+
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        assertEquals("items", entry.getFolderConfigName());
+    }
+
+    @Test
+    void constructor_WithBackslashPath_NormalizesToForwardSlash() {
+        FolderConfig annotation = createAnnotation("", "configs\\items", "", "filename", "", "", "_");
+
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        assertEquals("items", entry.getFolderConfigName());
+    }
+
+    // ========== Initialize Tests ==========
+
+    @Test
+    void initialize_FolderDoesNotExist_CreatesFolderAndLoadsEmpty() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        entry.initialize();
+
+        assertTrue(Files.exists(itemsFolder));
+        assertTrue(entry.getRef().get().isEmpty());
+    }
+
+    @Test
+    void initialize_FolderExists_LoadsItemsWithoutRecreating() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Test\npriority: 1");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        entry.initialize();
+
+        assertTrue(Files.exists(itemsFolder));
+        assertEquals(1, entry.getRef().get().size());
+    }
+
+    @Test
+    void initialize_EmptyFolder_ReturnsEmptySnapshot() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        entry.initialize();
+
+        assertTrue(entry.getRef().get().isEmpty());
+        assertEquals(0, entry.getRef().get().size());
+    }
+
+    // ========== LoadAll Tests ==========
+
+    @Test
+    void loadAll_WithYmlFiles_LoadsAllItems() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+        createTestFile("item2.yml", "name: Item2\npriority: 2");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(2, entry.getRef().get().size());
+        assertTrue(entry.getRef().get().contains("item1"));
+        assertTrue(entry.getRef().get().contains("item2"));
+    }
+
+    @Test
+    void loadAll_WithYamlFiles_LoadsAllItems() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yaml", "name: Item1\npriority: 1");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(1, entry.getRef().get().size());
+        assertTrue(entry.getRef().get().contains("item1"));
+    }
+
+    @Test
+    void loadAll_IgnoresNonYamlFiles() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+        createTestFile("readme.txt", "This is not a config");
+        createTestFile("data.json", "{}");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(1, entry.getRef().get().size());
+    }
+
+    @Test
+    void loadAll_WithExcludePrefix_SkipsMatchingFiles() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+        createTestFile("_template.yml", "name: Template\npriority: 0");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(1, entry.getRef().get().size());
+        assertTrue(entry.getRef().get().contains("item1"));
+        assertFalse(entry.getRef().get().contains("_template"));
+    }
+
+    @Test
+    void loadAll_WithEmptyExcludePrefix_LoadsAll() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+        createTestFile("_template.yml", "name: Template\npriority: 0");
+
+        FolderConfig annotation = createAnnotation("", "items", "", "filename", "", "", "");
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(2, entry.getRef().get().size());
+    }
+
+    @Test
+    void loadAll_SkipsDirectories() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+        Files.createDirectory(itemsFolder.resolve("subdir"));
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(1, entry.getRef().get().size());
+    }
+
+    @Test
+    void loadAll_FolderDoesNotExist_SetsEmptySnapshot() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        entry.loadAll();
+
+        assertTrue(entry.getRef().get().isEmpty());
+    }
+
+    @Test
+    void loadAll_OrdersByFilename_DefaultBehavior() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("c-item.yml", "name: C\npriority: 3");
+        createTestFile("a-item.yml", "name: A\npriority: 1");
+        createTestFile("b-item.yml", "name: B\npriority: 2");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<TestItem> values = new ArrayList<>(entry.getRef().get().values());
+        assertEquals(3, values.size());
+        assertEquals("A", values.get(0).getName());
+        assertEquals("B", values.get(1).getName());
+        assertEquals("C", values.get(2).getName());
+    }
+
+    @Test
+    void loadAll_OrdersByField_WhenOrderBySpecified() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 3");
+        createTestFile("item2.yml", "name: Item2\npriority: 1");
+        createTestFile("item3.yml", "name: Item3\npriority: 2");
+
+        FolderConfig annotation = createAnnotation("", "items", "", "priority", "", "", "_");
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<TestItem> values = new ArrayList<>(entry.getRef().get().values());
+        assertEquals(3, values.size());
+        assertEquals(1, values.get(0).getPriority());
+        assertEquals(2, values.get(1).getPriority());
+        assertEquals(3, values.get(2).getPriority());
+    }
+
+    // ========== ID Injection Tests ==========
+
+    @Test
+    void loadItem_WithNodeKeyField_InjectsId() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("my-item.yml", "name: Test");
+
+        FolderConfig annotation = createAnnotation("", "items", "", "filename", "", "", "_");
+        FolderConfigEntry<TestItemWithNodeKey> entry = new FolderConfigEntry<>(
+                TestItemWithNodeKey.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        TestItemWithNodeKey loaded = entry.getRef().get().find("my-item");
+        assertNotNull(loaded);
+        assertEquals("my-item", loaded.getId());
+    }
+
+    @Test
+    void loadItem_WithExplicitIdField_InjectsId() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("my-item.yml", "name: Test");
+
+        FolderConfig annotation = createAnnotation("", "items", "itemId", "filename", "", "", "_");
+        FolderConfigEntry<TestItemWithIdField> entry = new FolderConfigEntry<>(
+                TestItemWithIdField.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        TestItemWithIdField loaded = entry.getRef().get().find("my-item");
+        assertNotNull(loaded);
+        assertEquals("my-item", loaded.getItemId());
+    }
+
+    // ========== Enabled Filtering Tests ==========
+
+    @Test
+    void loadAll_WithEnabledField_FiltersDisabledItems() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("enabled-item.yml", "name: Enabled\nenabled: true\npriority: 1");
+        createTestFile("disabled-item.yml", "name: Disabled\nenabled: false\npriority: 2");
+
+        FolderConfig annotation = createAnnotation("", "items", "", "filename", "enabled", "", "_");
+        FolderConfigEntry<TestItemWithEnabled> entry = new FolderConfigEntry<>(
+                TestItemWithEnabled.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(2, entry.getRef().get().size());
+        assertEquals(1, entry.getRef().get().enabled().size());
+    }
+
+    @Test
+    void loadAll_WithEmptyEnabledField_ReturnsAllAsEnabled() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\nenabled: true\npriority: 1");
+        createTestFile("item2.yml", "name: Item2\nenabled: false\npriority: 2");
+
+        FolderConfig annotation = createAnnotation("", "items", "", "filename", "", "", "_");
+        FolderConfigEntry<TestItemWithEnabled> entry = new FolderConfigEntry<>(
+                TestItemWithEnabled.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertEquals(2, entry.getRef().get().size());
+        assertEquals(2, entry.getRef().get().enabled().size());
+    }
+
+    // ========== Reload Tests ==========
+
+    @Test
+    void reloadAll_NewFileAdded_NotifiesAddedChange() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> changes = new ArrayList<>();
+        entry.getRef().addListener(changes::add);
+
+        createTestFile("item2.yml", "name: Item2\npriority: 2");
+        entry.reloadAll();
+
+        assertEquals(1, changes.size());
+        assertEquals(ItemChangeType.ADDED, changes.get(0).getType());
+        assertEquals("item2", changes.get(0).getId());
+    }
+
+    @Test
+    void reloadAll_FileRemoved_NotifiesRemovedChange() throws IOException {
+        Files.createDirectories(itemsFolder);
+        Path item1Path = createTestFile("item1.yml", "name: Item1\npriority: 1");
+        createTestFile("item2.yml", "name: Item2\npriority: 2");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> changes = new ArrayList<>();
+        entry.getRef().addListener(changes::add);
+
+        Files.delete(item1Path);
+        entry.reloadAll();
+
+        assertEquals(1, changes.size());
+        assertEquals(ItemChangeType.REMOVED, changes.get(0).getType());
+        assertEquals("item1", changes.get(0).getId());
+    }
+
+    @Test
+    void reloadItem_ItemDoesNotExist_AddsItem() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> changes = new ArrayList<>();
+        entry.getRef().addListener(changes::add);
+
+        createTestFile("new-item.yml", "name: NewItem\npriority: 1");
+        entry.reloadItem("new-item");
+
+        assertEquals(1, changes.size());
+        assertEquals(ItemChangeType.ADDED, changes.get(0).getType());
+        assertEquals("new-item", changes.get(0).getId());
+    }
+
+    @Test
+    void reloadItem_ItemRemoved_RemovesAndNotifies() throws IOException {
+        Files.createDirectories(itemsFolder);
+        Path itemPath = createTestFile("item1.yml", "name: Item1\npriority: 1");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> changes = new ArrayList<>();
+        entry.getRef().addListener(changes::add);
+
+        Files.delete(itemPath);
+        entry.reloadItem("item1");
+
+        assertEquals(1, changes.size());
+        assertEquals(ItemChangeType.REMOVED, changes.get(0).getType());
+        assertEquals("item1", changes.get(0).getId());
+        assertNull(entry.getRef().get().find("item1"));
+    }
+
+    // ========== SaveItem Tests ==========
+
+    @Test
+    void saveItem_ValidId_SavesAndReturnsSuccess() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        TestItem item = new TestItem();
+        item.setName("Test");
+        item.setPriority(5);
+
+        EditResult<TestItem> result = entry.saveItem("new-item", item);
+
+        assertTrue(result.isSuccess());
+        assertNotNull(result.getValue());
+        assertTrue(Files.exists(itemsFolder.resolve("new-item.yml")));
+    }
+
+    @Test
+    void saveItem_NewItem_NotifiesAdded() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> changes = new ArrayList<>();
+        entry.getRef().addListener(changes::add);
+
+        TestItem item = new TestItem();
+        item.setName("Test");
+        item.setPriority(5);
+
+        entry.saveItem("new-item", item);
+
+        assertEquals(1, changes.size());
+        assertEquals(ItemChangeType.ADDED, changes.get(0).getType());
+    }
+
+    @Test
+    void saveItem_NullId_ReturnsFailure() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        TestItem item = new TestItem();
+
+        EditResult<TestItem> result = entry.saveItem(null, item);
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getErrorMessage().contains("Invalid item ID"));
+    }
+
+    @Test
+    void saveItem_EmptyId_ReturnsFailure() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        TestItem item = new TestItem();
+
+        EditResult<TestItem> result = entry.saveItem("", item);
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getErrorMessage().contains("Invalid item ID"));
+    }
+
+    @Test
+    void saveItem_IdWithSlash_ReturnsFailure() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        TestItem item = new TestItem();
+
+        EditResult<TestItem> result = entry.saveItem("foo/bar", item);
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getErrorMessage().contains("Invalid item ID"));
+    }
+
+    @Test
+    void saveItem_IdWithBackslash_ReturnsFailure() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        TestItem item = new TestItem();
+
+        EditResult<TestItem> result = entry.saveItem("foo\\bar", item);
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getErrorMessage().contains("Invalid item ID"));
+    }
+
+    @Test
+    void saveItem_IdWithDoubleDot_ReturnsFailure() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        TestItem item = new TestItem();
+
+        EditResult<TestItem> result = entry.saveItem("foo..bar", item);
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getErrorMessage().contains("Invalid item ID"));
+    }
+
+    @Test
+    void saveItem_IdWithSpecialChars_ReturnsFailure() {
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        TestItem item = new TestItem();
+
+        EditResult<TestItem> result = entry.saveItem("foo@bar!", item);
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getErrorMessage().contains("Invalid item ID"));
+    }
+
+    @Test
+    void saveItem_ValidIdWithDot_Succeeds() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        TestItem item = new TestItem();
+        item.setName("Test");
+        item.setPriority(5);
+
+        EditResult<TestItem> result = entry.saveItem("config.v1", item);
+
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
+    void saveItem_ValidIdWithUnderscore_Succeeds() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        TestItem item = new TestItem();
+        item.setName("Test");
+        item.setPriority(5);
+
+        EditResult<TestItem> result = entry.saveItem("my_config", item);
+
+        assertTrue(result.isSuccess());
+    }
+
+    @Test
+    void saveItem_ValidIdWithHyphen_Succeeds() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        TestItem item = new TestItem();
+        item.setName("Test");
+        item.setPriority(5);
+
+        EditResult<TestItem> result = entry.saveItem("my-config", item);
+
+        assertTrue(result.isSuccess());
+    }
+
+    // ========== DeleteItem Tests ==========
+
+    @Test
+    void deleteItem_ExistingItem_DeletesAndReturnsSuccess() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        EditResult<Void> result = entry.deleteItem("item1");
+
+        assertTrue(result.isSuccess());
+        assertNull(entry.getRef().get().find("item1"));
+    }
+
+    @Test
+    void deleteItem_ExistingItem_NotifiesRemoved() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item1.yml", "name: Item1\npriority: 1");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> changes = new ArrayList<>();
+        entry.getRef().addListener(changes::add);
+
+        entry.deleteItem("item1");
+
+        assertEquals(1, changes.size());
+        assertEquals(ItemChangeType.REMOVED, changes.get(0).getType());
+        assertEquals("item1", changes.get(0).getId());
+    }
+
+    @Test
+    void deleteItem_NonExistentItem_ReturnsFailure() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        EditResult<Void> result = entry.deleteItem("nonexistent");
+
+        assertTrue(result.isFailure());
+        assertTrue(result.getErrorMessage().contains("Item not found"));
+    }
+
+    // ========== CopyItem Tests ==========
+
+    @Test
+    void copyItem_ValidItem_ReturnsDeepCopy() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        TestItem original = new TestItem();
+        original.setName("Original");
+        original.setPriority(10);
+
+        TestItem result = entry.copyItem(original);
+
+        assertNotNull(result);
+        assertNotSame(original, result);
+        assertEquals(original.getName(), result.getName());
+        assertEquals(original.getPriority(), result.getPriority());
+    }
+
+    // ========== Path Resolution Tests ==========
+
+    @Test
+    void resolveItemPath_YamlExists_PrefersYaml() throws IOException {
+        Files.createDirectories(itemsFolder);
+        createTestFile("item.yml", "name: Yml\npriority: 1");
+        createTestFile("item.yaml", "name: Yaml\npriority: 2");
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        assertTrue(entry.getRef().get().contains("item"));
+    }
+
+    // ========== Listener Tests ==========
+
+    @Test
+    void addListener_ReceivesNotifications() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> receivedChanges = new ArrayList<>();
+        FolderConfigChangeListener<TestItem> listener = receivedChanges::add;
+        entry.getRef().addListener(listener);
+
+        TestItem item = new TestItem();
+        item.setName("Test");
+        item.setPriority(5);
+
+        entry.saveItem("new-item", item);
+
+        assertEquals(1, receivedChanges.size());
+    }
+
+    @Test
+    void removeListener_StopsReceivingNotifications() throws IOException {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+        entry.loadAll();
+
+        List<FolderConfigItemChange<TestItem>> receivedChanges = new ArrayList<>();
+        FolderConfigChangeListener<TestItem> listener = receivedChanges::add;
+        entry.getRef().addListener(listener);
+        entry.getRef().removeListener(listener);
+
+        TestItem item = new TestItem();
+        item.setName("Test");
+        item.setPriority(5);
+
+        entry.saveItem("new-item", item);
+
+        assertTrue(receivedChanges.isEmpty());
+    }
+
+    // ========== Resource-Copy Containment Guard Tests ==========
+
+    private void invokeCopyResourceFile(FolderConfigEntry<?> entry, String resourcePath, String fileName)
+            throws Exception {
+        Method method = FolderConfigEntry.class
+                .getDeclaredMethod("copyResourceFile", String.class, String.class);
+        method.setAccessible(true);
+        method.invoke(entry, resourcePath, fileName);
+    }
+
+    @Test
+    void copyResourceFile_BenignFileName_WritesInsideFolder() throws Exception {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        lenient().when(plugin.getResourceAsStream("items/default.yml")).thenReturn(
+                new ByteArrayInputStream("name: Default\npriority: 1".getBytes(StandardCharsets.UTF_8)));
+
+        invokeCopyResourceFile(entry, "items/default.yml", "default.yml");
+
+        assertTrue(Files.exists(itemsFolder.resolve("default.yml")));
+    }
+
+    @Test
+    void copyResourceFile_FileNameEscapesFolder_SkipsAndDoesNotWriteOutside() throws Exception {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        lenient().when(plugin.getResourceAsStream("items/evil.yml")).thenReturn(
+                new ByteArrayInputStream("name: Evil".getBytes(StandardCharsets.UTF_8)));
+
+        // resolves to tempDir/escape.yml, i.e. outside the items folder
+        invokeCopyResourceFile(entry, "items/evil.yml", "../escape.yml");
+
+        assertFalse(Files.exists(tempDir.resolve("escape.yml")),
+                "guard must not write resources outside the target folder");
+        try (var entries = Files.list(itemsFolder)) {
+            assertTrue(entries.findFirst().isEmpty(), "skipped resource must not write anything");
+        }
+    }
+
+    @Test
+    void copyResourceFile_DeepEscapeFileName_SkipsAndDoesNotWriteOutside() throws Exception {
+        Files.createDirectories(itemsFolder);
+
+        FolderConfig annotation = createDefaultAnnotation();
+        FolderConfigEntry<TestItem> entry = new FolderConfigEntry<>(
+                TestItem.class, annotation, plugin, loader, binder, NamingStrategy.SNAKE_CASE);
+
+        lenient().when(plugin.getResourceAsStream("items/evil.yml")).thenReturn(
+                new ByteArrayInputStream("name: Evil".getBytes(StandardCharsets.UTF_8)));
+
+        String uniqueName = "deep-escape-" + UUID.randomUUID() + ".yml";
+        Path outside = tempDir.getParent().resolve(uniqueName);
+        Files.deleteIfExists(outside);
+
+        invokeCopyResourceFile(entry, "items/evil.yml", "../../" + uniqueName);
+
+        assertFalse(Files.exists(outside),
+                "guard must not write resources outside the target folder via '..' segments");
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/injector/ConfigValueInjectorTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/injector/ConfigValueInjectorTest.java
@@ -1,0 +1,158 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.injector;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.annotation.ConfigValue;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigValueInjector;
+import tech.guilhermekaua.spigotboot.core.context.component.proxy.methodHandler.MethodHandlerRegistry;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionResult;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigValueInjectorTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private BungeeConfigManager configManager;
+    private ConfigValueInjector injector;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        MethodHandlerRegistry.clear();
+        Logger logger = Logger.getLogger(ConfigValueInjectorTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+        configManager = new BungeeConfigManager(plugin);
+        Files.writeString(tempDir.resolve("app.yml"), "name: hello\nport: 25565\n");
+        configManager.register(AppConfig.class);
+        configManager.initializeAll();
+        injector = new ConfigValueInjector(configManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        MethodHandlerRegistry.clear();
+    }
+
+    @Test
+    void supports_onlyWhenAnnotationPresent() throws NoSuchFieldException {
+        assertTrue(injector.supports(InjectionPoint.fromField(FieldBean.class.getDeclaredField("name"))));
+        assertFalse(injector.supports(InjectionPoint.fromField(FieldBean.class.getDeclaredField("untouched"))));
+    }
+
+    @Test
+    void order_isMinus100() {
+        assertEquals(-100, injector.getOrder());
+    }
+
+    @Test
+    void resolve_returnsHandledValue() throws NoSuchFieldException {
+        InjectionResult result = injector.resolve(InjectionPoint.fromField(FieldBean.class.getDeclaredField("name")));
+        assertTrue(result.isHandled());
+        assertEquals("hello", result.getValue());
+    }
+
+    @Test
+    void di_injectsFieldWithoutInjectAnnotation() {
+        DependencyManager dm = new DependencyManager();
+        dm.registerInjector(injector);
+        dm.registerDependency(FieldBean.class, null, false, null, null);
+
+        FieldBean bean = dm.resolveDependency(FieldBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("hello", bean.name);
+        assertEquals(25565, bean.port);
+        assertNull(bean.untouched);
+    }
+
+    @Test
+    void di_injectsConstructorParameter() {
+        DependencyManager dm = new DependencyManager();
+        dm.registerInjector(injector);
+        dm.registerDependency(CtorBean.class, null, false, null, null);
+
+        CtorBean bean = dm.resolveDependency(CtorBean.class, null);
+
+        assertNotNull(bean);
+        assertEquals("hello", bean.name);
+    }
+
+    @Test
+    void di_requiredMissing_failsBeanCreation() {
+        DependencyManager dm = new DependencyManager();
+        dm.registerInjector(injector);
+        dm.registerDependency(RequiredMissingBean.class, null, false, null, null);
+
+        assertThrows(RuntimeException.class, () -> dm.resolveDependency(RequiredMissingBean.class, null));
+    }
+
+    // ---- fixtures ----
+
+    @Config(value = "app.yml", name = "app", generateDefaults = false)
+    public static class AppConfig {
+        private String name;
+        private int port;
+        public AppConfig() {}
+    }
+
+    static class FieldBean {
+        @ConfigValue("app:name") String name;
+        @ConfigValue("app:port") int port;
+        String untouched;
+    }
+
+    static class CtorBean {
+        final String name;
+        CtorBean(@ConfigValue("app:name") String name) {
+            this.name = name;
+        }
+    }
+
+    static class RequiredMissingBean {
+        @ConfigValue("app:missing") String missing;
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/injector/ConfigValueResolverTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/injector/ConfigValueResolverTest.java
@@ -1,0 +1,250 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.injector;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.annotation.ConfigValue;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.injector.ConfigValueResolver;
+import tech.guilhermekaua.spigotboot.core.context.dependency.injector.InjectionPoint;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigValueResolverTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private BungeeConfigManager configManager;
+    private ConfigValueResolver resolver;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Logger logger = Logger.getLogger(ConfigValueResolverTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+        configManager = new BungeeConfigManager(plugin);
+        Files.writeString(tempDir.resolve("app.yml"),
+                "name: hello\nport: 25565\nenabled: true\nratio: 1.5\n");
+        configManager.register(AppConfig.class);
+        configManager.initializeAll();
+        resolver = new ConfigValueResolver(configManager);
+    }
+
+    private Object resolveField(Class<?> beanType, String fieldName) throws NoSuchFieldException {
+        return resolver.resolve(InjectionPoint.fromField(beanType.getDeclaredField(fieldName)));
+    }
+
+    @Test
+    void valueMode_resolvesScalars() throws NoSuchFieldException {
+        assertEquals("hello", resolveField(ValueModeBean.class, "name"));
+        assertEquals(25565, ((Number) resolveField(ValueModeBean.class, "port")).intValue());
+        assertEquals(Boolean.TRUE, resolveField(ValueModeBean.class, "enabled"));
+        assertEquals(1.5, ((Number) resolveField(ValueModeBean.class, "ratio")).doubleValue());
+    }
+
+    @Test
+    void configMode_resolvesByClassAndPath() throws NoSuchFieldException {
+        assertEquals("hello", resolveField(ConfigModeBean.class, "name"));
+    }
+
+    @Test
+    void default_appliedWhenAbsent() throws NoSuchFieldException {
+        assertEquals("fallback", resolveField(DefaultBean.class, "missing"));
+        assertEquals(7, ((Number) resolveField(DefaultBean.class, "missingNum")).intValue());
+        assertEquals("", resolveField(DefaultBean.class, "emptyDefault"));
+    }
+
+    @Test
+    void requiredMissing_throwsNamingSite() throws NoSuchFieldException {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> resolveField(RequiredMissingBean.class, "missing"));
+        assertTrue(ex.getMessage().contains(RequiredMissingBean.class.getName() + "#missing"));
+    }
+
+    @Test
+    void neitherValueNorConfig_throws() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> resolveField(NeitherBean.class, "x"));
+        assertTrue(ex.getMessage().contains("value() or config()"));
+    }
+
+    @Test
+    void configWithoutPath_throws() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> resolveField(ConfigNoPathBean.class, "x"));
+        assertTrue(ex.getMessage().contains("path()"));
+    }
+
+    @Test
+    void unsupportedType_throws() throws NoSuchFieldException {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> resolveField(UnsupportedTypeBean.class, "list"));
+        assertTrue(ex.getMessage().contains(UnsupportedTypeBean.class.getName() + "#list"));
+    }
+
+    @Test
+    void arrayType_throws() throws NoSuchFieldException {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> resolveField(ArrayTypeBean.class, "arr"));
+        assertTrue(ex.getMessage().contains("not supported"));
+    }
+
+    @Test
+    void unknownConfigClass_throws() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> resolveField(UnknownConfigBean.class, "x"));
+        assertTrue(ex.getMessage().contains(UnregisteredConfig.class.getName()));
+    }
+
+    @Test
+    void notInitialized_throws() throws IOException, NoSuchFieldException {
+        Files.writeString(tempDir.resolve("late.yml"), "name: x\n");
+        BungeeConfigManager notInit = new BungeeConfigManager(plugin);
+        notInit.register(LateConfig.class); // registered but NOT initialized
+        ConfigValueResolver lateResolver = new ConfigValueResolver(notInit);
+
+        ConfigException ex = assertThrows(ConfigException.class, () -> lateResolver.resolve(
+                InjectionPoint.fromField(LateBean.class.getDeclaredField("name"))));
+        assertTrue(ex.getMessage().contains("not initialized"));
+    }
+
+    @Test
+    void barePathWithMultipleConfigs_throwsNamingSite() throws IOException, NoSuchFieldException {
+        Files.writeString(tempDir.resolve("a.yml"), "k: 1\n");
+        Files.writeString(tempDir.resolve("b.yml"), "k: 2\n");
+        BungeeConfigManager multi = new BungeeConfigManager(plugin);
+        multi.register(AConfig.class);
+        multi.register(BConfig.class);
+        multi.initializeAll();
+        ConfigValueResolver multiResolver = new ConfigValueResolver(multi);
+
+        ConfigException ex = assertThrows(ConfigException.class, () -> multiResolver.resolve(
+                InjectionPoint.fromField(BarePathBean.class.getDeclaredField("k"))));
+        assertTrue(ex.getMessage().contains("Ambiguous"));
+        assertTrue(ex.getMessage().contains(BarePathBean.class.getName()));
+    }
+
+    // ---- fixtures ----
+
+    @Config(value = "app.yml", name = "app", generateDefaults = false)
+    public static class AppConfig {
+        private String name;
+        private int port;
+        private boolean enabled;
+        private double ratio;
+        public AppConfig() {}
+    }
+
+    @Config(value = "late.yml", name = "late", generateDefaults = false)
+    public static class LateConfig {
+        private String name;
+        public LateConfig() {}
+    }
+
+    @Config(value = "unregistered.yml", name = "unregistered", generateDefaults = false)
+    public static class UnregisteredConfig {
+        private String name;
+        public UnregisteredConfig() {}
+    }
+
+    @Config(value = "a.yml", name = "a", generateDefaults = false)
+    public static class AConfig {
+        private int k;
+        public AConfig() {}
+    }
+
+    @Config(value = "b.yml", name = "b", generateDefaults = false)
+    public static class BConfig {
+        private int k;
+        public BConfig() {}
+    }
+
+    static class ValueModeBean {
+        @ConfigValue("app:name") String name;
+        @ConfigValue("app:port") int port;
+        @ConfigValue("app:enabled") boolean enabled;
+        @ConfigValue("app:ratio") double ratio;
+    }
+
+    static class ConfigModeBean {
+        @ConfigValue(config = AppConfig.class, path = "name") String name;
+    }
+
+    static class DefaultBean {
+        @ConfigValue(value = "app:missing", defaultValue = "fallback") String missing;
+        @ConfigValue(value = "app:missingNum", defaultValue = "7") int missingNum;
+        @ConfigValue(value = "app:emptyDefault", defaultValue = "") String emptyDefault;
+    }
+
+    static class RequiredMissingBean {
+        @ConfigValue("app:missing") String missing;
+    }
+
+    static class NeitherBean {
+        @ConfigValue String x;
+    }
+
+    static class ConfigNoPathBean {
+        @ConfigValue(config = AppConfig.class) String x;
+    }
+
+    static class UnsupportedTypeBean {
+        @ConfigValue("app:name") List<String> list;
+    }
+
+    static class ArrayTypeBean {
+        @ConfigValue("app:name") String[] arr;
+    }
+
+    static class UnknownConfigBean {
+        @ConfigValue(config = UnregisteredConfig.class, path = "name") String x;
+    }
+
+    static class LateBean {
+        @ConfigValue("late:name") String name;
+    }
+
+    static class BarePathBean {
+        @ConfigValue("k") int k;
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/loader/YamlConfigLoaderTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/loader/YamlConfigLoaderTest.java
@@ -1,0 +1,218 @@
+package tech.guilhermekaua.spigotboot.config.bungee.test.loader;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import tech.guilhermekaua.spigotboot.config.loader.ConfigSource;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.loader.YamlConfigLoader;
+import tech.guilhermekaua.spigotboot.config.bungee.node.YamlConfigNode;
+import tech.guilhermekaua.spigotboot.core.validation.PropertyPath;
+
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class YamlConfigLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private YamlConfigLoader loader;
+
+    @BeforeEach
+    void setUp() {
+        loader = new YamlConfigLoader();
+    }
+
+    @Test
+    void save_scalarWithColon_roundTripsCorrectly() throws Exception {
+        String value = "host: localhost";
+        ConfigSource source = ConfigSource.file(tempDir.resolve("colon.yml"));
+
+        loader.save(new ScalarConfigNode(value), source);
+        ConfigNode loaded = loader.load(source);
+
+        assertEquals(value, loaded.raw());
+    }
+
+    @Test
+    void save_scalarWithHash_roundTripsCorrectly() throws Exception {
+        String value = "# this is not a comment";
+        ConfigSource source = ConfigSource.file(tempDir.resolve("hash.yml"));
+
+        loader.save(new ScalarConfigNode(value), source);
+        ConfigNode loaded = loader.load(source);
+
+        assertEquals(value, loaded.raw());
+    }
+
+    @Test
+    void save_scalarBooleanLikeString_roundTripsCorrectly() throws Exception {
+        String value = "yes";
+        ConfigSource source = ConfigSource.file(tempDir.resolve("bool.yml"));
+
+        loader.save(new ScalarConfigNode(value), source);
+        ConfigNode loaded = loader.load(source);
+
+        assertEquals(value, String.valueOf(loaded.raw()));
+    }
+
+    @Test
+    void save_scalarWithMidStringHash_roundTripsCorrectly() throws Exception {
+        String value = "foo #bar";
+        ConfigSource source = ConfigSource.file(tempDir.resolve("midhash.yml"));
+
+        loader.save(new ScalarConfigNode(value), source);
+        ConfigNode loaded = loader.load(source);
+
+        assertEquals(value, loaded.raw());
+    }
+
+    @Test
+    void save_plainScalar_roundTripsCorrectly() throws Exception {
+        String value = "hello world";
+        ConfigSource source = ConfigSource.file(tempDir.resolve("plain.yml"));
+
+        loader.save(new ScalarConfigNode(value), source);
+        ConfigNode loaded = loader.load(source);
+
+        assertEquals(value, loaded.raw());
+    }
+
+    @ParameterizedTest(name = "map value round-trip keeps scalar string: {0}")
+    @MethodSource("yamlSpecialScalarCases")
+    void save_yamlConfigNodeMapSpecialScalar_roundTripsAsString(String fileName, String value) throws Exception {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("value", value);
+
+        ConfigSource source = ConfigSource.file(tempDir.resolve(fileName + "-map.yml"));
+
+        loader.save(new YamlConfigNode(data), source);
+        ConfigNode loaded = loader.load(source);
+
+        Object loadedValue = loaded.node("value").raw();
+        assertEquals(value, loadedValue);
+        assertInstanceOf(String.class, loadedValue, "expected loaded map scalar to remain a string");
+    }
+
+    @ParameterizedTest(name = "list item round-trip keeps scalar string: {0}")
+    @MethodSource("yamlSpecialScalarCases")
+    void save_yamlConfigNodeListSpecialScalar_roundTripsAsString(String fileName, String value) throws Exception {
+        List<Object> items = new ArrayList<>();
+        items.add(value);
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("items", items);
+
+        ConfigSource source = ConfigSource.file(tempDir.resolve(fileName + "-list.yml"));
+
+        loader.save(new YamlConfigNode(data), source);
+        ConfigNode loaded = loader.load(source);
+
+        Object loadedValue = loaded.node("items").node(0).raw();
+        assertEquals(value, loadedValue);
+        assertInstanceOf(String.class, loadedValue, "expected loaded list item to remain a string");
+    }
+
+    private static Stream<Arguments> yamlSpecialScalarCases() {
+        return Stream.of(
+                Arguments.of("contains-inline-comment", "foo #bar"),
+                Arguments.of("ends-with-colon", "foo:"),
+                Arguments.of("ends-with-colon-space", "foo: "),
+                Arguments.of("leading-space", "  leading"),
+                Arguments.of("trailing-space", "trailing  "),
+                Arguments.of("flow-empty-list", "[]"),
+                Arguments.of("flow-empty-map", "{}"),
+                Arguments.of("comma-only", ",")
+        );
+    }
+
+    private static class ScalarConfigNode implements ConfigNode {
+        private final Object value;
+
+        ScalarConfigNode(@Nullable Object value) {
+            this.value = value;
+        }
+
+        @Override
+        public @Nullable Object raw() {
+            return value;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> @Nullable T get(@NotNull Class<T> type) {
+            return type.isInstance(value) ? (T) value : null;
+        }
+
+        @Override
+        public <T> @NotNull T get(@NotNull Class<T> type, @NotNull T defaultValue) {
+            T result = get(type);
+            return result != null ? result : defaultValue;
+        }
+
+        @Override
+        public @NotNull ConfigNode node(@NotNull Object... path) {
+            return this;
+        }
+
+        @Override
+        public @NotNull ConfigNode node(@NotNull PropertyPath path) {
+            return this;
+        }
+
+        @Override
+        public boolean hasChild(@NotNull Object... path) {
+            return false;
+        }
+
+        @Override
+        public @NotNull Map<String, ? extends ConfigNode> childrenMap() {
+            return Collections.emptyMap();
+        }
+
+        @Override
+        public @NotNull List<? extends ConfigNode> childrenList() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public boolean isMap() {
+            return false;
+        }
+
+        @Override
+        public boolean isList() {
+            return false;
+        }
+
+        @Override
+        public boolean isScalar() {
+            return value != null;
+        }
+
+        @Override
+        public boolean isNull() {
+            return value == null;
+        }
+
+        @Override
+        public boolean isVirtual() {
+            return false;
+        }
+
+        @Override
+        public @NotNull PropertyPath path() {
+            return PropertyPath.root();
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/manager/BungeeConfigManagerFolderItemTypesTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/manager/BungeeConfigManagerFolderItemTypesTest.java
@@ -1,0 +1,63 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.manager;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class BungeeConfigManagerFolderItemTypesTest {
+
+    @TempDir
+    Path tempDir;
+    @Mock
+    Plugin plugin;
+    private BungeeConfigManager configManager;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = Logger.getLogger(BungeeConfigManagerFolderItemTypesTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+        configManager = new BungeeConfigManager(plugin);
+    }
+
+    @Test
+    void getRegisteredFolderConfigItemTypes_emptyWhenNoneRegistered() {
+        Set<Class<?>> types = configManager.getRegisteredFolderConfigItemTypes();
+        assertTrue(types.isEmpty());
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/manager/BungeeConfigManagerTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/manager/BungeeConfigManagerTest.java
@@ -1,0 +1,310 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.manager;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfig;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class BungeeConfigManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private BungeeConfigManager configManager;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = Logger.getLogger(BungeeConfigManagerTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+        configManager = new BungeeConfigManager(plugin);
+    }
+
+    @Test
+    void get_WhenConfigIsNotRegistered_ThrowsConfigException() {
+        ConfigException exception = assertThrows(
+                ConfigException.class,
+                () -> configManager.get(TestConfig.class)
+        );
+
+        assertTrue(exception.getMessage().contains("Config not registered"));
+        assertTrue(exception.getMessage().contains(TestConfig.class.getName()));
+    }
+
+    @Test
+    void get_WhenConfigIsRegisteredButNotInitialized_ThrowsConfigException() {
+        configManager.register(TestConfig.class);
+
+        ConfigException exception = assertThrows(
+                ConfigException.class,
+                () -> configManager.get(TestConfig.class)
+        );
+
+        assertTrue(exception.getMessage().contains("Config not loaded"));
+        assertTrue(exception.getMessage().contains(TestConfig.class.getName()));
+    }
+
+    @Test
+    void get_WhenConfigIsInitialized_ReturnsInstance() {
+        configManager.register(TestConfig.class);
+        configManager.initializeAll();
+
+        TestConfig config = configManager.get(TestConfig.class);
+
+        assertNotNull(config);
+    }
+
+    @Test
+    void getByPath_WhenSingleConfigWithoutPrefix_ReturnsValue() throws IOException {
+        writeYaml("single.yml", "value: single\n");
+        configManager.register(SingleNamedConfig.class);
+
+        String value = configManager.get("value", String.class);
+
+        assertEquals("single", value);
+    }
+
+    @Test
+    void getByPath_WhenMultipleConfigsWithPrefix_ReturnsValueFromRequestedConfig() throws IOException {
+        writeYaml("main.yml", "value: main\n");
+        writeYaml("messages.yml", "value: messages\n");
+        configManager.register(MainNamedConfig.class);
+        configManager.register(MessagesNamedConfig.class);
+
+        String value = configManager.get("messages:value", String.class);
+
+        assertEquals("messages", value);
+    }
+
+    @Test
+    void getByPath_WhenMultipleConfigsWithoutPrefix_ThrowsAmbiguousLookupException() throws IOException {
+        writeYaml("main.yml", "value: main\n");
+        writeYaml("messages.yml", "value: messages\n");
+        configManager.register(MainNamedConfig.class);
+        configManager.register(MessagesNamedConfig.class);
+
+        RuntimeException exception = assertThrows(
+                RuntimeException.class,
+                () -> configManager.get("value", String.class)
+        );
+
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.toLowerCase().contains("ambiguous"));
+        assertTrue(message.contains("main"));
+        assertTrue(message.contains("messages"));
+    }
+
+    @Test
+    void register_WhenSameClassRegisteredTwice_ThrowsConfigException() {
+        configManager.register(TestConfig.class);
+
+        ConfigException exception = assertThrows(
+                ConfigException.class,
+                () -> configManager.register(TestConfig.class)
+        );
+
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains(TestConfig.class.getName()));
+
+        assertTrue(configManager.isRegistered(TestConfig.class));
+        assertEquals(1, configManager.getRegisteredConfigs().size());
+    }
+
+    @Test
+    void register_WhenDifferentClassesShareSameConfigName_ThrowsConfigExceptionAndKeepsOriginalMapping() throws IOException {
+        writeYaml("collision-one.yml", "value: one\n");
+        writeYaml("collision-two.yml", "value: two\n");
+
+        configManager.register(CollisionConfigOne.class);
+
+        ConfigException exception = assertThrows(
+                ConfigException.class,
+                () -> configManager.register(CollisionConfigTwo.class)
+        );
+
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("collision"));
+
+        assertTrue(configManager.isRegistered(CollisionConfigOne.class));
+        assertFalse(configManager.isRegistered(CollisionConfigTwo.class));
+        assertEquals(1, configManager.getRegisteredConfigs().size());
+
+        String value = configManager.get("collision:value", String.class);
+        assertEquals("one", value);
+    }
+
+    @Test
+    void registerFolderConfig_WhenSameTypeAndNameRegisteredTwice_ThrowsConfigExceptionAndKeepsOriginalEntry() {
+        FolderConfig annotation = DuplicateKeyFolderItem.class.getAnnotation(FolderConfig.class);
+        assertNotNull(annotation);
+
+        configManager.registerFolderConfig(DuplicateKeyFolderItem.class, annotation);
+
+        Object originalEntry = configManager.getFolderConfigEntry(DuplicateKeyFolderItem.class, "shared_key");
+        assertNotNull(originalEntry);
+
+        ConfigException exception = assertThrows(
+                ConfigException.class,
+                () -> configManager.registerFolderConfig(DuplicateKeyFolderItem.class, annotation)
+        );
+
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("shared_key"));
+        assertTrue(message.contains(DuplicateKeyFolderItem.class.getName()));
+
+        Object currentEntry = configManager.getFolderConfigEntry(DuplicateKeyFolderItem.class, "shared_key");
+        assertSame(originalEntry, currentEntry);
+        assertEquals(1, configManager.getFolderConfigNames(DuplicateKeyFolderItem.class).size());
+    }
+
+    @Test
+    void registerFolderConfig_WhenDifferentTypesShareSameName_ThrowsConfigExceptionAndKeepsOriginalEntry() {
+        FolderConfig firstAnnotation = SharedNameFolderItemOne.class.getAnnotation(FolderConfig.class);
+        FolderConfig secondAnnotation = SharedNameFolderItemTwo.class.getAnnotation(FolderConfig.class);
+        assertNotNull(firstAnnotation);
+        assertNotNull(secondAnnotation);
+
+        configManager.registerFolderConfig(SharedNameFolderItemOne.class, firstAnnotation);
+
+        var originalByName = configManager.getFolderConfigEntryByName("shared_name");
+        assertNotNull(originalByName);
+        assertEquals(SharedNameFolderItemOne.class, originalByName.getItemType());
+
+        ConfigException exception = assertThrows(
+                ConfigException.class,
+                () -> configManager.registerFolderConfig(SharedNameFolderItemTwo.class, secondAnnotation)
+        );
+
+        String message = exception.getMessage();
+        assertNotNull(message);
+        assertTrue(message.contains("shared_name"));
+        assertTrue(message.contains(SharedNameFolderItemOne.class.getName()));
+        assertTrue(message.contains(SharedNameFolderItemTwo.class.getName()));
+
+        var currentByName = configManager.getFolderConfigEntryByName("shared_name");
+        assertNotNull(currentByName);
+        assertEquals(SharedNameFolderItemOne.class, currentByName.getItemType());
+        assertNull(configManager.getFolderConfigEntry(SharedNameFolderItemTwo.class, "shared_name"));
+    }
+
+    private void writeYaml(String fileName, String content) throws IOException {
+        Files.writeString(tempDir.resolve(fileName), content);
+    }
+
+    @Config(value = "test-config.yml", generateDefaults = false)
+    public static class TestConfig {
+        private String name = "default-name";
+
+        public TestConfig() {
+        }
+    }
+
+    @Config(value = "single.yml", name = "single", generateDefaults = false)
+    public static class SingleNamedConfig {
+        private String value;
+
+        public SingleNamedConfig() {
+        }
+    }
+
+    @Config(value = "main.yml", name = "main", generateDefaults = false)
+    public static class MainNamedConfig {
+        private String value;
+
+        public MainNamedConfig() {
+        }
+    }
+
+    @Config(value = "messages.yml", name = "messages", generateDefaults = false)
+    public static class MessagesNamedConfig {
+        private String value;
+
+        public MessagesNamedConfig() {
+        }
+    }
+
+    @Config(value = "collision-one.yml", name = "collision", generateDefaults = false)
+    public static class CollisionConfigOne {
+        private String value;
+
+        public CollisionConfigOne() {
+        }
+    }
+
+    @Config(value = "collision-two.yml", name = "collision", generateDefaults = false)
+    public static class CollisionConfigTwo {
+        private String value;
+
+        public CollisionConfigTwo() {
+        }
+    }
+
+    @FolderConfig(name = "shared_key", folder = "shared-key-folder")
+    public static class DuplicateKeyFolderItem {
+        private String value;
+
+        public DuplicateKeyFolderItem() {
+        }
+    }
+
+    @FolderConfig(name = "shared_name", folder = "shared-name-folder-one")
+    public static class SharedNameFolderItemOne {
+        private String value;
+
+        public SharedNameFolderItemOne() {
+        }
+    }
+
+    @FolderConfig(name = "shared_name", folder = "shared-name-folder-two")
+    public static class SharedNameFolderItemTwo {
+        private String value;
+
+        public SharedNameFolderItemTwo() {
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/manager/BungeeConfigManagerValueAccessTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/manager/BungeeConfigManagerValueAccessTest.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.manager;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+class BungeeConfigManagerValueAccessTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private BungeeConfigManager configManager;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        Logger logger = Logger.getLogger(BungeeConfigManagerValueAccessTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+        configManager = new BungeeConfigManager(plugin);
+        Files.writeString(tempDir.resolve("app.yml"),
+                "name: hello\nport: 25565\nenabled: true\nratio: 1.5\n");
+        configManager.register(AppConfig.class);
+        configManager.initializeAll();
+    }
+
+    @Test
+    void getConfigName_returnsRegisteredName() {
+        assertEquals("app", configManager.getConfigName(AppConfig.class));
+    }
+
+    @Test
+    void getConfigName_whenUnregistered_throws() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> configManager.getConfigName(UnregisteredConfig.class));
+        assertTrue(ex.getMessage().contains(UnregisteredConfig.class.getName()));
+    }
+
+    @Test
+    void deserializeAt_readsScalarsOfEachType() {
+        assertEquals("hello", configManager.deserializeAt("app:name", String.class));
+        assertEquals(Integer.valueOf(25565), configManager.deserializeAt("app:port", Integer.class));
+        assertEquals(Integer.valueOf(25565), configManager.deserializeAt("app:port", int.class));
+        assertEquals(Boolean.TRUE, configManager.deserializeAt("app:enabled", Boolean.class));
+        assertEquals(Double.valueOf(1.5), configManager.deserializeAt("app:ratio", Double.class));
+    }
+
+    @Test
+    void deserializeAt_whenKeyAbsent_returnsNull() {
+        assertNull(configManager.deserializeAt("app:missing", String.class));
+    }
+
+    @Test
+    void deserializeAt_whenTypeUnsupported_throws() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> configManager.deserializeAt("app:name", List.class));
+        assertTrue(ex.getMessage().contains(List.class.getName()));
+    }
+
+    @Test
+    void coerceDefault_coercesToTargetType() {
+        assertEquals(Integer.valueOf(42), configManager.coerceDefault("42", Integer.class));
+        assertEquals("", configManager.coerceDefault("", String.class));
+    }
+
+    @Test
+    void coerceDefault_whenUnparseable_throws() {
+        assertThrows(ConfigException.class, () -> configManager.coerceDefault("abc", Integer.class));
+    }
+
+    @Config(value = "app.yml", name = "app", generateDefaults = false)
+    public static class AppConfig {
+        private String name;
+        private int port;
+        private boolean enabled;
+        private double ratio;
+
+        public AppConfig() {
+        }
+    }
+
+    @Config(value = "unregistered.yml", name = "unregistered", generateDefaults = false)
+    public static class UnregisteredConfig {
+        private String value;
+
+        public UnregisteredConfig() {
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/node/YamlConfigNodeTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/node/YamlConfigNodeTest.java
@@ -1,0 +1,118 @@
+package tech.guilhermekaua.spigotboot.config.bungee.test.node;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.config.node.MutableConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.node.YamlConfigNode;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class YamlConfigNodeTest {
+
+    @Test
+    void remove_fromMapParent_removesEntryFromParent() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("a", "val_a");
+        data.put("b", "val_b");
+        YamlConfigNode root = new YamlConfigNode(data);
+
+        MutableConfigNode child = root.node("a");
+        assertFalse(child.isVirtual());
+        assertEquals("val_a", child.raw());
+
+        child.remove();
+
+        assertTrue(child.isVirtual(), "removed node should be virtual");
+        assertNull(child.raw(), "removed node value should be null");
+        assertFalse(root.childrenMap().containsKey("a"), "parent map should no longer contain removed key");
+        assertTrue(root.node("a").isVirtual(), "re-accessing removed key should return a virtual node");
+        assertEquals(1, root.childrenMap().size(), "parent map should have one remaining entry");
+    }
+
+    @Test
+    void remove_fromListParent_removesElementFromParent() {
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("first");
+        list.add("second");
+        list.add("third");
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("items", list);
+        YamlConfigNode root = new YamlConfigNode(data);
+
+        MutableConfigNode listNode = root.node("items");
+        assertEquals(3, listNode.childrenList().size());
+
+        MutableConfigNode child = listNode.node(1);
+        assertFalse(child.isVirtual());
+        assertEquals("second", child.raw());
+
+        child.remove();
+
+        assertTrue(child.isVirtual(), "removed node should be virtual");
+        assertNull(child.raw(), "removed node value should be null");
+        assertEquals(2, listNode.childrenList().size(), "parent list should have one fewer element after removal");
+    }
+
+    @Test
+    void appendListItem_onVirtualNode_listVisibleFromRoot() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        YamlConfigNode root = new YamlConfigNode(data);
+
+        MutableConfigNode listNode = root.node("items");
+        assertTrue(listNode.isVirtual(), "node should start as virtual");
+
+        MutableConfigNode item = listNode.appendListItem();
+        item.set("hello");
+
+        MutableConfigNode refetched = root.node("items");
+        assertTrue(refetched.isList(), "re-navigated node should be a list");
+        List<?> children = refetched.childrenList();
+        assertEquals(1, children.size(), "list should contain one element");
+        assertEquals("hello", refetched.node(0).raw(), "element should be the value we set");
+    }
+
+    @Test
+    void appendListItem_onScalarNode_listVisibleFromRoot() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("key", "scalar");
+        YamlConfigNode root = new YamlConfigNode(data);
+
+        MutableConfigNode scalarNode = root.node("key");
+        assertTrue(scalarNode.isScalar(), "node should start as scalar");
+
+        MutableConfigNode item = scalarNode.appendListItem();
+        item.set("replaced");
+
+        MutableConfigNode refetched = root.node("key");
+        assertTrue(refetched.isList(), "re-navigated node should now be a list, not a scalar");
+        assertEquals(1, refetched.childrenList().size(), "list should contain one element");
+        assertEquals("replaced", refetched.node(0).raw());
+    }
+
+    @Test
+    void appendListItem_onExistingList_itemVisibleFromRoot() {
+        ArrayList<Object> list = new ArrayList<>();
+        list.add("existing");
+
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("items", list);
+        YamlConfigNode root = new YamlConfigNode(data);
+
+        MutableConfigNode listNode = root.node("items");
+        assertTrue(listNode.isList(), "node should already be a list");
+
+        MutableConfigNode item = listNode.appendListItem();
+        item.set("appended");
+
+        MutableConfigNode refetched = root.node("items");
+        assertTrue(refetched.isList(), "re-navigated node should still be a list");
+        assertEquals(2, refetched.childrenList().size(), "list should now have two elements");
+        assertEquals("existing", refetched.node(0).raw());
+        assertEquals("appended", refetched.node(1).raw());
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/proxy/ConfigProxyTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/proxy/ConfigProxyTest.java
@@ -1,0 +1,187 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.proxy;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.bungee.proxy.ConfigProxy;
+
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConfigProxyTest {
+
+    @Test
+    void toString_WithDefaultObjectMethod_IsIntercepted() {
+        TestConfig proxy = createProxy();
+
+        assertEquals(
+                "ConfigProxy[TestConfig]@" + Integer.toHexString(System.identityHashCode(proxy)),
+                proxy.toString()
+        );
+    }
+
+    @Test
+    void hashCode_WithDefaultObjectMethod_IsIntercepted() {
+        TestConfig proxy = createProxy();
+
+        assertEquals(System.identityHashCode(proxy), proxy.hashCode());
+    }
+
+    @Test
+    void equals_WithSameInstance_ReturnsTrue() {
+        TestConfig proxy = createProxy();
+
+        assertEquals(proxy, proxy, "proxy equality must be reflexive");
+    }
+
+    @Test
+    void equals_WithNull_ReturnsFalse() {
+        TestConfig proxy = createProxy();
+
+        assertNotEquals(null, proxy);
+    }
+
+    @Test
+    void equals_WithNonProxyObject_ReturnsFalse() {
+        TestConfig proxy = createProxy();
+
+        assertNotEquals(new Object(), proxy);
+    }
+
+    @Test
+    void equals_WithDifferentProxyInstance_ReturnsFalse() {
+        TestConfig first = createProxy();
+        TestConfig second = createProxy();
+
+        assertNotEquals(first, second);
+        assertNotEquals(second, first);
+    }
+
+    @Test
+    void toString_WithOverride_DelegatesToCurrentConfig() {
+        OverriddenObjectMethodsConfig proxy = createProxy(
+                OverriddenObjectMethodsConfig.class,
+                new OverriddenObjectMethodsConfig()
+        );
+
+        assertEquals(OverriddenObjectMethodsConfig.TO_STRING_RESULT, proxy.toString());
+    }
+
+    @Test
+    void hashCode_WithOverride_DelegatesToCurrentConfig() {
+        OverriddenObjectMethodsConfig proxy = createProxy(
+                OverriddenObjectMethodsConfig.class,
+                new OverriddenObjectMethodsConfig()
+        );
+
+        assertEquals(OverriddenObjectMethodsConfig.HASH_CODE_RESULT, proxy.hashCode());
+    }
+
+    @Test
+    void equals_WithOverride_DelegatesToCurrentConfig() {
+        OverriddenObjectMethodsConfig proxy = createProxy(
+                OverriddenObjectMethodsConfig.class,
+                new OverriddenObjectMethodsConfig()
+        );
+
+        assertTrue(proxy.equals(OverriddenObjectMethodsConfig.EQUALS_MATCH_VALUE));
+    }
+
+    private @NotNull TestConfig createProxy() {
+        return createProxy(TestConfig.class, new TestConfig());
+    }
+
+    private <T> @NotNull T createProxy(Class<T> configClass, T instance) {
+        return ConfigProxy.createProxy(configClass, new StubConfigRef<>(configClass, instance));
+    }
+
+    static class TestConfig {
+        public TestConfig() {
+        }
+    }
+
+    public static class OverriddenObjectMethodsConfig {
+        static final String TO_STRING_RESULT = "overridden-to-string";
+        static final int HASH_CODE_RESULT = 1337;
+        static final String EQUALS_MATCH_VALUE = "magic-equals";
+
+        public OverriddenObjectMethodsConfig() {
+        }
+
+        @Override
+        public String toString() {
+            return TO_STRING_RESULT;
+        }
+
+        @Override
+        public int hashCode() {
+            return HASH_CODE_RESULT;
+        }
+
+        @SuppressWarnings("EqualsDoesntCheckParameterClass")
+        @Override
+        public boolean equals(Object obj) {
+            return EQUALS_MATCH_VALUE.equals(obj);
+        }
+    }
+
+    static final class StubConfigRef<T> implements ConfigRef<T> {
+        private final Class<T> configClass;
+        private final T instance;
+
+        StubConfigRef(Class<T> configClass, T instance) {
+            this.configClass = configClass;
+            this.instance = instance;
+        }
+
+        @Override
+        public @NotNull T get() {
+            return instance;
+        }
+
+        @Override
+        public void addListener(@NotNull Consumer<T> listener) {
+        }
+
+        @Override
+        public void removeListener(@NotNull Consumer<T> listener) {
+        }
+
+        @Override
+        public boolean isLoaded() {
+            return true;
+        }
+
+        @Override
+        public void reload() {
+        }
+
+        @Override
+        public @NotNull Class<T> getConfigClass() {
+            return configClass;
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reference/ReferenceResolvingPreprocessorTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reference/ReferenceResolvingPreprocessorTest.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.reference;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.node.ConfigNode;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceErrorHandler;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceLookup;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceParser;
+import tech.guilhermekaua.spigotboot.config.reference.ConfigReferenceResolver;
+import tech.guilhermekaua.spigotboot.config.reference.context.ConfigTypeMismatchContext;
+import tech.guilhermekaua.spigotboot.config.reference.key.ReferenceKey;
+import tech.guilhermekaua.spigotboot.config.bungee.node.YamlConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.reference.ReferenceResolvingPreprocessor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ReferenceResolvingPreprocessor")
+class ReferenceResolvingPreprocessorTest {
+
+    @Mock
+    private ConfigReferenceLookup lookup;
+
+    @Mock
+    private ConfigReferenceErrorHandler errorHandler;
+
+    @Test
+    @DisplayName("passes the expected type to the resolver so onTypeMismatch fires")
+    void firesTypeMismatchWhenResolvedValueIncompatibleWithExpectedType() {
+        when(lookup.resolve(any())).thenReturn(new YamlConfigNode("not a number"));
+
+        ConfigReferenceResolver resolver = new ConfigReferenceResolver(lookup, new ConfigReferenceParser(), errorHandler);
+        ReferenceResolvingPreprocessor preprocessor = new ReferenceResolvingPreprocessor(resolver);
+        preprocessor.setCurrentSourceKey(ReferenceKey.singleConfig("source"));
+
+        try {
+            ConfigNode input = new YamlConfigNode("${label}");
+            preprocessor.preprocess(input, null, Integer.class);
+        } finally {
+            preprocessor.clearCurrentSourceKey();
+        }
+
+        ArgumentCaptor<ConfigTypeMismatchContext> captor = ArgumentCaptor.forClass(ConfigTypeMismatchContext.class);
+        verify(errorHandler).onTypeMismatch(captor.capture());
+        assertEquals("${label}", captor.getValue().getFullReference());
+        assertEquals(Integer.class, captor.getValue().getExpectedType());
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/registry/ConfigRegistryTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/registry/ConfigRegistryTest.java
@@ -1,0 +1,422 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.registry;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.ConfigManager;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.annotation.ConfigValue;
+import tech.guilhermekaua.spigotboot.config.annotation.FolderConfig;
+import tech.guilhermekaua.spigotboot.config.annotation.OnConfigReload;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.registry.ConfigRegistry;
+import tech.guilhermekaua.spigotboot.core.context.Context;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Primary;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Qualifier;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.lang.reflect.Modifier;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class ConfigRegistryTest {
+
+    private ConfigRegistry configRegistry;
+    private DependencyManager dependencyManager;
+
+    @Mock
+    private Context context;
+
+    @Mock
+    private ConfigManager configManager;
+
+    @BeforeEach
+    void setUp() {
+        configRegistry = new ConfigRegistry();
+        dependencyManager = new DependencyManager();
+
+        lenient().when(context.getBean(ConfigManager.class)).thenReturn(configManager);
+        lenient().when(context.getDependencyManager()).thenReturn(dependencyManager);
+    }
+
+    @Config("valid-config.yml")
+    public static class ValidConfig {
+        private String name;
+        private int value;
+
+        public ValidConfig() {
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    @Config("invalid-config.yml")
+    public static class InvalidConfigWithPublicField {
+        public String publicField;
+        private String privateField;
+    }
+
+    @Config("invalid-config2.yml")
+    public static class InvalidConfigWithProtectedField {
+        protected String protectedField;
+    }
+
+    @Config("invalid-config3.yml")
+    public static class InvalidConfigWithPackagePrivateField {
+        String packagePrivateField;
+    }
+
+    @Config("nested-config.yml")
+    public static class NestedConfig {
+        private NestedSection section;
+
+        public NestedConfig() {
+        }
+
+        public NestedSection getSection() {
+            return section;
+        }
+
+        public static class NestedSection {
+            private String value;
+
+            public String getValue() {
+                return value;
+            }
+        }
+    }
+
+    @Config("qualified-config.yml")
+    @Qualifier("qualified")
+    public static class QualifiedConfig {
+        private String data;
+
+        public QualifiedConfig() {
+        }
+
+        public String getData() {
+            return data;
+        }
+    }
+
+    @Config("primary-config.yml")
+    @Primary
+    public static class PrimaryConfig {
+        private String data;
+
+        public PrimaryConfig() {
+        }
+
+        public String getData() {
+            return data;
+        }
+    }
+
+    @Config("empty-config.yml")
+    public static class EmptyConfig {
+        public EmptyConfig() {
+        }
+    }
+
+    @Config("config-with-configvalue.yml")
+    public static class ConfigWithConfigValueField {
+        @ConfigValue("other:x")
+        private String injected;
+
+        public ConfigWithConfigValueField() {
+        }
+    }
+
+    @FolderConfig(name = "items_with_configvalue", folder = "items-with-configvalue")
+    public static class FolderItemWithConfigValueField {
+        @ConfigValue("other:x")
+        private String injected;
+
+        public FolderItemWithConfigValueField() {
+        }
+    }
+
+    public static class BaseConfigWithConfigValueField {
+        @ConfigValue("other:x")
+        private String inheritedInjected;
+    }
+
+    @Config("config-inherited-configvalue.yml")
+    public static class ConfigExtendingConfigValueBase extends BaseConfigWithConfigValueField {
+        private String own;
+
+        public ConfigExtendingConfigValueBase() {
+        }
+    }
+
+    @Config("config-with-configvalue-ctor.yml")
+    public static class ConfigWithConfigValueCtorParam {
+        private final String x;
+
+        public ConfigWithConfigValueCtorParam(@ConfigValue("other:x") String x) {
+            this.x = x;
+        }
+    }
+
+    static class MockConfigRef<T> implements ConfigRef<T> {
+        private final Class<T> configClass;
+        private T instance;
+
+        @SuppressWarnings("unchecked")
+        MockConfigRef(Class<T> configClass) {
+            this.configClass = configClass;
+            try {
+                this.instance = configClass.getDeclaredConstructor().newInstance();
+            } catch (Exception e) {
+                this.instance = null;
+            }
+        }
+
+        @Override
+        public @NotNull T get() {
+            return instance;
+        }
+
+        @Override
+        public void addListener(@NotNull Consumer<T> listener) {
+        }
+
+        @Override
+        public void removeListener(@NotNull Consumer<T> listener) {
+        }
+
+        @Override
+        public boolean isLoaded() {
+            return true;
+        }
+
+        @Override
+        public void reload() {
+        }
+
+        @Override
+        public @NotNull Class<T> getConfigClass() {
+            return configClass;
+        }
+    }
+
+    @Test
+    void testProcessConfigClass_WithValidConfig() {
+        ConfigRef<ValidConfig> configRef = new MockConfigRef<>(ValidConfig.class);
+        when(configManager.getRef(ValidConfig.class)).thenReturn(configRef);
+
+        assertDoesNotThrow(() -> configRegistry.processConfigClass(ValidConfig.class, context, configManager));
+
+        verify(configManager).register(ValidConfig.class);
+        verify(configManager).getRef(ValidConfig.class);
+
+        ValidConfig resolved = dependencyManager.resolveDependency(ValidConfig.class, null);
+        assertNotNull(resolved);
+    }
+
+    @Test
+    void testProcessConfigClass_WithQualifiedConfig() {
+        ConfigRef<QualifiedConfig> configRef = new MockConfigRef<>(QualifiedConfig.class);
+        when(configManager.getRef(QualifiedConfig.class)).thenReturn(configRef);
+
+        assertDoesNotThrow(() -> configRegistry.processConfigClass(QualifiedConfig.class, context, configManager));
+
+        QualifiedConfig resolved = dependencyManager.resolveDependency(QualifiedConfig.class, "qualified");
+        assertNotNull(resolved);
+    }
+
+    @Test
+    void testProcessConfigClass_WithPrimaryConfig() {
+        ConfigRef<PrimaryConfig> configRef = new MockConfigRef<>(PrimaryConfig.class);
+        when(configManager.getRef(PrimaryConfig.class)).thenReturn(configRef);
+
+        assertDoesNotThrow(() -> configRegistry.processConfigClass(PrimaryConfig.class, context, configManager));
+
+        PrimaryConfig resolved = dependencyManager.resolveDependency(PrimaryConfig.class, null);
+        assertNotNull(resolved);
+    }
+
+    @Test
+    void testProcessConfigClass_WithEmptyConfig() {
+        ConfigRef<EmptyConfig> configRef = new MockConfigRef<>(EmptyConfig.class);
+        when(configManager.getRef(EmptyConfig.class)).thenReturn(configRef);
+
+        assertDoesNotThrow(() -> configRegistry.processConfigClass(EmptyConfig.class, context, configManager));
+
+        verify(configManager).register(EmptyConfig.class);
+
+        EmptyConfig resolved = dependencyManager.resolveDependency(EmptyConfig.class, null);
+        assertNotNull(resolved);
+    }
+
+    @Test
+    void testValidateConfigClass_WithPublicField_ThrowsException() {
+        ConfigException exception = assertThrows(ConfigException.class, () ->
+                configRegistry.processConfigClass(InvalidConfigWithPublicField.class, context, configManager)
+        );
+
+        assertTrue(exception.getMessage().contains("non-private field"));
+        assertTrue(exception.getMessage().contains("publicField"));
+        assertTrue(exception.getMessage().contains("reload safety"));
+    }
+
+    @Test
+    void testValidateConfigClass_WithProtectedField_ThrowsException() {
+        ConfigException exception = assertThrows(ConfigException.class, () ->
+                configRegistry.processConfigClass(InvalidConfigWithProtectedField.class, context, configManager)
+        );
+
+        assertTrue(exception.getMessage().contains("non-private field"));
+        assertTrue(exception.getMessage().contains("protectedField"));
+    }
+
+    @Test
+    void testValidateConfigClass_WithPackagePrivateField_ThrowsException() {
+        ConfigException exception = assertThrows(ConfigException.class, () ->
+                configRegistry.processConfigClass(InvalidConfigWithPackagePrivateField.class, context, configManager)
+        );
+
+        assertTrue(exception.getMessage().contains("non-private field"));
+        assertTrue(exception.getMessage().contains("packagePrivateField"));
+    }
+
+    @Test
+    void testProcessConfigClass_WithNestedConfig() {
+        ConfigRef<NestedConfig> configRef = new MockConfigRef<>(NestedConfig.class);
+        when(configManager.getRef(NestedConfig.class)).thenReturn(configRef);
+
+        assertDoesNotThrow(() -> configRegistry.processConfigClass(NestedConfig.class, context, configManager));
+
+        verify(configManager).register(NestedConfig.class);
+
+        NestedConfig resolved = dependencyManager.resolveDependency(NestedConfig.class, null);
+        assertNotNull(resolved);
+    }
+
+    @Test
+    void testProcessConfigClass_WhenConfigManagerThrows_PropagatesException() {
+        doThrow(new ConfigException("Config loading failed")).when(configManager).register(ValidConfig.class);
+
+        assertThrows(ConfigException.class, () ->
+                configRegistry.processConfigClass(ValidConfig.class, context, configManager)
+        );
+    }
+
+    @Test
+    void testProcessConfigClass_ConfigExceptionNotWrapped() {
+        ConfigException originalException = new ConfigException("Original error");
+        doThrow(originalException).when(configManager).register(ValidConfig.class);
+
+        ConfigException thrownException = assertThrows(ConfigException.class, () ->
+                configRegistry.processConfigClass(ValidConfig.class, context, configManager)
+        );
+
+        assertSame(originalException, thrownException);
+    }
+
+    @Test
+    void testFieldModifierValidation() {
+        for (var field : InvalidConfigWithPublicField.class.getDeclaredFields()) {
+            if (field.getName().equals("publicField")) {
+                assertFalse(Modifier.isPrivate(field.getModifiers()));
+            }
+            if (field.getName().equals("privateField")) {
+                assertTrue(Modifier.isPrivate(field.getModifiers()));
+            }
+        }
+    }
+
+    @Test
+    void testConfigRegistryIsComponent() {
+        assertTrue(ConfigRegistry.class.isAnnotationPresent(Component.class));
+    }
+
+    @Config("reload-hook.yml")
+    static class ConfigWithReloadHook {
+        @OnConfigReload
+        void onReload() { }
+    }
+
+    @Test
+    void processConfigClass_rejectsOnConfigReloadOnConfigPojo() {
+        ConfigException exception = assertThrows(
+                ConfigException.class,
+                () -> configRegistry.processConfigClass(ConfigWithReloadHook.class, context, configManager)
+        );
+        assertTrue(exception.getMessage().contains("@OnConfigReload"));
+    }
+
+    @Test
+    void processConfigClass_whenConfigValueField_throwsConfigException() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> configRegistry.processConfigClass(ConfigWithConfigValueField.class, context, configManager));
+        assertTrue(ex.getMessage().contains("@ConfigValue"));
+        assertTrue(ex.getMessage().contains("injected"));
+    }
+
+    @Test
+    void processFolderConfigClass_whenConfigValueField_throwsConfigException() {
+        BungeeConfigManager bungeeConfigManager = mock(BungeeConfigManager.class);
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> configRegistry.processFolderConfigClass(
+                        FolderItemWithConfigValueField.class,
+                        bungeeConfigManager,
+                        Logger.getLogger(ConfigRegistryTest.class.getName())));
+        assertTrue(ex.getMessage().contains("@ConfigValue"));
+        assertTrue(ex.getMessage().contains("injected"));
+    }
+
+    @Test
+    void processConfigClass_whenInheritedConfigValueField_throwsConfigException() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> configRegistry.processConfigClass(ConfigExtendingConfigValueBase.class, context, configManager));
+        assertTrue(ex.getMessage().contains("@ConfigValue"));
+        assertTrue(ex.getMessage().contains("inheritedInjected"));
+    }
+
+    @Test
+    void processConfigClass_whenConfigValueConstructorParam_throwsConfigException() {
+        ConfigException ex = assertThrows(ConfigException.class,
+                () -> configRegistry.processConfigClass(ConfigWithConfigValueCtorParam.class, context, configManager));
+        assertTrue(ex.getMessage().contains("@ConfigValue"));
+        assertTrue(ex.getMessage().contains("constructor parameter"));
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadBinderTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadBinderTest.java
@@ -1,0 +1,236 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.reload;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import tech.guilhermekaua.spigotboot.config.annotation.OnConfigReload;
+import tech.guilhermekaua.spigotboot.config.exception.ConfigException;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigChangeListener;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigItemChange;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigRef;
+import tech.guilhermekaua.spigotboot.config.folder.FolderConfigSnapshot;
+import tech.guilhermekaua.spigotboot.config.folder.ItemChangeType;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadBinder;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadInvoker;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class OnConfigReloadBinderTest {
+
+    // ---- fixtures ----
+    static class MainConfig { }
+    static class Mob { }
+
+    static class SimpleBean {
+        Object received = "unset";
+        int noArgCount = 0;
+
+        @OnConfigReload(MainConfig.class)
+        void onReloadNoArg() { noArgCount++; }
+
+        @OnConfigReload
+        void onReloadWithArg(MainConfig cfg) { received = cfg; }
+    }
+
+    static class FolderBean {
+        FolderConfigItemChange<Mob> change;
+        FolderConfigSnapshot<Mob> snapshot;
+
+        @OnConfigReload
+        void onChange(FolderConfigItemChange<Mob> change) { this.change = change; }
+
+        @OnConfigReload
+        void onSnapshot(FolderConfigSnapshot<Mob> snapshot) { this.snapshot = snapshot; }
+    }
+
+    static class BadBean {
+        @OnConfigReload
+        void twoParams(MainConfig a, MainConfig b) { }
+
+        @OnConfigReload
+        String nonVoid() { return ""; }
+
+        @OnConfigReload(MainConfig.class)
+        void folderPayloadOnSimpleTarget(FolderConfigItemChange<Mob> change) { }
+
+        @OnConfigReload(Mob.class)
+        void simplePayloadOnFolderTarget(Mob mob) { }
+
+        @OnConfigReload(String.class)
+        void unregisteredTarget() { }
+
+        @OnConfigReload(MainConfig.class)
+        static void staticHook() { }
+    }
+
+    private BungeeConfigManager cm;
+    private OnConfigReloadBinder binder;
+
+    @BeforeEach
+    void setUp() {
+        cm = mock(BungeeConfigManager.class);
+        when(cm.getRegisteredConfigs()).thenReturn(Set.<Class<?>>of(MainConfig.class));
+        when(cm.getRegisteredFolderConfigItemTypes()).thenReturn(Set.<Class<?>>of(Mob.class));
+        when(cm.getFolderConfigNames(Mob.class)).thenReturn(Set.of("mobs"));
+        binder = new OnConfigReloadBinder(cm, new OnConfigReloadInvoker(Logger.getLogger("test")));
+    }
+
+    private static Method method(Class<?> type, String name, Class<?>... params) throws Exception {
+        return type.getDeclaredMethod(name, params);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void simpleInstanceMethodReceivesNewValue() throws Exception {
+        ConfigRef<MainConfig> ref = mock(ConfigRef.class);
+        when(cm.getRef(MainConfig.class)).thenReturn(ref);
+
+        SimpleBean bean = new SimpleBean();
+        binder.bind(bean, method(SimpleBean.class, "onReloadWithArg", MainConfig.class));
+
+        ArgumentCaptor<Consumer<MainConfig>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(ref).addListener(captor.capture());
+
+        MainConfig fresh = new MainConfig();
+        captor.getValue().accept(fresh);
+        assertSame(fresh, bean.received);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void simpleNoArgMethodFiresOnReload() throws Exception {
+        ConfigRef<MainConfig> ref = mock(ConfigRef.class);
+        when(cm.getRef(MainConfig.class)).thenReturn(ref);
+
+        SimpleBean bean = new SimpleBean();
+        binder.bind(bean, method(SimpleBean.class, "onReloadNoArg"));
+
+        ArgumentCaptor<Consumer<MainConfig>> captor = ArgumentCaptor.forClass(Consumer.class);
+        verify(ref).addListener(captor.capture());
+        captor.getValue().accept(new MainConfig());
+        assertEquals(1, bean.noArgCount);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void folderChangeMethodReceivesChange() throws Exception {
+        FolderConfigRef<Mob> ref = mock(FolderConfigRef.class);
+        when(cm.getFolderConfigRef(Mob.class, "mobs")).thenReturn(ref);
+
+        FolderBean bean = new FolderBean();
+        binder.bind(bean, method(FolderBean.class, "onChange", FolderConfigItemChange.class));
+
+        ArgumentCaptor<FolderConfigChangeListener<Mob>> captor = ArgumentCaptor.forClass(FolderConfigChangeListener.class);
+        verify(ref).addListener(captor.capture());
+
+        FolderConfigItemChange<Mob> change = new FolderConfigItemChange<>(
+                "mobs", Mob.class, "zombie", ItemChangeType.MODIFIED, new Mob(), new Mob());
+        captor.getValue().onItemChange(change);
+        assertSame(change, bean.change);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void folderSnapshotMethodReceivesCurrentSnapshot() throws Exception {
+        FolderConfigRef<Mob> ref = mock(FolderConfigRef.class);
+        FolderConfigSnapshot<Mob> snapshot = mock(FolderConfigSnapshot.class);
+        when(cm.getFolderConfigRef(Mob.class, "mobs")).thenReturn(ref);
+        when(ref.get()).thenReturn(snapshot);
+
+        FolderBean bean = new FolderBean();
+        binder.bind(bean, method(FolderBean.class, "onSnapshot", FolderConfigSnapshot.class));
+
+        ArgumentCaptor<FolderConfigChangeListener<Mob>> captor = ArgumentCaptor.forClass(FolderConfigChangeListener.class);
+        verify(ref).addListener(captor.capture());
+
+        captor.getValue().onItemChange(new FolderConfigItemChange<>(
+                "mobs", Mob.class, "zombie", ItemChangeType.ADDED, null, new Mob()));
+        assertSame(snapshot, bean.snapshot);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void emptyValueZeroArgRegistersOnEverySimpleAndFolderConfig() throws Exception {
+        ConfigRef<MainConfig> simpleRef = mock(ConfigRef.class);
+        FolderConfigRef<Mob> folderRef = mock(FolderConfigRef.class);
+        when(cm.getRef(MainConfig.class)).thenReturn(simpleRef);
+        when(cm.getFolderConfigRef(Mob.class, "mobs")).thenReturn(folderRef);
+
+        class AnyBean {
+            @OnConfigReload
+            void onAny() { }
+        }
+
+        binder.bind(new AnyBean(), method(AnyBean.class, "onAny"));
+
+        verify(simpleRef).addListener(any());
+        verify(folderRef).addListener(any());
+    }
+
+    @Test
+    void rejectsTwoParameters() {
+        BadBean bean = new BadBean();
+        assertThrows(ConfigException.class,
+                () -> binder.bind(bean, method(BadBean.class, "twoParams", MainConfig.class, MainConfig.class)));
+    }
+
+    @Test
+    void rejectsNonVoid() {
+        assertThrows(ConfigException.class,
+                () -> binder.bind(new BadBean(), method(BadBean.class, "nonVoid")));
+    }
+
+    @Test
+    void rejectsFolderPayloadOnSimpleTarget() {
+        assertThrows(ConfigException.class,
+                () -> binder.bind(new BadBean(), method(BadBean.class, "folderPayloadOnSimpleTarget", FolderConfigItemChange.class)));
+    }
+
+    @Test
+    void rejectsSimplePayloadOnFolderTarget() {
+        assertThrows(ConfigException.class,
+                () -> binder.bind(new BadBean(), method(BadBean.class, "simplePayloadOnFolderTarget", Mob.class)));
+    }
+
+    @Test
+    void rejectsUnregisteredTarget() {
+        assertThrows(ConfigException.class,
+                () -> binder.bind(new BadBean(), method(BadBean.class, "unregisteredTarget")));
+    }
+
+    @Test
+    void rejectsStaticMethod() {
+        assertThrows(ConfigException.class,
+                () -> binder.bind(new BadBean(), method(BadBean.class, "staticHook")));
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadInvokerTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadInvokerTest.java
@@ -1,0 +1,77 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.reload;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadInvoker;
+
+import java.lang.reflect.Method;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OnConfigReloadInvokerTest {
+
+    static class Bean {
+        Object received = "unset";
+        boolean noArgCalled = false;
+
+        private void withArg(String value) {
+            this.received = value;
+        }
+
+        void noArg() {
+            this.noArgCalled = true;
+        }
+
+        void boom() {
+            throw new IllegalStateException("kaboom");
+        }
+    }
+
+    private final OnConfigReloadInvoker invoker = new OnConfigReloadInvoker(Logger.getLogger("test"));
+
+    @Test
+    void invokesPrivateMethodWithArg() throws Exception {
+        Bean bean = new Bean();
+        Method m = Bean.class.getDeclaredMethod("withArg", String.class);
+        invoker.invoke(bean, m, new Object[]{"hello"});
+        assertEquals("hello", bean.received);
+    }
+
+    @Test
+    void invokesNoArgMethod() throws Exception {
+        Bean bean = new Bean();
+        Method m = Bean.class.getDeclaredMethod("noArg");
+        invoker.invoke(bean, m, new Object[0]);
+        assertTrue(bean.noArgCalled);
+    }
+
+    @Test
+    void swallowsAndLogsCallbackException() throws Exception {
+        Bean bean = new Bean();
+        Method m = Bean.class.getDeclaredMethod("boom");
+        // must not propagate — a throwing callback cannot break the reload listener loop
+        assertDoesNotThrow(() -> invoker.invoke(bean, m, new Object[0]));
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadProcessorIntegrationTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadProcessorIntegrationTest.java
@@ -1,0 +1,163 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.reload;
+
+import net.md_5.bungee.api.plugin.Plugin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.guilhermekaua.spigotboot.config.annotation.Config;
+import tech.guilhermekaua.spigotboot.config.annotation.OnConfigReload;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadProcessor;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+/**
+ * End-to-end integration test for {@code @OnConfigReload} that exercises the real config machinery:
+ * a real {@link BungeeConfigManager} over a temp data folder, a real {@code @Config} fixture loaded
+ * from a YAML file, the real {@link OnConfigReloadProcessor} binding listeners, and a real
+ * {@link BungeeConfigManager#reload(Class)} dispatching to those listeners. Nothing about the config
+ * manager or its reload pipeline is mocked.
+ */
+@ExtendWith(MockitoExtension.class)
+class OnConfigReloadProcessorIntegrationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Mock
+    Plugin plugin;
+
+    private BungeeConfigManager configManager;
+    private OnConfigReloadProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = Logger.getLogger(OnConfigReloadProcessorIntegrationTest.class.getName());
+        lenient().when(plugin.getDataFolder()).thenReturn(tempDir.toFile());
+        lenient().when(plugin.getLogger()).thenReturn(logger);
+        configManager = new BungeeConfigManager(plugin);
+        processor = new OnConfigReloadProcessor(configManager, logger);
+    }
+
+    @Test
+    void reload_invokesConfigParamCallbackWithNewValue() throws IOException {
+        writeYaml("reload-config.yml", "message: initial\n");
+        configManager.register(ReloadConfig.class);
+        configManager.initializeAll();
+
+        // sanity: initial value bound from disk before any reload
+        assertEquals("initial", configManager.get(ReloadConfig.class).getMessage());
+
+        ConfigParamListener bean = new ConfigParamListener();
+        runProcessor(bean);
+
+        // real reload: overwrite the backing file with a new value, then reload the config
+        writeYaml("reload-config.yml", "message: reloaded\n");
+        configManager.reload(ReloadConfig.class);
+
+        ReloadConfig received = bean.received.get();
+        assertNotNull(received, "callback should have fired and received the reloaded config");
+        assertEquals("reloaded", received.getMessage(),
+                "callback must receive a config bound to the NEW on-disk value, not the old one");
+        // and the manager itself reflects the new value too
+        assertEquals("reloaded", configManager.get(ReloadConfig.class).getMessage());
+    }
+
+    @Test
+    void reload_invokesZeroArgCallback() throws IOException {
+        writeYaml("reload-config.yml", "message: initial\n");
+        configManager.register(ReloadConfig.class);
+        configManager.initializeAll();
+
+        ZeroArgListener bean = new ZeroArgListener();
+        runProcessor(bean);
+
+        assertFalse(bean.fired, "callback must not fire before a reload");
+        assertEquals(0, bean.count.get());
+
+        writeYaml("reload-config.yml", "message: reloaded\n");
+        configManager.reload(ReloadConfig.class);
+
+        assertTrue(bean.fired, "zero-arg callback should have fired on reload");
+        assertEquals(1, bean.count.get(), "callback should fire exactly once per reload");
+    }
+
+    private void runProcessor(Object bean) {
+        BeanDefinition definition = mock(BeanDefinition.class);
+        DependencyManager dependencyManager = mock(DependencyManager.class);
+        Object result = processor.postProcess(definition, bean, dependencyManager);
+        assertSame(bean, result, "processor must return the same bean instance");
+    }
+
+    private void writeYaml(String fileName, String content) throws IOException {
+        Files.writeString(tempDir.resolve(fileName), content);
+    }
+
+    @Config(value = "reload-config.yml", name = "reload", generateDefaults = false)
+    public static class ReloadConfig {
+        private String message = "default";
+
+        public ReloadConfig() {
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    static class ConfigParamListener {
+        final AtomicReference<ReloadConfig> received = new AtomicReference<>();
+
+        @OnConfigReload(ReloadConfig.class)
+        void onReload(ReloadConfig cfg) {
+            received.set(cfg);
+        }
+    }
+
+    static class ZeroArgListener {
+        volatile boolean fired = false;
+        final AtomicInteger count = new AtomicInteger();
+
+        @OnConfigReload(ReloadConfig.class)
+        void onReload() {
+            fired = true;
+            count.incrementAndGet();
+        }
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadProcessorTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/reload/OnConfigReloadProcessorTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.reload;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.config.annotation.OnConfigReload;
+import tech.guilhermekaua.spigotboot.config.reload.ConfigRef;
+import tech.guilhermekaua.spigotboot.config.bungee.BungeeConfigManager;
+import tech.guilhermekaua.spigotboot.config.bungee.reload.OnConfigReloadProcessor;
+import tech.guilhermekaua.spigotboot.core.context.dependency.BeanDefinition;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+
+import java.util.Set;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class OnConfigReloadProcessorTest {
+
+    static class MainConfig { }
+
+    static class Base {
+        // package-private so this exercises discovery of non-public *inherited* callbacks
+        @OnConfigReload(MainConfig.class)
+        void inherited() { }
+    }
+
+    static class Bean extends Base {
+        @OnConfigReload(MainConfig.class)
+        void own() { }
+    }
+
+    static class Plain { }
+
+    private BungeeConfigManager cm;
+    private OnConfigReloadProcessor processor;
+
+    @BeforeEach
+    void setUp() {
+        cm = mock(BungeeConfigManager.class);
+        when(cm.getRegisteredConfigs()).thenReturn(Set.<Class<?>>of(MainConfig.class));
+        when(cm.getRegisteredFolderConfigItemTypes()).thenReturn(Set.<Class<?>>of());
+        processor = new OnConfigReloadProcessor(cm, Logger.getLogger("test"));
+    }
+
+    @Test
+    void runsAfterProxyProcessor() {
+        assertTrue(processor.getOrder() > 0);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void registersListenersForOwnAndInheritedMethodsAndReturnsSameInstance() {
+        ConfigRef<MainConfig> ref = mock(ConfigRef.class);
+        when(cm.getRef(MainConfig.class)).thenReturn(ref);
+
+        Bean bean = new Bean();
+        BeanDefinition def = mock(BeanDefinition.class);
+        DependencyManager dm = mock(DependencyManager.class);
+
+        Object result = processor.postProcess(def, bean, dm);
+
+        assertSame(bean, result);
+        // one binding for own() + one for inherited() = 2 listeners on the same ref
+        verify(ref, times(2)).addListener(any());
+    }
+
+    @Test
+    void ignoresBeansWithoutAnnotatedMethods() {
+        Plain plain = new Plain();
+        Object result = processor.postProcess(mock(BeanDefinition.class), plain, mock(DependencyManager.class));
+        assertSame(plain, result);
+        verify(cm, never()).getRef(any());
+    }
+
+    static class OverrideBase {
+        @OnConfigReload(MainConfig.class)
+        void hook() { }
+    }
+
+    static class OverrideChild extends OverrideBase {
+        @Override
+        @OnConfigReload(MainConfig.class)
+        void hook() { }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void overriddenReannotatedMethodRegistersExactlyOnce() {
+        ConfigRef<MainConfig> ref = mock(ConfigRef.class);
+        when(cm.getRef(MainConfig.class)).thenReturn(ref);
+
+        processor.postProcess(mock(BeanDefinition.class), new OverrideChild(), mock(DependencyManager.class));
+
+        // hook() is annotated on both the override and the superclass; it must bind only once
+        verify(ref, times(1)).addListener(any());
+    }
+}

--- a/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/serialization/DurationSerializerTest.java
+++ b/platform-bungee/config-bungee/src/test/java/tech/guilhermekaua/spigotboot/config/bungee/test/serialization/DurationSerializerTest.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.config.bungee.test.serialization;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.config.exception.SerializationException;
+import tech.guilhermekaua.spigotboot.config.bungee.node.YamlConfigNode;
+import tech.guilhermekaua.spigotboot.config.bungee.serialization.DurationSerializer;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DurationSerializerTest {
+
+    private final DurationSerializer serializer = new DurationSerializer();
+
+    @Test
+    void deserializesHumanReadableUnits() {
+        assertEquals(Duration.ofMillis(500), serializer.deserialize(new YamlConfigNode("500ms"), Duration.class));
+        assertEquals(Duration.ofSeconds(30), serializer.deserialize(new YamlConfigNode("30s"), Duration.class));
+        assertEquals(Duration.ofMinutes(5), serializer.deserialize(new YamlConfigNode("5m"), Duration.class));
+        assertEquals(Duration.ofHours(2), serializer.deserialize(new YamlConfigNode("2h"), Duration.class));
+        assertEquals(Duration.ofDays(1), serializer.deserialize(new YamlConfigNode("1d"), Duration.class));
+        assertEquals(Duration.ofDays(7), serializer.deserialize(new YamlConfigNode("1w"), Duration.class));
+    }
+
+    @Test
+    void deserializesPlainNumberAsSeconds() {
+        assertEquals(Duration.ofSeconds(45), serializer.deserialize(new YamlConfigNode(45), Duration.class));
+    }
+
+    @Test
+    void rejectsInvalidFormat() {
+        assertThrows(SerializationException.class,
+                () -> serializer.deserialize(new YamlConfigNode("not-a-duration"), Duration.class));
+    }
+
+    @Test
+    void serializesToCompactUnit() {
+        YamlConfigNode node = new YamlConfigNode();
+        serializer.serialize(Duration.ofMinutes(5), node);
+        assertEquals("5m", node.raw());
+    }
+}

--- a/platform-bungee/pom.xml
+++ b/platform-bungee/pom.xml
@@ -17,6 +17,7 @@
 
     <modules>
         <module>core-bungee</module>
+        <module>config-bungee</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
## Summary
- New **`platform-bungee/config-bungee`** module: a full-parity port of `platform-spigot/config-spigot` to BungeeCord, in package `tech.guilhermekaua.spigotboot.config.bungee`. The generic `config` core is reused unchanged.
- Covers the whole feature set: `@Config` live-reload (javassist `ConfigProxy`), `@ConfigValue`, `@OnConfigReload`, `@FolderConfig`, and `${...}` cross-config references.
- **SnakeYAML-direct** (like config-spigot) — does **not** use `net.md_5.bungee.config.*`. The only platform delta is the plugin seam (`net.md_5.bungee.api.plugin.Plugin`, `getResourceAsStream`) and dropping Bukkit-only serializers (Material/Sound/World/Location); a ported `DurationSerializer` is kept via `BungeeConfigSerializers`.
- **Relocation-safe shading:** `ConfigProxy` uses the javassist API directly, so the module shades `javassist` → `tech.guilhermekaua.spigotboot.shaded.javassist` (artifactSet = own module only; javassist `provided`). A maven-failsafe **`ConfigProxyRelocationIT`** inspects the packaged jar to prove `ConfigProxy.class` references only the relocated package — a guard a normal surefire test cannot provide.
- Spec & plan: `docs/superpowers/specs/2026-06-15-bungeecord-config-design.md`, `docs/superpowers/plans/2026-06-15-bungeecord-config.md`.

## Notes for reviewers
- **Stacked on `worktree-bungeecord-core-bungee`** (config-bungee depends on `spigot-boot-core-bungee`). The 12 commits here are config-bungee only.
- **Expected trivial conflict in `platform-bungee/pom.xml`** `<modules>`: this branch adds `<module>config-bungee</module>`; the integration branch added `commands-bungee`/`annotation-processor-bungee`. Resolve by keeping all module entries.
- Most main classes are verbatim ports (package rename + the Plugin seam); review focus is the seam, the DI wiring (`ConfigConfiguration`, `BungeeConfigModule` + marker), and the relocation guard.

## Test plan
- [x] `mvnw -pl platform-bungee/config-bungee -am -Danimal.sniffer.skip=true verify` — 169 unit tests + `ConfigProxyRelocationIT` green
- [x] `mvnw -Danimal.sniffer.skip=true install -DskipTests` — full reactor BUILD SUCCESS
- [x] `git grep -nE "config\.spigot|org\.bukkit" -- platform-bungee/config-bungee/src` — no matches
- [x] Relocation teeth-check: removing `<relocations>` makes `ConfigProxyRelocationIT` fail; restoring makes it pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)