### PR TITLE
fix(data-jdbc): read MySQL temporal values into java.sql.Timestamp/Date/Time (#81)

### DIFF
--- a/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
+++ b/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
@@ -54,6 +54,9 @@ public final class BuiltInConverters {
         registry.register(Duration.class, new DurationConverter());
         registry.register(Date.class, new DateConverter());
         registry.register(Calendar.class, new CalendarConverter());
+        registry.register(Timestamp.class, new SqlTimestampConverter());
+        registry.register(java.sql.Date.class, new SqlDateConverter());
+        registry.register(Time.class, new SqlTimeConverter());
     }
 
     static class BigDecimalConverter implements AttributeConverter<BigDecimal, Object> {
@@ -363,6 +366,155 @@ public final class BuiltInConverters {
         }
     }
 
+    static class SqlTimestampConverter implements AttributeConverter<Timestamp, Object> {
+        @Override
+        public Object convertToDatabaseColumn(Timestamp attribute) {
+            return attribute;
+        }
+
+        @Override
+        public Timestamp convertToEntityAttribute(Object dbData) {
+            if (dbData == null) {
+                return null;
+            }
+
+            if (dbData instanceof Timestamp) {
+                return (Timestamp) dbData;
+            }
+
+            // mysql-connector-j returns java.time.LocalDateTime from DATETIME/TIMESTAMP columns
+            if (dbData instanceof LocalDateTime) {
+                return Timestamp.valueOf((LocalDateTime) dbData);
+            }
+
+            if (dbData instanceof LocalDate) {
+                return Timestamp.valueOf(((LocalDate) dbData).atStartOfDay());
+            }
+
+            if (dbData instanceof Date) {
+                return new Timestamp(((Date) dbData).getTime());
+            }
+
+            if (dbData instanceof Instant) {
+                return Timestamp.from((Instant) dbData);
+            }
+
+            if (dbData instanceof Number) {
+                return new Timestamp(((Number) dbData).longValue());
+            }
+
+            if (dbData instanceof String) {
+                String trimmed = ((String) dbData).trim();
+                // SQLite stores java.sql.* temporal values as epoch millis in a TEXT column
+                Long epochMillis = parseEpochMillis(trimmed);
+                if (epochMillis != null) {
+                    return new Timestamp(epochMillis);
+                }
+                return Timestamp.valueOf(parseLocalDateTime(trimmed));
+            }
+
+            throw new IllegalArgumentException("Unsupported database value for java.sql.Timestamp conversion: " + dbData.getClass().getName());
+        }
+    }
+
+    static class SqlDateConverter implements AttributeConverter<java.sql.Date, Object> {
+        @Override
+        public Object convertToDatabaseColumn(java.sql.Date attribute) {
+            return attribute;
+        }
+
+        @Override
+        public java.sql.Date convertToEntityAttribute(Object dbData) {
+            if (dbData == null) {
+                return null;
+            }
+
+            if (dbData instanceof java.sql.Date) {
+                return (java.sql.Date) dbData;
+            }
+
+            // mysql-connector-j returns java.time.LocalDate from DATE columns
+            if (dbData instanceof LocalDate) {
+                return java.sql.Date.valueOf((LocalDate) dbData);
+            }
+
+            if (dbData instanceof LocalDateTime) {
+                return java.sql.Date.valueOf(((LocalDateTime) dbData).toLocalDate());
+            }
+
+            if (dbData instanceof Timestamp) {
+                return java.sql.Date.valueOf(((Timestamp) dbData).toLocalDateTime().toLocalDate());
+            }
+
+            if (dbData instanceof Date) {
+                return new java.sql.Date(((Date) dbData).getTime());
+            }
+
+            if (dbData instanceof Number) {
+                return new java.sql.Date(((Number) dbData).longValue());
+            }
+
+            if (dbData instanceof String) {
+                String trimmed = ((String) dbData).trim();
+                // SQLite stores java.sql.* temporal values as epoch millis in a TEXT column
+                Long epochMillis = parseEpochMillis(trimmed);
+                if (epochMillis != null) {
+                    return new java.sql.Date(epochMillis);
+                }
+                return java.sql.Date.valueOf(parseLocalDate(trimmed));
+            }
+
+            throw new IllegalArgumentException("Unsupported database value for java.sql.Date conversion: " + dbData.getClass().getName());
+        }
+    }
+
+    static class SqlTimeConverter implements AttributeConverter<Time, Object> {
+        @Override
+        public Object convertToDatabaseColumn(Time attribute) {
+            return attribute;
+        }
+
+        @Override
+        public Time convertToEntityAttribute(Object dbData) {
+            if (dbData == null) {
+                return null;
+            }
+
+            if (dbData instanceof Time) {
+                return (Time) dbData;
+            }
+
+            // mysql-connector-j returns java.time.LocalTime from TIME columns
+            if (dbData instanceof LocalTime) {
+                return Time.valueOf((LocalTime) dbData);
+            }
+
+            if (dbData instanceof LocalDateTime) {
+                return Time.valueOf(((LocalDateTime) dbData).toLocalTime());
+            }
+
+            if (dbData instanceof Timestamp) {
+                return Time.valueOf(((Timestamp) dbData).toLocalDateTime().toLocalTime());
+            }
+
+            if (dbData instanceof Number) {
+                return new Time(((Number) dbData).longValue());
+            }
+
+            if (dbData instanceof String) {
+                String trimmed = ((String) dbData).trim();
+                // SQLite stores java.sql.* temporal values as epoch millis in a TEXT column
+                Long epochMillis = parseEpochMillis(trimmed);
+                if (epochMillis != null) {
+                    return new Time(epochMillis);
+                }
+                return Time.valueOf(parseLocalTime(trimmed));
+            }
+
+            throw new IllegalArgumentException("Unsupported database value for java.sql.Time conversion: " + dbData.getClass().getName());
+        }
+    }
+
     private static Instant toInstant(Object dbData, String targetType) {
         if (dbData instanceof Instant) {
             return (Instant) dbData;
@@ -494,6 +646,14 @@ public final class BuiltInConverters {
         }
 
         throw new IllegalArgumentException("Unsupported database value for LocalTime conversion: " + dbData);
+    }
+
+    private static Long parseEpochMillis(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
     }
 
     private static String normalizeDateTimeLiteral(String dbData) {

--- a/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
+++ b/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
@@ -382,11 +382,14 @@ public final class BuiltInConverters {
                 return (Timestamp) dbData;
             }
 
-            // mysql-connector-j returns java.time.LocalDateTime from DATETIME/TIMESTAMP columns
+            // mysql-connector-j returns java.time.LocalDateTime from DATETIME/TIMESTAMP columns.
+            // Timestamp.valueOf interprets the local value in the JVM default time zone, which is the
+            // native java.sql.Timestamp semantic (it round-trips with Timestamp.toLocalDateTime()).
             if (dbData instanceof LocalDateTime) {
                 return Timestamp.valueOf((LocalDateTime) dbData);
             }
 
+            // atStartOfDay() yields 00:00:00 in the JVM default zone, consistent with the branch above
             if (dbData instanceof LocalDate) {
                 return Timestamp.valueOf(((LocalDate) dbData).atStartOfDay());
             }

--- a/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
+++ b/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConverters.java
@@ -497,6 +497,11 @@ public final class BuiltInConverters {
                 return Time.valueOf(((Timestamp) dbData).toLocalDateTime().toLocalTime());
             }
 
+            // mirrors SqlTimestampConverter/SqlDateConverter: tolerate a legacy-driver java.util.Date
+            if (dbData instanceof Date) {
+                return new Time(((Date) dbData).getTime());
+            }
+
             if (dbData instanceof Number) {
                 return new Time(((Number) dbData).longValue());
             }

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
@@ -351,6 +351,106 @@ class BuiltInConvertersTest {
             assertEquals(Time.class, result.getClass());
             assertEquals(value, result);
         }
+
+        @Test
+        void sqlTimestampConverterReadsLocalDate() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            LocalDate value = LocalDate.of(2026, 3, 3);
+
+            Timestamp result = converter.convertToEntityAttribute(value);
+
+            assertEquals(Timestamp.class, result.getClass());
+            assertEquals(Timestamp.valueOf(value.atStartOfDay()), result);
+        }
+
+        @Test
+        void sqlTimestampConverterReadsInstant() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            Instant value = Instant.parse("2026-03-03T12:34:56Z");
+
+            Timestamp result = converter.convertToEntityAttribute(value);
+
+            assertEquals(Timestamp.class, result.getClass());
+            assertEquals(Timestamp.from(value), result);
+        }
+
+        @Test
+        void sqlTimestampConverterReadsUtilDate() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            Date value = new Date(1710000000123L);
+
+            Timestamp result = converter.convertToEntityAttribute(value);
+
+            assertEquals(Timestamp.class, result.getClass());
+            assertEquals(value.getTime(), result.getTime());
+        }
+
+        @Test
+        void sqlDateConverterReadsLocalDateTime() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            LocalDateTime value = LocalDateTime.of(2026, 3, 3, 12, 15, 45);
+
+            java.sql.Date result = converter.convertToEntityAttribute(value);
+
+            assertEquals(java.sql.Date.class, result.getClass());
+            assertEquals(java.sql.Date.valueOf(value.toLocalDate()), result);
+        }
+
+        @Test
+        void sqlDateConverterReadsTimestamp() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            Timestamp value = Timestamp.valueOf("2026-03-03 12:15:45");
+
+            java.sql.Date result = converter.convertToEntityAttribute(value);
+
+            assertEquals(java.sql.Date.class, result.getClass());
+            assertEquals(java.sql.Date.valueOf("2026-03-03"), result);
+        }
+
+        @Test
+        void sqlDateConverterReadsUtilDate() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            Date value = new Date(1710000000123L);
+
+            java.sql.Date result = converter.convertToEntityAttribute(value);
+
+            assertEquals(java.sql.Date.class, result.getClass());
+            assertEquals(value.getTime(), result.getTime());
+        }
+
+        @Test
+        void sqlTimeConverterReadsLocalDateTime() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            LocalDateTime value = LocalDateTime.of(2026, 3, 3, 9, 5, 7);
+
+            Time result = converter.convertToEntityAttribute(value);
+
+            assertEquals(Time.class, result.getClass());
+            assertEquals(Time.valueOf(value.toLocalTime()), result);
+        }
+
+        @Test
+        void sqlTimeConverterReadsTimestamp() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            Timestamp value = Timestamp.valueOf("2026-03-03 09:05:07");
+
+            Time result = converter.convertToEntityAttribute(value);
+
+            assertEquals(Time.class, result.getClass());
+            assertEquals(Time.valueOf("09:05:07"), result);
+        }
+
+        @Test
+        void sqlTimeConverterReadsUtilDate() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            // SqlTimeConverter must tolerate a legacy-driver java.util.Date like the sibling converters do
+            Date value = new Date(1710000000123L);
+
+            Time result = converter.convertToEntityAttribute(value);
+
+            assertEquals(Time.class, result.getClass());
+            assertEquals(value.getTime(), result.getTime());
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/converter/BuiltInConvertersTest.java
@@ -65,6 +65,9 @@ class BuiltInConvertersTest {
             assertTrue(registry.hasConverter(Duration.class));
             assertTrue(registry.hasConverter(Date.class));
             assertTrue(registry.hasConverter(Calendar.class));
+            assertTrue(registry.hasConverter(Timestamp.class));
+            assertTrue(registry.hasConverter(java.sql.Date.class));
+            assertTrue(registry.hasConverter(Time.class));
         }
     }
 
