### PR TITLE
fix(data-jdbc): read MySQL java.time temporal values in built-in converters

### DIFF
--- a/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
+++ b/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
@@ -156,6 +156,11 @@ public final class BuiltInConverters {
                 return null;
             }
 
+            // mysql-connector-j returns java.time.LocalDate from DATE columns
+            if (dbData instanceof LocalDate) {
+                return (LocalDate) dbData;
+            }
+
             if (dbData instanceof java.sql.Date) {
                 return ((java.sql.Date) dbData).toLocalDate();
             }
@@ -188,6 +193,11 @@ public final class BuiltInConverters {
                 return null;
             }
 
+            // mysql-connector-j returns java.time.LocalDateTime from DATETIME columns
+            if (dbData instanceof LocalDateTime) {
+                return (LocalDateTime) dbData;
+            }
+
             if (dbData instanceof Timestamp) {
                 return ((Timestamp) dbData).toLocalDateTime();
             }
@@ -214,6 +224,11 @@ public final class BuiltInConverters {
         public LocalTime convertToEntityAttribute(Object dbData) {
             if (dbData == null) {
                 return null;
+            }
+
+            // mysql-connector-j returns java.time.LocalTime from TIME columns
+            if (dbData instanceof LocalTime) {
+                return (LocalTime) dbData;
             }
 
             if (dbData instanceof Time) {
@@ -370,6 +385,11 @@ public final class BuiltInConverters {
 
         if (dbData instanceof Timestamp) {
             return ((Timestamp) dbData).toInstant();
+        }
+
+        // mysql-connector-j returns java.time.LocalDateTime from DATETIME/TIMESTAMP columns; reverse the Timestamp.from(...) write path
+        if (dbData instanceof LocalDateTime) {
+            return ((LocalDateTime) dbData).atZone(ZoneId.systemDefault()).toInstant();
         }
 
         if (dbData instanceof Date) {

--- a/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
+++ b/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
@@ -387,7 +387,9 @@ public final class BuiltInConverters {
             return ((Timestamp) dbData).toInstant();
         }
 
-        // mysql-connector-j returns java.time.LocalDateTime from DATETIME/TIMESTAMP columns; reverse the Timestamp.from(...) write path
+        // mysql-connector-j returns java.time.LocalDateTime from DATETIME/TIMESTAMP columns; reverse the Timestamp.from(...) write path.
+        // the value is the stored wall-clock re-interpreted in the JVM default zone, so it is inherently ambiguous during a DST
+        // fall-back overlap (a limitation of persisting an instant to a timezone-less DATETIME column, not a defect here).
         if (dbData instanceof LocalDateTime) {
             return ((LocalDateTime) dbData).atZone(ZoneId.systemDefault()).toInstant();
         }

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
@@ -121,8 +121,8 @@ class BuiltInConvertersTest {
             AttributeConverter<LocalDateTime, Object> converter = converterFor(LocalDateTime.class);
             LocalDateTime expected = LocalDateTime.of(2026, 3, 3, 12, 15, 45);
 
-            // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME column
-            assertEquals(expected, converter.convertToEntityAttribute(expected));
+            // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME column; it must pass through untouched
+            assertSame(expected, converter.convertToEntityAttribute(expected));
         }
 
         @Test
@@ -139,8 +139,8 @@ class BuiltInConvertersTest {
             AttributeConverter<LocalTime, Object> converter = converterFor(LocalTime.class);
             LocalTime expected = LocalTime.of(9, 5, 7);
 
-            // mysql-connector-j 8.x returns java.time.LocalTime from a TIME column
-            assertEquals(expected, converter.convertToEntityAttribute(expected));
+            // mysql-connector-j 8.x returns java.time.LocalTime from a TIME column; it must pass through untouched
+            assertSame(expected, converter.convertToEntityAttribute(expected));
         }
 
         @Test
@@ -190,8 +190,8 @@ class BuiltInConvertersTest {
             AttributeConverter<LocalDate, Object> converter = converterFor(LocalDate.class);
             LocalDate expected = LocalDate.of(2026, 3, 3);
 
-            // mysql-connector-j 8.x returns java.time.LocalDate from a DATE column
-            assertEquals(expected, converter.convertToEntityAttribute(expected));
+            // mysql-connector-j 8.x returns java.time.LocalDate from a DATE column; it must pass through untouched
+            assertSame(expected, converter.convertToEntityAttribute(expected));
         }
     }
 

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
@@ -99,11 +99,30 @@ class BuiltInConvertersTest {
         }
 
         @Test
+        void instantConverterReadsLocalDateTimeFromMySql() {
+            AttributeConverter<Instant, Object> converter = converterFor(Instant.class);
+            Instant instant = Instant.parse("2026-03-03T12:34:56Z");
+            // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME/TIMESTAMP column
+            LocalDateTime mysqlValue = LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+
+            assertEquals(instant, converter.convertToEntityAttribute(mysqlValue));
+        }
+
+        @Test
         void localDateTimeConverterReadsJdbcLiteral() {
             AttributeConverter<LocalDateTime, Object> converter = converterFor(LocalDateTime.class);
             LocalDateTime expected = LocalDateTime.of(2026, 3, 3, 12, 15, 45);
 
             assertEquals(expected, converter.convertToEntityAttribute("2026-03-03 12:15:45"));
+        }
+
+        @Test
+        void localDateTimeConverterReadsLocalDateTimeFromMySql() {
+            AttributeConverter<LocalDateTime, Object> converter = converterFor(LocalDateTime.class);
+            LocalDateTime expected = LocalDateTime.of(2026, 3, 3, 12, 15, 45);
+
+            // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME column
+            assertEquals(expected, converter.convertToEntityAttribute(expected));
         }
 
         @Test
@@ -113,6 +132,15 @@ class BuiltInConvertersTest {
 
             assertEquals(expected, converter.convertToEntityAttribute(Time.valueOf(expected)));
             assertEquals(expected, converter.convertToEntityAttribute("09:05:07"));
+        }
+
+        @Test
+        void localTimeConverterReadsLocalTimeFromMySql() {
+            AttributeConverter<LocalTime, Object> converter = converterFor(LocalTime.class);
+            LocalTime expected = LocalTime.of(9, 5, 7);
+
+            // mysql-connector-j 8.x returns java.time.LocalTime from a TIME column
+            assertEquals(expected, converter.convertToEntityAttribute(expected));
         }
 
         @Test
@@ -156,6 +184,15 @@ class BuiltInConvertersTest {
 
             assertEquals(LocalDate.of(2026, 3, 3), converter.convertToEntityAttribute("2026-03-03"));
         }
+
+        @Test
+        void localDateConverterReadsLocalDateFromMySql() {
+            AttributeConverter<LocalDate, Object> converter = converterFor(LocalDate.class);
+            LocalDate expected = LocalDate.of(2026, 3, 3);
+
+            // mysql-connector-j 8.x returns java.time.LocalDate from a DATE column
+            assertEquals(expected, converter.convertToEntityAttribute(expected));
+        }
     }
 
     @Nested
@@ -173,6 +210,17 @@ class BuiltInConvertersTest {
         }
 
         @Test
+        void dateConverterReadsLocalDateTimeFromMySql() {
+            AttributeConverter<Date, Object> converter = converterFor(Date.class);
+            Date value = new Date(1710000000123L);
+            // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME/TIMESTAMP column
+            LocalDateTime mysqlValue = LocalDateTime.ofInstant(value.toInstant(), ZoneId.systemDefault());
+
+            Date mapped = converter.convertToEntityAttribute(mysqlValue);
+            assertEquals(value.getTime(), mapped.getTime());
+        }
+
+        @Test
         void calendarConverterRoundTripsTimestamp() {
             AttributeConverter<Calendar, Object> converter = converterFor(Calendar.class);
             Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
@@ -182,6 +230,18 @@ class BuiltInConvertersTest {
             assertNotNull(dbValue);
 
             Calendar mapped = converter.convertToEntityAttribute(dbValue);
+            assertEquals(calendar.getTimeInMillis(), mapped.getTimeInMillis());
+        }
+
+        @Test
+        void calendarConverterReadsLocalDateTimeFromMySql() {
+            AttributeConverter<Calendar, Object> converter = converterFor(Calendar.class);
+            Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+            calendar.setTimeInMillis(1710000000456L);
+            // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME/TIMESTAMP column
+            LocalDateTime mysqlValue = LocalDateTime.ofInstant(calendar.toInstant(), ZoneId.systemDefault());
+
+            Calendar mapped = converter.convertToEntityAttribute(mysqlValue);
             assertEquals(calendar.getTimeInMillis(), mapped.getTimeInMillis());
         }
     }


### PR DESCRIPTION
## What & why

Fixes #79 and #80. On MySQL, reading temporal entity fields threw `IllegalArgumentException: Unsupported database value ...`.

**Root cause:** mysql-connector-j 8.x returns `java.time.*` objects from `ResultSet.getObject()` — `DATE → LocalDate`, `DATETIME`/`TIMESTAMP → LocalDateTime`, `TIME → LocalTime`. `EntityRowMapper` reads every column with `getObject()` and hands it to `convertToEntityAttribute()`, but the built-in converters only anticipated the legacy `java.sql.*` / `java.util.Date` types. SQLite was unaffected (it returns `java.sql.Timestamp` / `String`).

## Changes (`modules/data-jdbc` → `BuiltInConverters`)

- **#79** — `toInstant(Object, String)` now handles `LocalDateTime` via `atZone(ZoneId.systemDefault()).toInstant()`, reversing the `Timestamp.from(...)` write path. This single shared branch fixes `InstantConverter`, `DateConverter`, and `CalendarConverter`.
- **#80** — `LocalDateConverter`, `LocalDateTimeConverter`, and `LocalTimeConverter` now return the matching `java.time` value directly.

All four are **purely additive** `instanceof` branches: `java.time.Local*` are `final` and share no hierarchy with `java.sql.*` / `java.util.Date`, so they can neither shadow nor be shadowed by existing branches, and every previously-working input is unchanged.

## Testing

- TDD: 6 new tests written first, confirmed failing with the exact issue errors, then made green.
- `mvnw -pl modules/data-jdbc test` → **54 tests, 0 failures** (built with JDK 21).
- New tests feed the precise `java.time` shapes mysql-connector-j returns; the `Instant`/`Date`/`Calendar` ones build their input via `LocalDateTime.ofInstant(instant, systemDefault())` and were verified hermetic (timezone-independent) across the full tzdata zone set.

## Known limitation (documented, not a regression)

For the `Instant`/`Date`/`Calendar` path, persisting an instant into a timezone-less `DATETIME` column is inherently lossy at a **DST fall-back overlap** (~1h/year): the stored wall-clock is ambiguous, so the recovered instant can differ by the DST offset. This is a property of the column type, not of the reverse function — `atZone(systemDefault())` (per #79's recommendation) is correct for all non-overlap times. Strict instant fidelity on MySQL would require storing UTC/epoch, which is out of scope here.

## Related (not in this PR)

A completeness audit surfaced a separate gap of the same family — entity fields / scalar `@Query` returns declared directly as `java.sql.Timestamp/Date/Time` get no converter and fail on MySQL. Filed as #81 to keep this PR scoped to #79/#80.