### PR TITLE
fix(commands): hide commands from senders who can use no route

### DIFF
--- a/commands/src/main/java/tech/guilhermekaua/spigotboot/commands/execution/CommandDispatcher.java
+++ b/commands/src/main/java/tech/guilhermekaua/spigotboot/commands/execution/CommandDispatcher.java
@@ -101,6 +101,36 @@ public class CommandDispatcher {
         return new ArrayList<>(suggestions);
     }
 
+    /**
+     * Returns whether the sender can use at least one route of the given root command — either the
+     * default handler or any subcommand route whose {@code @Permission} the sender satisfies (a route
+     * with no permission is always usable). Platform adapters use this to gate command <em>visibility</em>
+     * (client-side tab completion / the command tree) so a command is hidden from senders who cannot run
+     * any of its routes, mirroring the per-route filtering {@link #complete} already applies to argument
+     * suggestions. The {@code @CatchUnknown} handler is intentionally not counted: it handles unmatched
+     * input rather than representing a usable command path.
+     *
+     * @param root   the compiled root command; must not be {@code null}
+     * @param sender the sender to test; must not be {@code null}
+     * @return {@code true} if the default handler or at least one route is permitted for {@code sender}
+     */
+    public boolean canUseAnyRoute(CompiledRootCommand root, CommandSenderHandle sender) {
+        if (isPermitted(root.getDefaultRoute(), sender)) {
+            return true;
+        }
+        for (CompiledCommandRoute route : root.getRoutes()) {
+            if (isPermitted(route, sender)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isPermitted(CompiledCommandRoute route, CommandSenderHandle sender) {
+        return route != null
+                && (route.getPermission().isEmpty() || sender.hasPermission(route.getPermission()));
+    }
+
     private boolean execute(CompiledCommandRoute route, DefaultCommandExecutionContext context) {
         CommandMessages messages = messagesProvider.resolve(context.getContext());
         CommandInvocationPlan invocation = route.getInvocationPlan();

--- a/commands/src/test/java/tech/guilhermekaua/spigotboot/commands/test/CommandDispatcherTest.java
+++ b/commands/src/test/java/tech/guilhermekaua/spigotboot/commands/test/CommandDispatcherTest.java
@@ -31,7 +31,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static tech.guilhermekaua.spigotboot.commands.test.CommandTestSupport.*;
@@ -158,6 +160,54 @@ class CommandDispatcherTest {
         List<String> suggestions = dispatcher.complete(context, root, senderHandleFor(sender), "admin", new String[]{"tp", "T"});
 
         assertEquals(Collections.emptyList(), suggestions);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // canUseAnyRoute drives command visibility on every platform adapter (BungeeBootCommand#hasPermission,
+    // SpigotBootCommand#testPermissionSilent). These module-level tests pin the routing logic — including
+    // the intentional @CatchUnknown exclusion — independently of any platform's test infrastructure.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void canUseAnyRouteHidesFullyGatedCommandFromSenderWithoutPermission() {
+        CompiledRootCommand root = compileRoot(new GatedNetworkCommand());
+        CommandDispatcher dispatcher = newDispatcher();
+
+        assertFalse(dispatcher.canUseAnyRoute(root, senderHandleFor(testSender("NoPerms"))));
+    }
+
+    @Test
+    void canUseAnyRouteShowsGatedCommandToSenderWithPermission() {
+        CompiledRootCommand root = compileRoot(new GatedNetworkCommand());
+        CommandDispatcher dispatcher = newDispatcher();
+
+        assertTrue(dispatcher.canUseAnyRoute(root, senderHandleFor(testSender("Admin", "network.reload"))));
+    }
+
+    @Test
+    void canUseAnyRouteShowsCommandWithPermissionlessDefaultHandlerToEveryone() {
+        CompiledRootCommand root = compileRoot(new OpenDefaultCommand());
+        CommandDispatcher dispatcher = newDispatcher();
+
+        assertTrue(dispatcher.canUseAnyRoute(root, senderHandleFor(testSender("AnyOne"))));
+    }
+
+    @Test
+    void canUseAnyRouteHidesCommandWhoseOnlyHandlerIsCatchUnknown() {
+        CompiledRootCommand root = compileRoot(new CatchUnknownOnlyCommand());
+        CommandDispatcher dispatcher = newDispatcher();
+
+        // @CatchUnknown handles unmatched input; it is not a usable route, so the command exposes none.
+        assertFalse(dispatcher.canUseAnyRoute(root, senderHandleFor(testSender("AnyOne"))));
+    }
+
+    @Test
+    void canUseAnyRouteShowsCommandWhenAtLeastOneRouteIsUngated() {
+        CompiledRootCommand root = compileRoot(new MixedAccessCommand());
+        CommandDispatcher dispatcher = newDispatcher();
+
+        // the gated 'reload' route is denied, but the permissionless 'info' route is still usable.
+        assertTrue(dispatcher.canUseAnyRoute(root, senderHandleFor(testSender("NoPerms"))));
     }
 
     private CompiledRootCommand compileRoot(Object handler) {
@@ -328,6 +378,44 @@ class CommandDispatcherTest {
         @Permission("admin.tp")
         @Command("tp <target>")
         public void teleport(@Completion("targets") String target) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("network")
+    static class GatedNetworkCommand {
+        @Permission("network.reload")
+        @Command("reload")
+        public void reload(@Sender TestSender sender) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("status")
+    static class OpenDefaultCommand {
+        @DefaultCommand
+        public void status(@Sender TestSender sender) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("broadcast")
+    static class CatchUnknownOnlyCommand {
+        @CatchUnknown
+        public void unknown() {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("monitor")
+    static class MixedAccessCommand {
+        @Command("info")
+        public void info(@Sender TestSender sender) {
+        }
+
+        @Permission("monitor.reload")
+        @Command("reload")
+        public void reload(@Sender TestSender sender) {
         }
     }
 

--- a/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java
+++ b/platform-bungee/commands-bungee/src/main/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommand.java
@@ -38,10 +38,14 @@ import java.util.List;
  * A BungeeCord {@link Command} that bridges a compiled root command to the generic
  * {@link CommandDispatcher}. Mirrors the Spigot {@code SpigotBootCommand}.
  *
- * <p>The base command is constructed with a {@code null} permission: BungeeCord's
- * {@code PluginManager} only blocks execution when {@code hasPermission} fails, so leaving it null
- * guarantees {@link #execute}/{@link #onTabComplete} are always reached and the dispatcher enforces
- * per-route {@code @Permission} for both — the same end-state as the Spigot adapter.
+ * <p>The base command carries no static permission (it is constructed with {@code null}); visibility is
+ * instead computed per-sender in {@link #hasPermission(CommandSender)} from the command's routes.
+ * BungeeCord consults {@code hasPermission} both to inject this command into the player's command tree —
+ * and therefore into client-side tab completion (see {@code DownstreamBridge#handle(Commands)}) — and to
+ * gate {@link #execute}/{@link #onTabComplete} (see {@code PluginManager#dispatchCommand}). Reporting
+ * whether the sender can use at least one route hides the command from senders who can run none of its
+ * subcommands (nor its default handler), while the {@link CommandDispatcher} still enforces per-route
+ * {@code @Permission} during dispatch and argument completion for senders who pass this gate.
  *
  * <p>{@link TabExecutor} is implemented because BungeeCord's base {@link Command} has no tab-complete
  * method; the dispatcher invokes {@link #onTabComplete} via {@code instanceof TabExecutor}.
@@ -77,6 +81,20 @@ public class BungeeBootCommand extends Command implements TabExecutor {
         List<String> completions = dispatcher.complete(context, rootCommand,
                 commandPlatformSupport.createSender(sender), getName(), args);
         return completions == null ? Collections.emptyList() : completions;
+    }
+
+    /**
+     * Reports whether {@code sender} can use at least one route of this command, so BungeeCord hides the
+     * command from senders who can run none of its subcommands (nor its default handler) and only offers
+     * it in tab completion to those who can. See the type-level documentation for how BungeeCord consults
+     * this for both command-tree visibility and execution gating.
+     *
+     * @param sender the sender BungeeCord is testing
+     * @return {@code true} if {@code sender} can use at least one of this command's routes
+     */
+    @Override
+    public boolean hasPermission(CommandSender sender) {
+        return dispatcher.canUseAnyRoute(rootCommand, commandPlatformSupport.createSender(sender));
     }
 
     public CompiledRootCommand getRootCommand() {

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java
@@ -30,6 +30,7 @@ import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginDescription;
 import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
+import tech.guilhermekaua.spigotboot.commands.annotations.CatchUnknown;
 import tech.guilhermekaua.spigotboot.commands.annotations.Command;
 import tech.guilhermekaua.spigotboot.commands.annotations.CommandHandler;
 import tech.guilhermekaua.spigotboot.commands.annotations.DefaultCommand;
@@ -234,6 +235,39 @@ class BungeeBootCommandEndToEndTest {
                 "a command whose default handler needs no permission must stay visible to everyone");
     }
 
+    @Test
+    void commandWithOnlyACatchUnknownHandlerIsHiddenFromEveryone() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(player.getName()).thenReturn("AnyOne");
+
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(new CatchUnknownOnlyCommand()), newDispatcher(plugin), platformSupport);
+
+        // @CatchUnknown only handles unmatched input; it is not a usable route, so the command exposes none.
+        assertFalse(command.hasPermission(player),
+                "a command whose only handler is @CatchUnknown offers no usable route and must stay hidden");
+    }
+
+    @Test
+    void commandStaysVisibleWhenOnlyOneOfSeveralRoutesIsUngated() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(player.getName()).thenReturn("NoPerms");
+        when(player.hasPermission("monitor.reload")).thenReturn(false);
+
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(new MixedAccessCommand()), newDispatcher(plugin), platformSupport);
+
+        // the gated 'reload' route is denied, but the permissionless 'info' route is still usable.
+        assertTrue(command.hasPermission(player),
+                "a sender who can use at least one route must still see the command");
+    }
+
     @CommandHandler
     @RootCommand("server")
     static class ServerCommands {
@@ -263,6 +297,27 @@ class BungeeBootCommandEndToEndTest {
     static class OpenDefaultCommand {
         @DefaultCommand
         public void status(@Sender CommandSender sender) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("broadcast")
+    static class CatchUnknownOnlyCommand {
+        @CatchUnknown
+        public void unknown() {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("monitor")
+    static class MixedAccessCommand {
+        @Command("info")
+        public void info(@Sender CommandSender sender) {
+        }
+
+        @Command("reload")
+        @Permission("monitor.reload")
+        public void reload(@Sender CommandSender sender) {
         }
     }
 }

--- a/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java
+++ b/platform-bungee/commands-bungee/src/test/java/tech/guilhermekaua/spigotboot/commands/bungee/BungeeBootCommandEndToEndTest.java
@@ -22,6 +22,7 @@
  */
 package tech.guilhermekaua.spigotboot.commands.bungee;
 
+import net.md_5.bungee.api.CommandSender;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -31,6 +32,8 @@ import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.commands.CommandReplacementRegistry;
 import tech.guilhermekaua.spigotboot.commands.annotations.Command;
 import tech.guilhermekaua.spigotboot.commands.annotations.CommandHandler;
+import tech.guilhermekaua.spigotboot.commands.annotations.DefaultCommand;
+import tech.guilhermekaua.spigotboot.commands.annotations.Permission;
 import tech.guilhermekaua.spigotboot.commands.annotations.RootCommand;
 import tech.guilhermekaua.spigotboot.commands.annotations.Sender;
 import tech.guilhermekaua.spigotboot.commands.binding.CommandParameterBinder;
@@ -64,7 +67,9 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -162,6 +167,73 @@ class BungeeBootCommandEndToEndTest {
         assertEquals(Collections.singletonList("Target"), values);
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // command visibility vs. per-route permission.
+    //
+    // BungeeCord injects each registered command into the player's brigadier command tree (and thus
+    // into client-side tab completion) in DownstreamBridge#handle(Commands) only when
+    // command.hasPermission(connection) is true. The base BungeeBootCommand is created with a null
+    // permission, so Command#hasPermission always returns true — meaning a player who cannot use any
+    // subcommand still receives the command literal and sees it offered in completion.
+    //
+    // These tests pin the desired behaviour: the command must be visible iff the sender can use at
+    // least one route (a subcommand or the default handler).
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void commandWithOnlyAGatedSubcommandIsHiddenFromPlayersWithoutPermission() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(player.getName()).thenReturn("NoPerms");
+        when(player.hasPermission("network.reload")).thenReturn(false);
+
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(new GatedNetworkCommand()), newDispatcher(plugin), platformSupport);
+
+        // argument-level completion is already permission-filtered: "/network <TAB>" suggests nothing.
+        List<String> argSuggestions = new ArrayList<>();
+        command.onTabComplete(player, new String[]{""}).forEach(argSuggestions::add);
+        assertTrue(argSuggestions.isEmpty(), "the gated 'reload' subcommand must not be suggested");
+
+        // but command visibility keys off Command#hasPermission, which BungeeCord uses to decide whether
+        // to put "/network" in the player's command tree at all. It must be false here.
+        assertFalse(command.hasPermission(player),
+                "a player who can use no route must not see the command in tab completion");
+    }
+
+    @Test
+    void commandWithAGatedSubcommandStaysVisibleToPlayersWithPermission() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(player.getName()).thenReturn("Admin");
+        when(player.hasPermission("network.reload")).thenReturn(true);
+
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(new GatedNetworkCommand()), newDispatcher(plugin), platformSupport);
+
+        assertTrue(command.hasPermission(player),
+                "a player who can use a route must still see the command");
+    }
+
+    @Test
+    void commandWithPermissionlessDefaultStaysVisibleToEveryone() {
+        ProxyServer proxy = mock(ProxyServer.class);
+        Plugin plugin = mockPlugin(proxy);
+
+        ProxiedPlayer player = mock(ProxiedPlayer.class);
+        when(player.getName()).thenReturn("AnyOne");
+
+        BungeeBootCommand command = new BungeeBootCommand(
+                newContext(plugin), compileRoot(new OpenDefaultCommand()), newDispatcher(plugin), platformSupport);
+
+        assertTrue(command.hasPermission(player),
+                "a command whose default handler needs no permission must stay visible to everyone");
+    }
+
     @CommandHandler
     @RootCommand("server")
     static class ServerCommands {
@@ -174,6 +246,23 @@ class BungeeBootCommandEndToEndTest {
             this.lastSender = sender;
             this.lastTarget = target;
             this.lastServer = server;
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("network")
+    static class GatedNetworkCommand {
+        @Command("reload")
+        @Permission("network.reload")
+        public void reload(@Sender CommandSender sender) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("status")
+    static class OpenDefaultCommand {
+        @DefaultCommand
+        public void status(@Sender CommandSender sender) {
         }
     }
 }

--- a/platform-spigot/commands-spigot/src/main/java/tech/guilhermekaua/spigotboot/commands/spigot/SpigotBootCommand.java
+++ b/platform-spigot/commands-spigot/src/main/java/tech/guilhermekaua/spigotboot/commands/spigot/SpigotBootCommand.java
@@ -60,12 +60,29 @@ public class SpigotBootCommand extends Command {
     }
 
     /**
-     * Returns {@code null} so Bukkit skips its top-level permission check.
-     * Per-route permissions ({@literal @Permission}) are enforced by {@link CommandDispatcher}
-     * during both dispatch and tab-completion.
+     * Returns {@code null} so Bukkit carries no static permission for this command; visibility is computed
+     * per-sender in {@link #testPermissionSilent(CommandSender)} instead. Per-route permissions
+     * ({@literal @Permission}) are enforced by {@link CommandDispatcher} during both dispatch and
+     * tab-completion.
      */
     @Override
     public @Nullable String getPermission() {
         return null;
+    }
+
+    /**
+     * Reports whether {@code target} can use at least one route of this command. CraftBukkit builds each
+     * command's client-side command-tree node with a {@code requires(...)} predicate backed by this method,
+     * so returning the route-aware result hides the command in tab completion from senders who can run none
+     * of its subcommands (nor its default handler). Execution is unaffected — Bukkit's command dispatch does
+     * not consult permissions — so {@link CommandDispatcher} still enforces per-route {@literal @Permission}
+     * during {@link #execute} and {@link #tabComplete} for senders who pass this gate.
+     *
+     * @param target the sender being tested
+     * @return {@code true} if {@code target} can use at least one of this command's routes
+     */
+    @Override
+    public boolean testPermissionSilent(@NotNull CommandSender target) {
+        return dispatcher.canUseAnyRoute(rootCommand, commandPlatformSupport.createSender(target));
     }
 }

--- a/platform-spigot/commands-spigot/src/test/java/tech/guilhermekaua/spigotboot/commands/test/SpigotBootCommandTest.java
+++ b/platform-spigot/commands-spigot/src/test/java/tech/guilhermekaua/spigotboot/commands/test/SpigotBootCommandTest.java
@@ -108,6 +108,52 @@ class SpigotBootCommandTest {
         assertTrue(restrictedSuggestions.isEmpty());
     }
 
+    // ---------------------------------------------------------------------------------------------
+    // command visibility vs. per-route permission.
+    //
+    // CraftBukkit builds each command's client-side command-tree node with a requires(...) predicate
+    // backed by Command#testPermissionSilent, so a command with only a permission-gated subcommand must
+    // not be exposed in tab completion to players who cannot use any of its routes. Argument-level
+    // completion is already filtered by the dispatcher (covered above); these tests pin the visibility gate.
+    // ---------------------------------------------------------------------------------------------
+
+    @Test
+    void commandWithOnlyAGatedSubcommandIsHiddenFromPlayersWithoutPermission() {
+        JavaPlugin plugin = MockBukkit.createMockPlugin("TestPlugin");
+        Player player = server.addPlayer("NoPerms");
+
+        SpigotBootCommand command = new SpigotBootCommand(
+                newContext(plugin), compileRoot(new GatedNetworkCommand()), newDispatcher(), platformSupport);
+
+        assertFalse(command.testPermissionSilent(player),
+                "a player who can use no route must not see the command in tab completion");
+    }
+
+    @Test
+    void commandWithAGatedSubcommandStaysVisibleToPlayersWithPermission() {
+        JavaPlugin plugin = MockBukkit.createMockPlugin("TestPlugin");
+        Player player = server.addPlayer("Admin");
+        player.addAttachment(plugin, "network.reload", true);
+
+        SpigotBootCommand command = new SpigotBootCommand(
+                newContext(plugin), compileRoot(new GatedNetworkCommand()), newDispatcher(), platformSupport);
+
+        assertTrue(command.testPermissionSilent(player),
+                "a player who can use a route must still see the command");
+    }
+
+    @Test
+    void commandWithPermissionlessDefaultStaysVisibleToEveryone() {
+        JavaPlugin plugin = MockBukkit.createMockPlugin("TestPlugin");
+        Player player = server.addPlayer("AnyOne");
+
+        SpigotBootCommand command = new SpigotBootCommand(
+                newContext(plugin), compileRoot(new OpenDefaultCommand()), newDispatcher(), platformSupport);
+
+        assertTrue(command.testPermissionSilent(player),
+                "a command whose default handler needs no permission must stay visible to everyone");
+    }
+
     private Context newContext(JavaPlugin plugin) {
         Context context = mock(Context.class);
         when(context.getPlugin()).thenReturn(new SpigotBootPlugin(plugin));
@@ -150,6 +196,23 @@ class SpigotBootCommandTest {
         @Permission("admin.manage")
         @Command("manage")
         public void manage(@Sender Player sender) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("network")
+    static class GatedNetworkCommand {
+        @Permission("network.reload")
+        @Command("reload")
+        public void reload(@Sender Player sender) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("status")
+    static class OpenDefaultCommand {
+        @DefaultCommand
+        public void status(@Sender Player sender) {
         }
     }
 

--- a/platform-spigot/commands-spigot/src/test/java/tech/guilhermekaua/spigotboot/commands/test/SpigotBootCommandTest.java
+++ b/platform-spigot/commands-spigot/src/test/java/tech/guilhermekaua/spigotboot/commands/test/SpigotBootCommandTest.java
@@ -154,6 +154,32 @@ class SpigotBootCommandTest {
                 "a command whose default handler needs no permission must stay visible to everyone");
     }
 
+    @Test
+    void commandWithOnlyACatchUnknownHandlerIsHiddenFromEveryone() {
+        JavaPlugin plugin = MockBukkit.createMockPlugin("TestPlugin");
+        Player player = server.addPlayer("AnyOne");
+
+        SpigotBootCommand command = new SpigotBootCommand(
+                newContext(plugin), compileRoot(new CatchUnknownOnlyCommand()), newDispatcher(), platformSupport);
+
+        // @CatchUnknown only handles unmatched input; it is not a usable route, so the command exposes none.
+        assertFalse(command.testPermissionSilent(player),
+                "a command whose only handler is @CatchUnknown offers no usable route and must stay hidden");
+    }
+
+    @Test
+    void commandStaysVisibleWhenOnlyOneOfSeveralRoutesIsUngated() {
+        JavaPlugin plugin = MockBukkit.createMockPlugin("TestPlugin");
+        Player player = server.addPlayer("NoPerms");
+
+        SpigotBootCommand command = new SpigotBootCommand(
+                newContext(plugin), compileRoot(new MixedAccessCommand()), newDispatcher(), platformSupport);
+
+        // the gated 'reload' route is denied, but the permissionless 'info' route is still usable.
+        assertTrue(command.testPermissionSilent(player),
+                "a sender who can use at least one route must still see the command");
+    }
+
     private Context newContext(JavaPlugin plugin) {
         Context context = mock(Context.class);
         when(context.getPlugin()).thenReturn(new SpigotBootPlugin(plugin));
@@ -213,6 +239,27 @@ class SpigotBootCommandTest {
     static class OpenDefaultCommand {
         @DefaultCommand
         public void status(@Sender Player sender) {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("broadcast")
+    static class CatchUnknownOnlyCommand {
+        @CatchUnknown
+        public void unknown() {
+        }
+    }
+
+    @CommandHandler
+    @RootCommand("monitor")
+    static class MixedAccessCommand {
+        @Command("info")
+        public void info(@Sender Player sender) {
+        }
+
+        @Permission("monitor.reload")
+        @Command("reload")
+        public void reload(@Sender Player sender) {
         }
     }
 


### PR DESCRIPTION
## Problem
A command whose subcommands are all permission-gated was still offered in client-side tab completion to players who can use none of them. Observed on the sample Bungee plugin with `/network` (its only subcommand `reload` requires `network.reload`): a player without that permission still saw `/network`.

Argument-level completion was already filtered per-route — the gap was **command-name visibility**.

## Root cause
Both adapters register the base command with a `null` permission, so the platform "can this sender use the command" check always returns `true`:

- **BungeeCord** — `DownstreamBridge#handle(Commands)` injects a command into the client command tree only when `Command#hasPermission(con)` is true.
- **Spigot/CraftBukkit** — each command-tree node is built with a `requires(...)` predicate backed by `Command#testPermissionSilent`.

So the command was shown to everyone on both platforms (the Spigot case was the same latent bug).

## Fix
- `CommandDispatcher#canUseAnyRoute(root, sender)` — true iff the sender can use the default handler or at least one subcommand route (mirrors the per-route logic already in `complete()`).
- `BungeeBootCommand` overrides `hasPermission` → `canUseAnyRoute`.
- `SpigotBootCommand` overrides `testPermissionSilent` → `canUseAnyRoute` (`getPermission()` stays `null`).

## Tests
Regression tests on both platforms: hidden without permission, visible with permission, visible when a permissionless default handler exists. Full command-module reactor green (`commands` 52, `commands-spigot` 13, `commands-bungee` 32).

## Notes
- **Bungee-only side effect:** BungeeCord also uses `hasPermission` to gate execution (no separate hook). A sender with access to zero routes who explicitly types the command now gets BungeeCord's generic no-permission message instead of the framework's per-route message. On Spigot, dispatch does not check permission, so the framework message is preserved. Both platforms hide the command correctly.
- `@CatchUnknown` is intentionally not counted as a usable route for visibility (it handles unmatched input). A command with only a catch-unknown handler would be hidden — documented in the javadoc.
- Branched off `dev`; `master` is currently ahead (3.2.0 + CI). Retarget the base if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