@@ -183,6 +186,170 @@ class BuiltInConvertersTest {
 
             Calendar mapped = converter.convertToEntityAttribute(dbValue);
             assertEquals(calendar.getTimeInMillis(), mapped.getTimeInMillis());
+        }
+    }
+
+    @Nested
+    class SqlTemporalConverterTests {
+        @Test
+        void sqlTimestampConverterReadsLocalDateTimeFromMySql() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME/TIMESTAMP column
+            LocalDateTime mysqlValue = LocalDateTime.of(2026, 3, 3, 12, 15, 45);
+
+            Timestamp result = converter.convertToEntityAttribute(mysqlValue);
+
+            assertEquals(Timestamp.class, result.getClass());
+            assertEquals(Timestamp.valueOf(mysqlValue), result);
+        }
+
+        @Test
+        void sqlTimestampConverterPassesThroughTimestampFromSqlite() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            // the SQLite driver already returns java.sql.Timestamp for these columns
+            Timestamp sqliteValue = Timestamp.valueOf("2026-03-03 12:15:45");
+
+            assertSame(sqliteValue, converter.convertToEntityAttribute(sqliteValue));
+        }
+
+        @Test
+        void sqlDateConverterReadsLocalDateFromMySql() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            // mysql-connector-j 8.x returns java.time.LocalDate from a DATE column
+            LocalDate mysqlValue = LocalDate.of(2026, 3, 3);
+
+            java.sql.Date result = converter.convertToEntityAttribute(mysqlValue);
+
+            assertEquals(java.sql.Date.class, result.getClass());
+            assertEquals(java.sql.Date.valueOf(mysqlValue), result);
+        }
+
+        @Test
+        void sqlDateConverterPassesThroughSqlDate() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            java.sql.Date value = java.sql.Date.valueOf("2026-03-03");
+
+            assertSame(value, converter.convertToEntityAttribute(value));
+        }
+
+        @Test
+        void sqlTimeConverterReadsLocalTimeFromMySql() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            // mysql-connector-j 8.x returns java.time.LocalTime from a TIME column
+            LocalTime mysqlValue = LocalTime.of(9, 5, 7);
+
+            Time result = converter.convertToEntityAttribute(mysqlValue);
+
+            assertEquals(Time.class, result.getClass());
+            assertEquals(Time.valueOf(mysqlValue), result);
+        }
+
+        @Test
+        void sqlTimeConverterPassesThroughTime() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            Time value = Time.valueOf("09:05:07");
+
+            assertSame(value, converter.convertToEntityAttribute(value));
+        }
+
+        @Test
+        void sqlTimestampConverterRoundTripsThroughDatabaseColumn() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            Timestamp value = Timestamp.valueOf("2026-03-03 12:15:45.123456");
+
+            Object dbValue = converter.convertToDatabaseColumn(value);
+
+            assertEquals(value, converter.convertToEntityAttribute(dbValue));
+        }
+
+        @Test
+        void sqlDateConverterRoundTripsThroughDatabaseColumn() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            java.sql.Date value = java.sql.Date.valueOf("2026-03-03");
+
+            Object dbValue = converter.convertToDatabaseColumn(value);
+
+            assertEquals(value, converter.convertToEntityAttribute(dbValue));
+        }
+
+        @Test
+        void sqlTimeConverterRoundTripsThroughDatabaseColumn() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            Time value = Time.valueOf("09:05:07");
+
+            Object dbValue = converter.convertToDatabaseColumn(value);
+
+            assertEquals(value, converter.convertToEntityAttribute(dbValue));
+        }
+
+        @Test
+        void sqlTimestampConverterReadsEpochMillisStringFromSqlite() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            Timestamp value = Timestamp.valueOf("2026-03-03 12:15:45");
+            // the SQLite driver returns java.sql.* temporal values as an epoch-millis String from a TEXT column
+            String sqliteValue = Long.toString(value.getTime());
+
+            Timestamp result = converter.convertToEntityAttribute(sqliteValue);
+
+            assertEquals(Timestamp.class, result.getClass());
+            assertEquals(value, result);
+        }
+
+        @Test
+        void sqlDateConverterReadsEpochMillisStringFromSqlite() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            java.sql.Date value = java.sql.Date.valueOf("2026-03-03");
+            String sqliteValue = Long.toString(value.getTime());
+
+            java.sql.Date result = converter.convertToEntityAttribute(sqliteValue);
+
+            assertEquals(java.sql.Date.class, result.getClass());
+            assertEquals(value, result);
+        }
+
+        @Test
+        void sqlTimeConverterReadsEpochMillisStringFromSqlite() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            Time value = Time.valueOf("09:05:07");
+            String sqliteValue = Long.toString(value.getTime());
+
+            Time result = converter.convertToEntityAttribute(sqliteValue);
+
+            assertEquals(Time.class, result.getClass());
+            assertEquals(value, result);
+        }
+
+        @Test
+        void sqlTimestampConverterReadsEpochMillisNumber() {
+            AttributeConverter<Timestamp, Object> converter = converterFor(Timestamp.class);
+            Timestamp value = Timestamp.valueOf("2026-03-03 12:15:45");
+
+            Timestamp result = converter.convertToEntityAttribute(value.getTime());
+
+            assertEquals(Timestamp.class, result.getClass());
+            assertEquals(value, result);
+        }
+
+        @Test
+        void sqlDateConverterReadsEpochMillisNumber() {
+            AttributeConverter<java.sql.Date, Object> converter = converterFor(java.sql.Date.class);
+            java.sql.Date value = java.sql.Date.valueOf("2026-03-03");
+
+            java.sql.Date result = converter.convertToEntityAttribute(value.getTime());
+
+            assertEquals(java.sql.Date.class, result.getClass());
+            assertEquals(value, result);
+        }
+
+        @Test
+        void sqlTimeConverterReadsEpochMillisNumber() {
+            AttributeConverter<Time, Object> converter = converterFor(Time.class);
+            Time value = Time.valueOf("09:05:07");
+
+            Time result = converter.convertToEntityAttribute(value.getTime());
+
+            assertEquals(Time.class, result.getClass());
+            assertEquals(value, result);
         }
     }
 

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/methodHandler/QueryMethodHandlerScalarSqlTemporalTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/methodHandler/QueryMethodHandlerScalarSqlTemporalTest.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.data.jdbc.methodHandler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Column;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Id;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.IdStrategy;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Query;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Table;
+import tech.guilhermekaua.spigotboot.data.jdbc.connection.ConnectionProvider;
+import tech.guilhermekaua.spigotboot.data.jdbc.converter.BuiltInConverters;
+import tech.guilhermekaua.spigotboot.data.jdbc.converter.TypeConverterRegistry;
+import tech.guilhermekaua.spigotboot.data.jdbc.dialect.Dialect;
+import tech.guilhermekaua.spigotboot.data.jdbc.dialect.SQLiteDialect;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadata;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadataParser;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadataRegistry;
+
+import java.lang.reflect.Method;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class QueryMethodHandlerScalarSqlTemporalTest {
+    private TypeConverterRegistry converterRegistry;
+    private EntityMetadataRegistry metadataRegistry;
+    private EntityMetadata entityMetadata;
+    private Dialect dialect;
+
+    @BeforeEach
+    void setUp() {
+        converterRegistry = new TypeConverterRegistry();
+        BuiltInConverters.registerAll(converterRegistry);
+        metadataRegistry = new EntityMetadataRegistry(new EntityMetadataParser(converterRegistry));
+        entityMetadata = metadataRegistry.getOrParse(EventEntity.class);
+        dialect = new SQLiteDialect();
+    }
+
+    @Test
+    void scalarTimestampReturnReadsLocalDateTimeFromMySql() throws Exception {
+        // mysql-connector-j 8.x returns java.time.LocalDateTime from a DATETIME/TIMESTAMP column
+        LocalDateTime mysqlValue = LocalDateTime.of(2026, 3, 3, 12, 15, 45);
+
+        Object result = executeScalar("latestCreatedAt", mysqlValue);
+
+        assertEquals(Timestamp.valueOf(mysqlValue), result);
+    }
+
+    @Test
+    void scalarDateReturnReadsLocalDateFromMySql() throws Exception {
+        // mysql-connector-j 8.x returns java.time.LocalDate from a DATE column
+        LocalDate mysqlValue = LocalDate.of(2026, 3, 3);
+
+        Object result = executeScalar("earliestEventDate", mysqlValue);
+
+        assertEquals(java.sql.Date.class, result.getClass());
+        assertEquals(java.sql.Date.valueOf(mysqlValue), result);
+    }
+
+    @Test
+    void scalarTimeReturnReadsLocalTimeFromMySql() throws Exception {
+        // mysql-connector-j 8.x returns java.time.LocalTime from a TIME column
+        LocalTime mysqlValue = LocalTime.of(9, 5, 7);
+
+        Object result = executeScalar("earliestEventTime", mysqlValue);
+
+        assertEquals(Time.class, result.getClass());
+        assertEquals(Time.valueOf(mysqlValue), result);
+    }
+
+    private Object executeScalar(String methodName, Object dbValue) throws Exception {
+        ConnectionProvider connectionProvider = mock(ConnectionProvider.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement preparedStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+
+        when(connectionProvider.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement(anyString())).thenReturn(preparedStatement);
+        when(preparedStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getObject(1)).thenReturn(dbValue);
+
+        QueryMethodHandler handler = new QueryMethodHandler(connectionProvider, metadataRegistry, converterRegistry);
+        Method method = EventRepository.class.getMethod(methodName);
+        return handler.execute(method, new Object[0], entityMetadata, dialect);
+    }
+
+    @Table("events")
+    public static final class EventEntity {
+        @Id(strategy = IdStrategy.IDENTITY)
+        @Column("id")
+        private Long id;
+
+        @Column("created_at")
+        private Timestamp createdAt;
+
+        public EventEntity() {
+        }
+    }
+
+    interface EventRepository {
+        @Query("SELECT created_at FROM events ORDER BY created_at DESC LIMIT 1")
+        Timestamp latestCreatedAt();
+
+        @Query("SELECT event_date FROM events ORDER BY event_date ASC LIMIT 1")
+        java.sql.Date earliestEventDate();
+
+        @Query("SELECT event_time FROM events ORDER BY event_time ASC LIMIT 1")
+        Time earliestEventTime();
+    }
+}

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/repository/JdbcRepositorySqlTemporalRoundTripTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/repository/JdbcRepositorySqlTemporalRoundTripTest.java
@@ -93,7 +93,9 @@ class JdbcRepositorySqlTemporalRoundTripTest {
 
     @Test
     void roundTripsSqlTemporalFieldsThroughSqlite() {
-        Timestamp createdAt = Timestamp.valueOf("2026-03-03 12:15:45");
+        // millisecond precision survives the SQLite epoch-millis round trip; sub-millisecond
+        // nanoseconds are truncated because the value is stored as epoch millis (a known constraint)
+        Timestamp createdAt = Timestamp.valueOf("2026-03-03 12:15:45.123");
         java.sql.Date eventDate = java.sql.Date.valueOf("2026-03-03");
         Time eventTime = Time.valueOf("09:05:07");
 

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/repository/JdbcRepositorySqlTemporalRoundTripTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/repository/JdbcRepositorySqlTemporalRoundTripTest.java
@@ -1,0 +1,173 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.data.jdbc.repository;
+
+import com.zaxxer.hikari.HikariDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Column;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Id;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.IdStrategy;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Table;
+import tech.guilhermekaua.spigotboot.data.jdbc.connection.ConnectionProvider;
+import tech.guilhermekaua.spigotboot.data.jdbc.converter.BuiltInConverters;
+import tech.guilhermekaua.spigotboot.data.jdbc.converter.TypeConverterRegistry;
+import tech.guilhermekaua.spigotboot.data.jdbc.ddl.DdlGenerator;
+import tech.guilhermekaua.spigotboot.data.jdbc.dialect.Dialect;
+import tech.guilhermekaua.spigotboot.data.jdbc.dialect.SQLiteDialect;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadata;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadataParser;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadataRegistry;
+import tech.guilhermekaua.spigotboot.data.jdbc.repository.impl.JdbcRepositoryImpl;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.Statement;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JdbcRepositorySqlTemporalRoundTripTest {
+    private Path databaseFile;
+    private HikariDataSource dataSource;
+    private ConnectionProvider connectionProvider;
+    private JdbcRepositoryImpl<SqlTemporalRow, Long> repository;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        databaseFile = Files.createTempFile("data-jdbc-sql-temporal", ".db");
+
+        dataSource = new HikariDataSource();
+        dataSource.setJdbcUrl("jdbc:sqlite:" + toSqlitePath(databaseFile));
+        dataSource.setMaximumPoolSize(1);
+
+        connectionProvider = new ConnectionProvider(dataSource);
+        Dialect dialect = new SQLiteDialect();
+
+        TypeConverterRegistry converterRegistry = new TypeConverterRegistry();
+        BuiltInConverters.registerAll(converterRegistry);
+
+        EntityMetadataRegistry metadataRegistry = new EntityMetadataRegistry(new EntityMetadataParser(converterRegistry));
+        EntityMetadata metadata = metadataRegistry.getOrParse(SqlTemporalRow.class);
+
+        DdlGenerator ddlGenerator = new DdlGenerator(dialect, metadataRegistry);
+        createTable(ddlGenerator.generateCreateTable(metadata));
+
+        repository = new JdbcRepositoryImpl<>(connectionProvider, metadata, dialect, metadataRegistry);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (dataSource != null) {
+            dataSource.close();
+        }
+
+        if (databaseFile != null) {
+            Files.deleteIfExists(databaseFile);
+        }
+    }
+
+    @Test
+    void roundTripsSqlTemporalFieldsThroughSqlite() {
+        Timestamp createdAt = Timestamp.valueOf("2026-03-03 12:15:45");
+        java.sql.Date eventDate = java.sql.Date.valueOf("2026-03-03");
+        Time eventTime = Time.valueOf("09:05:07");
+
+        SqlTemporalRow row = new SqlTemporalRow();
+        row.setCreatedAt(createdAt);
+        row.setEventDate(eventDate);
+        row.setEventTime(eventTime);
+
+        repository.insert(row);
+
+        List<SqlTemporalRow> rows = repository.findAll();
+        assertEquals(1, rows.size());
+
+        SqlTemporalRow loaded = rows.get(0);
+        assertEquals(createdAt, loaded.getCreatedAt());
+        assertEquals(eventDate, loaded.getEventDate());
+        assertEquals(eventTime, loaded.getEventTime());
+    }
+
+    private void createTable(String ddl) throws Exception {
+        try (Connection connection = connectionProvider.getConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(ddl);
+        }
+    }
+
+    private String toSqlitePath(Path path) {
+        return path.toAbsolutePath().toString().replace('\\', '/');
+    }
+
+    @Table("sql_temporal_rows")
+    public static final class SqlTemporalRow {
+        @Id(strategy = IdStrategy.IDENTITY)
+        @Column("id")
+        private Long id;
+
+        @Column("created_at")
+        private Timestamp createdAt;
+
+        @Column("event_date")
+        private java.sql.Date eventDate;
+
+        @Column("event_time")
+        private Time eventTime;
+
+        public SqlTemporalRow() {
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public Timestamp getCreatedAt() {
+            return createdAt;
+        }
+
+        public void setCreatedAt(Timestamp createdAt) {
+            this.createdAt = createdAt;
+        }
+
+        public java.sql.Date getEventDate() {
+            return eventDate;
+        }
+
+        public void setEventDate(java.sql.Date eventDate) {
+            this.eventDate = eventDate;
+        }
+
+        public Time getEventTime() {
+            return eventTime;
+        }
+
+        public void setEventTime(Time eventTime) {
+            this.eventTime = eventTime;
+        }
+    }
+}

--- a/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/repository/mapper/EntityRowMapperSqlTemporalTest.java
+++ b/modules/data-jdbc/src/test/java/tech/guilhermekaua/spigotboot/data/jdbc/repository/mapper/EntityRowMapperSqlTemporalTest.java
@@ -1,0 +1,112 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.data.jdbc.repository.mapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Column;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Id;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.IdStrategy;
+import tech.guilhermekaua.spigotboot.data.jdbc.annotation.Table;
+import tech.guilhermekaua.spigotboot.data.jdbc.converter.BuiltInConverters;
+import tech.guilhermekaua.spigotboot.data.jdbc.converter.TypeConverterRegistry;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadata;
+import tech.guilhermekaua.spigotboot.data.jdbc.metadata.EntityMetadataParser;
+
+import java.sql.ResultSet;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EntityRowMapperSqlTemporalTest {
+    private EntityMetadata metadata;
+
+    @BeforeEach
+    void setUp() {
+        TypeConverterRegistry registry = new TypeConverterRegistry();
+        BuiltInConverters.registerAll(registry);
+        metadata = new EntityMetadataParser(registry).parse(SqlTemporalEntity.class);
+    }
+
+    @Test
+    void mapsMySqlJavaTimeValuesIntoSqlTemporalFields() throws Exception {
+        // mysql-connector-j 8.x returns java.time.* from DATETIME/DATE/TIME columns
+        LocalDateTime createdAt = LocalDateTime.of(2026, 3, 3, 12, 15, 45);
+        LocalDate eventDate = LocalDate.of(2026, 3, 3);
+        LocalTime eventTime = LocalTime.of(9, 5, 7);
+
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.getObject("id")).thenReturn(1L);
+        when(rs.getObject("created_at")).thenReturn(createdAt);
+        when(rs.getObject("event_date")).thenReturn(eventDate);
+        when(rs.getObject("event_time")).thenReturn(eventTime);
+
+        EntityRowMapper<SqlTemporalEntity> mapper = new EntityRowMapper<>(metadata);
+        SqlTemporalEntity entity = mapper.mapRow(rs);
+
+        assertEquals(Timestamp.valueOf(createdAt), entity.getCreatedAt());
+        assertEquals(java.sql.Date.valueOf(eventDate), entity.getEventDate());
+        assertEquals(Time.valueOf(eventTime), entity.getEventTime());
+    }
+
+    @Table("events")
+    public static final class SqlTemporalEntity {
+        @Id(strategy = IdStrategy.IDENTITY)
+        @Column("id")
+        private Long id;
+
+        @Column("created_at")
+        private Timestamp createdAt;
+
+        @Column("event_date")
+        private java.sql.Date eventDate;
+
+        @Column("event_time")
+        private Time eventTime;
+
+        public SqlTemporalEntity() {
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public Timestamp getCreatedAt() {
+            return createdAt;
+        }
+
+        public java.sql.Date getEventDate() {
+            return eventDate;
+        }
+
+        public Time getEventTime() {
+            return eventTime;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #81. Entity fields and scalar `@Query` returns declared as **`java.sql.Timestamp`, `java.sql.Date`, or `java.sql.Time`** got **no converter**, so on MySQL the read failed with `IllegalArgumentException` (*argument type mismatch*, wrapped as *Failed to map ResultSet row to ...*) or a `ClassCastException` for scalar returns.

### Root cause
- `TypeConverterRegistry.getConverter(Class)` is an exact-key lookup, and `BuiltInConverters.registerAll(...)` never registered the `java.sql.*` subclasses.
- So `EntityMetadataParser.resolveConverter` returns `null` for these fields, and both read paths — `EntityRowMapper.coerceType` (entity fields) and `QueryMethodHandler.convertScalarValue` (scalar `@Query`) — fall through and pass the raw DB value straight into the `java.sql.*` target.
- mysql-connector-j 8.x returns `java.time.LocalDateTime`/`LocalDate`/`LocalTime` from `getObject()`, so `field.set(...)` then throws. SQLite returns these columns as an **epoch-millis `String`** (TEXT affinity), which the literal-only parse helpers also couldn't read.

### Fix
Register dedicated `SqlTimestampConverter` / `SqlDateConverter` / `SqlTimeConverter` (issue's suggested option 1) that return the **exact** `java.sql.*` type and accept every shape the drivers produce:
- `java.time.LocalDateTime`/`LocalDate`/`LocalTime` (mysql-connector-j)
- `java.sql.*` / `java.util.Date` passthrough (SQLite direct, `java.util.Date` fields)
- epoch-millis `String` and `Number` (SQLite TEXT round-trip), mirroring the existing `parseInstant` handling

A plain assignable fallback to `DateConverter` does **not** work — it returns a `java.util.Date`, which isn't assignable to a `java.sql.Timestamp` field. Registering on the registry fixes **both** read paths at once. The **write path** (`EntityParameterBinder`) and **DDL generation** are unchanged: the converters' database-side type is `Object`, so `DdlGenerator` falls back to the field type exactly as before (no regression).

> Note: this PR is independent of the #79/#80 fix (which lives on a separate branch and handles the `java.time.*` converters); these new converters are self-contained.

## Affected modules
- `modules/data-jdbc` only.

## Tests
- **`BuiltInConvertersTest`** — registration + every input shape per type (MySQL `java.time.*`, passthrough, round-trip, epoch-millis `String`, `Number`), asserting exact return class.
- **`EntityRowMapperSqlTemporalTest`** — entity-field read path, mocked `ResultSet` returning the `java.time.*` shapes mysql-connector-j returns.
- **`QueryMethodHandlerScalarSqlTemporalTest`** — scalar `@Query` return path, mocked driver chain.
- **`JdbcRepositorySqlTemporalRoundTripTest`** — real SQLite insert→read round-trip (reproduced the originally-shipped SQLite failure, now green).

Verified locally with JDK 21: `mvnw.cmd -pl modules/data-jdbc -am test` → **68 tests, 0 failures**, upstream modules green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)