### PR TITLE
feat(inventory-api): slot-targeted empty-state and loading frames for pagination

### DIFF
--- a/docs/superpowers/plans/2026-06-18-pagination-slot-targeted-frames.md
+++ b/docs/superpowers/plans/2026-06-18-pagination-slot-targeted-frames.md
@@ -15,8 +15,12 @@
 - **Java 8 language level** for all main sources in `platform-spigot/inventory-api/api` (`pom.xml` `<source>1.8</source>`): no records, no `var`, no `List.of()`/`Stream.toList()`. Use `int[]`, `LinkedHashSet`, `Collections.emptyList()`, explicit loops.
 - **MIT license header** (copy verbatim from any sibling file) on every new file; complete Javadoc (`@param`/`@return`/`@throws`) on every new/changed public and protected API.
 - **Build with JDK 21.** The shell-default JDK 25 crashes Lombok 1.18.36 (`TypeTag :: UNKNOWN`). If Maven runs in a sandbox, disable the sandbox (`dangerouslyDisableSandbox`) or edits run against a stale overlay.
-- **Test command:** run from repo root. Per-task iteration may add `-Danimal.sniffer.skip=true` (this feature adds no Java-8-incompatible code; the skip only avoids needing the build-internal 1.8 signature jar). Example:
-  `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBuilderImplTest`
+- **Canonical test command (verified working in this environment):** run from the worktree root with the JDK-21 `JAVA_HOME` and the Maven sandbox disabled. The `-Dsurefire.failIfNoSpecifiedTests=false` flag is REQUIRED whenever `-Dtest=` is used with `-am`, because the filter also reaches upstream reactor modules (e.g. `spigot-boot-utils`) that lack the named test and would otherwise fail the build:
+  ```
+  JAVA_HOME="C:/Users/Guilherme/.jdks/ms-21.0.10" ./mvnw -q -pl platform-spigot/inventory-api/api -am test \
+    -Danimal.sniffer.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=<TestClassOrPattern>
+  ```
+  All `Run:` lines in the tasks below are shorthand for WHICH test to run — execute them with this canonical recipe, substituting the named class(es) into `-Dtest=`. The full-suite run in Task 5 Step 5 drops `-Dtest`/`-Dsurefire.failIfNoSpecifiedTests` (and may keep `-Danimal.sniffer.skip=true`).
 - **Absolute slots everywhere** (0 .. rows*9 - 1), consistent with `Layout.ofSlots` and component slots.
 - **Commit after each task** with a Conventional Commit message (`feat:`/`test:`).
 

--- a/docs/superpowers/plans/2026-06-18-pagination-slot-targeted-frames.md
+++ b/docs/superpowers/plans/2026-06-18-pagination-slot-targeted-frames.md
@@ -1,0 +1,1268 @@
+# Slot-targeted empty-state and loading frames — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a paginated view paint its empty-state and loading frame items into specific absolute slots instead of across the whole pagination layout.
+
+**Architecture:** A new builder method `emptyStateItem(fn, int... slots)` and a `loadingItem(fn, int... slots)` overload record the item + slots on `PaginationSpec`. `PaginationBinding.repaint()` becomes mode-based (loading-slots → empty-slots → normal engine fill), painting frame items at the chosen slots and clearing the rest via the existing `applyToSlot` path. The engine's `insertPageItems()` is unchanged except for a new `Paginator.isCurrentPageEmpty()` query. Open-time validation rejects frame slots that collide with a static component or another pagination.
+
+**Tech Stack:** Java 8, Maven (wrapper), JUnit 5, Mockito, MockBukkit.
+
+**Spec:** `docs/superpowers/specs/2026-06-18-pagination-slot-targeted-frames-design.md`
+
+## Global Constraints
+
+- **Java 8 language level** for all main sources in `platform-spigot/inventory-api/api` (`pom.xml` `<source>1.8</source>`): no records, no `var`, no `List.of()`/`Stream.toList()`. Use `int[]`, `LinkedHashSet`, `Collections.emptyList()`, explicit loops.
+- **MIT license header** (copy verbatim from any sibling file) on every new file; complete Javadoc (`@param`/`@return`/`@throws`) on every new/changed public and protected API.
+- **Build with JDK 21.** The shell-default JDK 25 crashes Lombok 1.18.36 (`TypeTag :: UNKNOWN`). If Maven runs in a sandbox, disable the sandbox (`dangerouslyDisableSandbox`) or edits run against a stale overlay.
+- **Test command:** run from repo root. Per-task iteration may add `-Danimal.sniffer.skip=true` (this feature adds no Java-8-incompatible code; the skip only avoids needing the build-internal 1.8 signature jar). Example:
+  `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBuilderImplTest`
+- **Absolute slots everywhere** (0 .. rows*9 - 1), consistent with `Layout.ofSlots` and component slots.
+- **Commit after each task** with a Conventional Commit message (`feat:`/`test:`).
+
+## File Structure
+
+Main sources (all in `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/`):
+- `pagination/PaginationBuilder.java` — interface: add `emptyStateItem(fn, slots)` + `loadingItem(fn, slots)`.
+- `internal/pagination/PaginationBuilderImpl.java` — fields, the two methods, slot validation, reset `loadingSlots` in the no-slots overload, wire `build()`.
+- `internal/pagination/PaginationSpec.java` — carry `emptyStateItem`, `emptyStateSlots`, `loadingSlots` + accessors.
+- `internal/pagination/engine/Paginator.java` — add `isCurrentPageEmpty()`.
+- `internal/pagination/engine/AbstractPageSourcePagination.java` — implement `isCurrentPageEmpty()`.
+- `internal/pagination/PaginationBinding.java` — resolve frame slots + bounds in `initialize`, mode-based `repaint()`, `paintFrameMode`/`clearSlots`/`frameSlots()`.
+- `internal/engine/phase/FirstRenderPhase.java` — extend `validatePaginationOverlap`.
+
+Tests:
+- `internal/pagination/PaginationBuilderImplTest.java` — builder validation/storage (modify).
+- `internal/pagination/PaginationBindingTest.java` — `isCurrentPageEmpty`, render modes, bounds (modify; the `specOf` helper must be updated for the new constructor).
+- `internal/engine/PaginationFrameSlotFlowsTest.java` — open-path overlap rejection + happy-path empty-state/loading flows (create; modeled on `PaginationOpenWiringTest`).
+
+---
+
+### Task 1: Configuration layer — carry empty-state and loading-slot declarations
+
+**Files:**
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSpec.java`
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/PaginationBuilder.java`
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImpl.java`
+- Test: `platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImplTest.java`
+- Compile-fix: `platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java` (the `specOf` helper)
+
+**Interfaces:**
+- Produces:
+  - `PaginationBuilder.emptyStateItem(Function<ViewContext, ItemStack> item, int... slots): PaginationBuilder<T>`
+  - `PaginationBuilder.loadingItem(Function<ViewContext, ItemStack> item, int... slots): PaginationBuilder<T>`
+  - `PaginationSpec.emptyStateItem(): Function<ViewContext, ItemStack>` (nullable)
+  - `PaginationSpec.emptyStateSlots(): int[]` (clone, empty when unset)
+  - `PaginationSpec.loadingSlots(): int[]` (clone, empty when unset)
+  - `PaginationSpec` constructor gains three trailing params: `Function<ViewContext, ItemStack> emptyStateItem, int[] emptyStateSlots, int[] loadingSlots`.
+
+- [ ] **Step 1: Extend the `PaginationSpec` constructor and add fields + accessors**
+
+In `PaginationSpec.java`, add three fields after `cacheMaxPages` (line ~101):
+
+```java
+    private final int cacheMaxPages;
+    private final Function<ViewContext, ItemStack> emptyStateItem;
+    private final int[] emptyStateSlots;
+    private final int[] loadingSlots;
+```
+
+Change the constructor signature: after the `int cacheMaxPages) {` parameter add three params, and add three `@param` lines to the Javadoc:
+
+```java
+     * @param cacheMaxPages  the async cache LRU bound; 128 unless overridden (the 2.x default)
+     * @param emptyStateItem the item painted at {@code emptyStateSlots} when the current page is
+     *                       empty, or null when no empty-state is declared
+     * @param emptyStateSlots the absolute slots the empty-state item paints into; never null,
+     *                       empty when no empty-state is declared
+     * @param loadingSlots   the absolute slots the loading item paints into; never null, empty
+     *                       when the loading item fills the whole layout (the default)
+```
+
+```java
+                   @Nullable Duration cacheTtl,
+                   int cacheMaxPages,
+                   @Nullable Function<ViewContext, ItemStack> emptyStateItem,
+                   int[] emptyStateSlots,
+                   int[] loadingSlots) {
+```
+
+At the end of the constructor body (after `this.cacheMaxPages = cacheMaxPages;`) add:
+
+```java
+        this.cacheMaxPages = cacheMaxPages;
+        this.emptyStateItem = emptyStateItem;
+        this.emptyStateSlots = emptyStateSlots == null ? new int[0] : emptyStateSlots.clone();
+        this.loadingSlots = loadingSlots == null ? new int[0] : loadingSlots.clone();
+```
+
+Add three accessors after `cacheMaxPages()` (line ~276):
+
+```java
+    /**
+     * Returns the empty-state item painted at {@link #emptyStateSlots()} when the current page
+     * settled with no elements.
+     *
+     * @return the empty-state item factory, or null when no empty-state is declared
+     */
+    public @Nullable Function<ViewContext, ItemStack> emptyStateItem() {
+        return emptyStateItem;
+    }
+
+    /**
+     * Returns the absolute slots the empty-state item paints into.
+     *
+     * @return a defensive copy; empty when no empty-state is declared
+     */
+    public int[] emptyStateSlots() {
+        return emptyStateSlots.clone();
+    }
+
+    /**
+     * Returns the absolute slots the loading item paints into.
+     *
+     * @return a defensive copy; empty when the loading item fills the whole layout
+     */
+    public int[] loadingSlots() {
+        return loadingSlots.clone();
+    }
+```
+
+- [ ] **Step 2: Update the two call sites so the module compiles**
+
+In `PaginationBuilderImpl.build()` (line ~197) change the `new PaginationSpec<>(...)` call to pass the new builder fields (added in Step 4):
+
+```java
+        PaginationSpec<T> spec = new PaginationSpec<>(geometry, target, layoutChar, explicitLayout,
+                patterns == null ? Collections.<Layout>emptyList() : patterns, renderer, fallbackItem,
+                loadingItem, source, errorCallback, requestTimeout, cacheTtl, cacheMaxPages,
+                emptyStateItem, emptyStateSlots, loadingSlots);
+```
+
+In `PaginationBindingTest.specOf(...)` (line ~208) append the three new arguments:
+
+```java
+        return new PaginationSpec<>(geometry, target, layoutChar, explicitLayout, patterns,
+                renderer, fallbackItem, null, source, null, null, null, 128,
+                null, new int[0], new int[0]);
+```
+
+(`PaginationBuilderImpl` references `emptyStateItem`/`emptyStateSlots`/`loadingSlots` fields that are added in Step 4 — do Steps 3–4 in the same edit so the module compiles before running tests.)
+
+- [ ] **Step 3: Add the interface methods with full Javadoc**
+
+In `PaginationBuilder.java`, add after `fallbackItem(...)` (line ~124):
+
+```java
+    /**
+     * Sets an item painted into the given slots when the current page settled with no elements,
+     * leaving every other layout slot empty. Unlike {@link #fallbackItem(Function)} — which fills
+     * every uncovered slot of every page — this renders only while the current page is empty, and
+     * only in {@code slots}; when the page has any element it renders nothing. When both are set,
+     * the empty page shows the empty-state item (the fallback fill is suppressed for that paint).
+     *
+     * <p>Slots are absolute container slots and may lie outside the pagination's layout. Evaluated
+     * against the session's context once per slot at paint time. A slot bound to a static component
+     * or to another pagination fails at open with {@link ViewConfigurationException}.
+     *
+     * @param item  the empty-state item factory
+     * @param slots the absolute container slots to paint, at least one, each non-negative
+     * @return this builder
+     * @throws NullPointerException     if {@code item} or {@code slots} is null
+     * @throws IllegalArgumentException if {@code slots} is empty or contains a negative slot
+     */
+    @NotNull PaginationBuilder<T> emptyStateItem(@NotNull Function<ViewContext, ItemStack> item,
+                                                 int... slots);
+```
+
+And add after the existing `loadingItem(Function)` (line ~133):
+
+```java
+    /**
+     * Sets the loading item painted only into the given slots while an async load is in flight,
+     * leaving every other layout slot empty. The slotted form of {@link #loadingItem(Function)};
+     * it has the same trigger (shown while loading) and only restricts where the item paints.
+     * Async-only: on a non-async builder {@link #build()} throws {@link ViewConfigurationException}.
+     *
+     * <p>Slots are absolute container slots and may lie outside the pagination's layout. Evaluated
+     * against the session's context once per slot at paint time. A slot bound to a static component
+     * or to another pagination fails at open with {@link ViewConfigurationException}.
+     *
+     * @param item  the loading item factory
+     * @param slots the absolute container slots to paint, at least one, each non-negative
+     * @return this builder
+     * @throws NullPointerException     if {@code item} or {@code slots} is null
+     * @throws IllegalArgumentException if {@code slots} is empty or contains a negative slot
+     */
+    @NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item,
+                                              int... slots);
+```
+
+- [ ] **Step 4: Implement the methods + validation in `PaginationBuilderImpl`**
+
+Add the import `import java.util.LinkedHashSet;` (next to the other `java.util` imports).
+
+Add three fields after `fallbackItem`/`loadingItem` (line ~72):
+
+```java
+    private Function<ViewContext, ItemStack> loadingItem;
+    private Function<ViewContext, ItemStack> emptyStateItem;
+    private int[] emptyStateSlots = new int[0];
+    private int[] loadingSlots = new int[0];
+```
+
+Replace the existing no-slots `loadingItem(Function)` method body so it resets `loadingSlots`:
+
+```java
+    @Override
+    public @NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item) {
+        this.loadingItem = Objects.requireNonNull(item, "item");
+        this.loadingSlots = new int[0];
+        return this;
+    }
+```
+
+Add the two new methods (after the no-slots `loadingItem`):
+
+```java
+    @Override
+    public @NotNull PaginationBuilder<T> emptyStateItem(@NotNull Function<ViewContext, ItemStack> item,
+                                                        int... slots) {
+        this.emptyStateItem = Objects.requireNonNull(item, "item");
+        this.emptyStateSlots = validatedFrameSlots(slots, "emptyStateItem");
+        return this;
+    }
+
+    @Override
+    public @NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item,
+                                                     int... slots) {
+        this.loadingItem = Objects.requireNonNull(item, "item");
+        this.loadingSlots = validatedFrameSlots(slots, "loadingItem");
+        return this;
+    }
+
+    // validates and de-duplicates frame slots (empty-state / slotted loading), preserving order
+    private static int[] validatedFrameSlots(int[] slots, String method) {
+        Objects.requireNonNull(slots, "slots");
+        if (slots.length == 0) {
+            throw new IllegalArgumentException(method + " requires at least one slot");
+        }
+        LinkedHashSet<Integer> unique = new LinkedHashSet<>();
+        for (int slot : slots) {
+            if (slot < 0) {
+                throw new IllegalArgumentException(method + " slot must not be negative: " + slot);
+            }
+            unique.add(slot);
+        }
+        int[] result = new int[unique.size()];
+        int index = 0;
+        for (int slot : unique) {
+            result[index++] = slot;
+        }
+        return result;
+    }
+```
+
+- [ ] **Step 5: Write the failing builder tests**
+
+In `PaginationBuilderImplTest.java` add imports:
+
+```java
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.ViewContext;
+import java.util.function.Function;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+```
+
+Add these tests:
+
+```java
+    @Test
+    void emptyStateItem_storesFunctionAndDeduplicatedSlots() {
+        Function<ViewContext, ItemStack> fn = ctx -> new ItemStack(Material.BARRIER);
+        PaginationImpl<String> token = (PaginationImpl<String>) eagerBuilder(new TestView())
+                .itemRenderer(renderer()).emptyStateItem(fn, 22, 22, 4).build();
+
+        assertSame(fn, token.spec().emptyStateItem());
+        assertArrayEquals(new int[]{22, 4}, token.spec().emptyStateSlots());
+    }
+
+    @Test
+    void emptyStateItem_nullFunction_throwsNpe() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        assertThrows(NullPointerException.class, () -> builder.emptyStateItem(null, 1));
+    }
+
+    @Test
+    void emptyStateItem_noSlots_throwsIllegalArgument() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.emptyStateItem(ctx -> new ItemStack(Material.BARRIER)));
+    }
+
+    @Test
+    void emptyStateItem_negativeSlot_throwsIllegalArgument() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 0, -1));
+    }
+
+    @Test
+    void loadingItem_withSlots_storesDeduplicatedSlots_onAsyncBuilder() {
+        PaginationImpl<String> token = (PaginationImpl<String>) asyncBuilder(new TestView())
+                .itemRenderer(renderer())
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD), 4, 4)
+                .build();
+
+        assertArrayEquals(new int[]{4}, token.spec().loadingSlots());
+    }
+
+    @Test
+    void loadingItem_withSlots_onEagerSource_throwsAsyncOnly() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        builder.itemRenderer(renderer()).loadingItem(ctx -> new ItemStack(Material.EMERALD), 4);
+
+        ViewConfigurationException thrown = assertThrows(ViewConfigurationException.class, builder::build);
+        assertTrue(thrown.getMessage().contains("loadingItem"));
+    }
+
+    @Test
+    void loadingItem_withoutSlots_resetsToFillAll() {
+        PaginationImpl<String> token = (PaginationImpl<String>) asyncBuilder(new TestView())
+                .itemRenderer(renderer())
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD), 4)
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD))
+                .build();
+
+        assertEquals(0, token.spec().loadingSlots().length);
+    }
+
+    @Test
+    void defaults_noEmptyStateItemNorFrameSlots() {
+        PaginationSpec<String> spec = ((PaginationImpl<String>) eagerBuilder(new TestView())
+                .itemRenderer(renderer()).build()).spec();
+
+        assertNull(spec.emptyStateItem());
+        assertEquals(0, spec.emptyStateSlots().length);
+        assertEquals(0, spec.loadingSlots().length);
+    }
+```
+
+- [ ] **Step 6: Run the tests — expect compile success and PASS**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBuilderImplTest`
+Expected: PASS (all old and new tests). If `PaginationBindingTest` fails to compile, the `specOf` helper edit from Step 2 is missing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/PaginationBuilder.java \
+        platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImpl.java \
+        platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSpec.java \
+        platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImplTest.java \
+        platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+git commit -m "feat: declare slot-targeted empty-state and loading frames on the pagination builder"
+```
+
+---
+
+### Task 2: `Paginator.isCurrentPageEmpty()` query
+
+**Files:**
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/Paginator.java`
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AbstractPageSourcePagination.java`
+- Test: `platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java`
+
+**Interfaces:**
+- Consumes: `PaginationBinding.paginator(): Paginator<?>` (existing), `binding.initialize(...)` (existing).
+- Produces: `Paginator.isCurrentPageEmpty(): boolean` — whether the most recently settled page rendered no elements.
+
+- [ ] **Step 1: Write the failing test**
+
+In `PaginationBindingTest.java` add:
+
+```java
+    @Test
+    void isCurrentPageEmpty_trueForEmptySource_falseWhenItemsPresent() {
+        ViewSession emptySession = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding empty = new PaginationBinding(
+                layoutCharSpec(amountRenderer(), PaginationSourceSpec.eager(Collections.<Integer>emptyList())),
+                0, emptySession, engine);
+        empty.initialize(emptySession.layout(), emptySession.effectiveConfig());
+        assertTrue(empty.paginator().isCurrentPageEmpty());
+
+        ViewSession itemsSession = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding withItems = new PaginationBinding(
+                layoutCharSpec(amountRenderer(), PaginationSourceSpec.eager(Arrays.asList(1, 2))),
+                0, itemsSession, engine);
+        withItems.initialize(itemsSession.layout(), itemsSession.effectiveConfig());
+        assertFalse(withItems.paginator().isCurrentPageEmpty());
+    }
+```
+
+- [ ] **Step 2: Run it — expect compile failure**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBindingTest#isCurrentPageEmpty_trueForEmptySource_falseWhenItemsPresent`
+Expected: FAIL — `isCurrentPageEmpty()` is not defined on `Paginator`.
+
+- [ ] **Step 3: Add the interface method**
+
+In `Paginator.java`, after `insertPageItems();` (line ~58) add:
+
+```java
+    /**
+     * Reports whether the most recently settled page rendered no elements. Used by the host to
+     * decide whether to paint the empty-state frame.
+     *
+     * @return {@code true} when the current page has no elements
+     */
+    boolean isCurrentPageEmpty();
+```
+
+- [ ] **Step 4: Implement it in `AbstractPageSourcePagination`**
+
+After `insertPageItems()` (line ~192) add:
+
+```java
+    @Override
+    public boolean isCurrentPageEmpty() {
+        return this.currentItems.isEmpty();
+    }
+```
+
+- [ ] **Step 5: Run the test — expect PASS**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBindingTest#isCurrentPageEmpty_trueForEmptySource_falseWhenItemsPresent`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/Paginator.java \
+        platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AbstractPageSourcePagination.java \
+        platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+git commit -m "feat: add Paginator.isCurrentPageEmpty query"
+```
+
+---
+
+### Task 3: `PaginationBinding` — frame-slot resolution, bounds, and empty-state rendering
+
+**Files:**
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java`
+- Test: `platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java`
+
+**Interfaces:**
+- Consumes: `PaginationSpec.emptyStateItem()/emptyStateSlots()/loadingSlots()` (Task 1), `Paginator.isCurrentPageEmpty()` (Task 2), existing `applyToSlot`, `frameSupplier`, `targetSlots`, `RenderedItem.ofItem(null)`.
+- Produces: `PaginationBinding.frameSlots(): int[]` — the de-duplicated union of empty-state and loading slots (for Task 5 validation). `repaint()` now paints the empty-state frame when the current page is empty.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `PaginationBindingTest.java` add the import `import java.util.concurrent.atomic.AtomicInteger;` and a spec helper plus tests:
+
+```java
+    // spec carrying an empty-state frame (LAYOUT_CHAR 'O', normal geometry)
+    private static <T> PaginationSpec<T> emptyStateSpec(PaginationItemRenderer<T> renderer,
+                                                        PaginationSourceSpec<T> source,
+                                                        Function<ViewContext, ItemStack> fallbackItem,
+                                                        Function<ViewContext, ItemStack> emptyStateItem,
+                                                        int[] emptyStateSlots) {
+        return new PaginationSpec<>(PaginationSpec.Geometry.NORMAL, PaginationSpec.Target.LAYOUT_CHAR,
+                'O', null, Collections.emptyList(), renderer, fallbackItem, null, source,
+                null, null, null, 128, emptyStateItem, emptyStateSlots, new int[0]);
+    }
+
+    @Test
+    void emptyState_emptyPage_paintsItemAtChosenSlotsAndClearsRestOfLayout() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Collections.<Integer>emptyList()),
+                        null, ctx -> new ItemStack(Material.BARRIER), new int[]{3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(Material.BARRIER, inventory.getItem(3).getType());
+        assertNull(inventory.getItem(2), "non-chosen layout slots clear when the page is empty");
+        assertNull(inventory.getItem(4));
+    }
+
+    @Test
+    void emptyState_pageWithItems_paintsNoEmptyState_andKeepsFallbackFill() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Arrays.asList(1, 2)),
+                        ctx -> new ItemStack(Material.STONE),
+                        ctx -> new ItemStack(Material.BARRIER), new int[]{3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(1, inventory.getItem(2).getAmount(), "elements render normally");
+        assertEquals(2, inventory.getItem(3).getAmount(), "chosen slot shows the element, not the empty-state");
+        assertEquals(Material.STONE, inventory.getItem(4).getType(), "uncovered slot keeps the fallback fill");
+    }
+
+    @Test
+    void emptyState_evaluatesItemOncePerSlot() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        AtomicInteger counter = new AtomicInteger();
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Collections.<Integer>emptyList()),
+                        null, ctx -> new ItemStack(Material.BARRIER, counter.incrementAndGet()),
+                        new int[]{2, 3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(1, inventory.getItem(2).getAmount());
+        assertEquals(2, inventory.getItem(3).getAmount(), "the factory runs once per chosen slot");
+    }
+
+    @Test
+    void emptyState_outsideLayoutSlot_paintedWhenEmpty_clearedOnTransitionToItems() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        AtomicReference<List<Integer>> backing = new AtomicReference<>(Collections.<Integer>emptyList());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.lazy(context -> backing.get()),
+                        null, ctx -> new ItemStack(Material.BARRIER), new int[]{7}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+        assertEquals(Material.BARRIER, session.inventory().getItem(7).getType(),
+                "the outside empty-state slot is painted while empty");
+
+        backing.set(Arrays.asList(1, 2, 3));
+        binding.refreshLazy(new PlainViewContextImpl(session, engine));
+        binding.repaint();
+
+        assertNull(session.inventory().getItem(7), "the outside empty-state slot clears once items arrive");
+        assertEquals(1, session.inventory().getItem(2).getAmount());
+    }
+
+    @Test
+    void initialize_emptyStateSlotOutOfBounds_throwsNamingSlotAndKind() {
+        // layoutConfig is a single row (size 9): slot 9 is out of bounds
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Arrays.asList(1)),
+                        null, ctx -> new ItemStack(Material.BARRIER), new int[]{9}),
+                0, session, engine);
+
+        ViewConfigurationException error = assertThrows(ViewConfigurationException.class,
+                () -> binding.initialize(session.layout(), session.effectiveConfig()));
+        assertTrue(error.getMessage().contains("slot 9"));
+        assertTrue(error.getMessage().contains("empty-state"));
+    }
+```
+
+- [ ] **Step 2: Run them — expect FAIL**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBindingTest`
+Expected: the new tests FAIL — empty-state is not yet painted (e.g. slot 3 is null / slot 9 does not throw).
+
+- [ ] **Step 3: Add frame-slot fields and resolution in `PaginationBinding`**
+
+Add fields after `targetSlots` (line ~114):
+
+```java
+    private int[] targetSlots = new int[0];
+
+    // frame slots resolved at initialize; emptyState/loading slots may lie outside targetSlots
+    private int[] emptyStateSlots = new int[0];
+    private int[] loadingSlots = new int[0];
+    private int[] ownedOutsideSlots = new int[0];
+    private Supplier<RenderedItem> emptyStateSupplier;
+```
+
+In `initialize(...)`, immediately after `this.targetSlots = resolveTargetSlots(fillLayout, patterns);` (line ~199) add:
+
+```java
+        this.targetSlots = resolveTargetSlots(fillLayout, patterns);
+        this.emptyStateSlots = spec.emptyStateSlots();
+        this.loadingSlots = spec.loadingSlots();
+        checkFrameSlotBounds(this.emptyStateSlots, "empty-state", effectiveConfig);
+        checkFrameSlotBounds(this.loadingSlots, "loading", effectiveConfig);
+        this.ownedOutsideSlots = outsideLayout(this.emptyStateSlots, this.loadingSlots, this.targetSlots);
+```
+
+After the existing `this.loadingSupplier = frameSupplier(spec.loadingItem(), "loading item");` (line ~204) add:
+
+```java
+        this.emptyStateSupplier = frameSupplier(spec.emptyStateItem(), "empty-state item");
+```
+
+- [ ] **Step 4: Add the helper methods and `frameSlots()` accessor**
+
+Add near `checkBounds(...)` (line ~455):
+
+```java
+    private void checkFrameSlotBounds(int[] slots, String label, ViewConfig effectiveConfig) {
+        int size = effectiveConfig.rows() * Layout.ROW_WIDTH;
+        for (int slot : slots) {
+            if (slot >= size) {
+                throw new ViewConfigurationException("pagination " + label + " slot " + slot
+                        + " is out of bounds for a " + effectiveConfig.rows() + "-row view of "
+                        + session.registered().type().getName());
+            }
+        }
+    }
+
+    // the frame slots that fall outside the pagination's own layout, de-duplicated in order
+    private static int[] outsideLayout(int[] emptyStateSlots, int[] loadingSlots, int[] layout) {
+        Set<Integer> layoutSet = new LinkedHashSet<>();
+        for (int slot : layout) {
+            layoutSet.add(slot);
+        }
+        LinkedHashSet<Integer> outside = new LinkedHashSet<>();
+        for (int slot : emptyStateSlots) {
+            if (!layoutSet.contains(slot)) {
+                outside.add(slot);
+            }
+        }
+        for (int slot : loadingSlots) {
+            if (!layoutSet.contains(slot)) {
+                outside.add(slot);
+            }
+        }
+        int[] result = new int[outside.size()];
+        int index = 0;
+        for (int slot : outside) {
+            result[index++] = slot;
+        }
+        return result;
+    }
+```
+
+Add the public accessor after `targetSlots()` (line ~258):
+
+```java
+    /**
+     * Returns the empty-state and loading frame slots this binding paints into, de-duplicated.
+     *
+     * @return a defensive copy of the frame slots; empty when no frame slots are declared
+     */
+    public @NotNull int[] frameSlots() {
+        LinkedHashSet<Integer> union = new LinkedHashSet<>();
+        for (int slot : emptyStateSlots) {
+            union.add(slot);
+        }
+        for (int slot : loadingSlots) {
+            union.add(slot);
+        }
+        int[] result = new int[union.size()];
+        int index = 0;
+        for (int slot : union) {
+            result[index++] = slot;
+        }
+        return result;
+    }
+```
+
+- [ ] **Step 5: Make `repaint()` mode-based and add the paint/clear helpers**
+
+Replace the existing `repaint()` body (line ~295):
+
+```java
+    public void repaint() {
+        // full passes may reach a binding whose initialize aborted mid-open (the abort
+        // tears the session down right after); painting nothing is the safe behavior
+        if (paginator == null) {
+            return;
+        }
+        Inventory inventory = session.inventory();
+        if (inventory == null) {
+            return;
+        }
+        boolean applyPlaceholders = session.effectiveConfig().applyPlaceholders();
+        boolean loading = paginator.isLoading();
+        boolean empty = !loading && paginator.isCurrentPageEmpty();
+
+        if (empty && emptyStateSlots.length > 0) {
+            paintFrameMode(inventory, emptyStateSupplier, emptyStateSlots, applyPlaceholders);
+        } else {
+            paginator.insertPageItems();
+            clearSlots(inventory, ownedOutsideSlots, applyPlaceholders);
+        }
+    }
+
+    // paints the frame item at each frame slot (one supplier call per slot, so each slot gets a
+    // fresh ItemStack) and clears every other slot this binding owns (layout + owned-outside)
+    private void paintFrameMode(Inventory inventory, Supplier<RenderedItem> supplier,
+                                int[] frameSlots, boolean applyPlaceholders) {
+        Set<Integer> chosen = new LinkedHashSet<>();
+        for (int slot : frameSlots) {
+            chosen.add(slot);
+        }
+        for (int slot : frameSlots) {
+            applyToSlot(inventory, slot, supplier.get(), applyPlaceholders);
+        }
+        for (int slot : targetSlots) {
+            if (!chosen.contains(slot)) {
+                applyToSlot(inventory, slot, RenderedItem.ofItem(null), applyPlaceholders);
+            }
+        }
+        for (int slot : ownedOutsideSlots) {
+            if (!chosen.contains(slot)) {
+                applyToSlot(inventory, slot, RenderedItem.ofItem(null), applyPlaceholders);
+            }
+        }
+    }
+
+    private void clearSlots(Inventory inventory, int[] slots, boolean applyPlaceholders) {
+        for (int slot : slots) {
+            applyToSlot(inventory, slot, RenderedItem.ofItem(null), applyPlaceholders);
+        }
+    }
+```
+
+(No new imports needed: `Inventory`, `Set`, `LinkedHashSet`, `Supplier`, `RenderedItem` are already imported in this file.)
+
+- [ ] **Step 6: Run the tests — expect PASS**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBindingTest`
+Expected: PASS (new empty-state tests and all existing binding tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java \
+        platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+git commit -m "feat: render slot-targeted empty-state frame in PaginationBinding"
+```
+
+---
+
+### Task 4: `PaginationBinding` — loading-state slots
+
+**Files:**
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java`
+- Test: `platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java`
+
+**Interfaces:**
+- Consumes: `paintFrameMode`, `loadingSupplier`, `loadingSlots`, `ownedOutsideSlots` (Task 3); existing `loadingSupplier` field.
+- Produces: `repaint()` paints the loading frame only at `loadingSlots` while loading (when any are declared).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `PaginationBindingTest.java` add a stuck-loading source double and a spec helper plus tests:
+
+```java
+    /** a source that never settles and always reports loading */
+    static final class LoadingPageSource implements PageSource<Integer> {
+        @Override
+        public void request(PageRequest request, BiConsumer<PageResult<Integer>, Throwable> onSettle) {
+            // never settles: stays loading
+        }
+
+        @Override
+        public int totalElements() {
+            return 0;
+        }
+
+        @Override
+        public boolean totalsKnown() {
+            return false;
+        }
+
+        @Override
+        public boolean isLoading() {
+            return true;
+        }
+
+        @Override
+        public Throwable lastError() {
+            return null;
+        }
+
+        @Override
+        public List<Integer> elements() {
+            return Collections.emptyList();
+        }
+    }
+
+    // spec carrying a loading frame with explicit slots (LAYOUT_CHAR 'O', normal geometry)
+    private static <T> PaginationSpec<T> loadingSlotsSpec(PaginationItemRenderer<T> renderer,
+                                                          PaginationSourceSpec<T> source,
+                                                          Function<ViewContext, ItemStack> loadingItem,
+                                                          int[] loadingSlots) {
+        return new PaginationSpec<>(PaginationSpec.Geometry.NORMAL, PaginationSpec.Target.LAYOUT_CHAR,
+                'O', null, Collections.emptyList(), renderer, null, loadingItem, source,
+                null, null, null, 128, null, new int[0], loadingSlots);
+    }
+
+    @Test
+    void loading_withSlots_paintsLoadingItemAtChosenSlotsAndClearsRest() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[]{3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(Material.EMERALD, inventory.getItem(3).getType());
+        assertNull(inventory.getItem(2), "non-chosen layout slots clear while loading");
+        assertNull(inventory.getItem(4));
+    }
+
+    @Test
+    void loading_withSlots_paintsOutsideLayoutSlot() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[]{7}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        assertEquals(Material.EMERALD, session.inventory().getItem(7).getType());
+        assertNull(session.inventory().getItem(2), "layout cleared; only the chosen loading slot painted");
+    }
+
+    @Test
+    void loading_withoutSlots_stillFillsAllLayoutSlots() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[0]),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(Material.EMERALD, inventory.getItem(2).getType());
+        assertEquals(Material.EMERALD, inventory.getItem(3).getType());
+        assertEquals(Material.EMERALD, inventory.getItem(4).getType());
+    }
+
+    @Test
+    void initialize_loadingSlotOutOfBounds_throwsNamingSlotAndKind() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[]{9}),
+                0, session, engine);
+
+        ViewConfigurationException error = assertThrows(ViewConfigurationException.class,
+                () -> binding.initialize(session.layout(), session.effectiveConfig()));
+        assertTrue(error.getMessage().contains("slot 9"));
+        assertTrue(error.getMessage().contains("loading"));
+    }
+```
+
+- [ ] **Step 2: Run them — expect FAIL**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBindingTest#loading_withSlots_paintsLoadingItemAtChosenSlotsAndClearsRest+loading_withSlots_paintsOutsideLayoutSlot`
+Expected: FAIL — without the loading branch, `insertPageItems()` fills all layout slots (slot 2 is EMERALD, not null).
+
+(The `loading_withoutSlots_stillFillsAllLayoutSlots` and `initialize_loadingSlotOutOfBounds...` tests already pass after Task 3 — the bounds check covers `loadingSlots` and the legacy fill path is unchanged; run them too to confirm no regression.)
+
+- [ ] **Step 3: Add the loading-slots branch to `repaint()`**
+
+In `PaginationBinding.repaint()`, insert the loading branch **before** the empty-state branch:
+
+```java
+        if (loading && loadingSlots.length > 0) {
+            paintFrameMode(inventory, loadingSupplier, loadingSlots, applyPlaceholders);
+        } else if (empty && emptyStateSlots.length > 0) {
+            paintFrameMode(inventory, emptyStateSupplier, emptyStateSlots, applyPlaceholders);
+        } else {
+            paginator.insertPageItems();
+            clearSlots(inventory, ownedOutsideSlots, applyPlaceholders);
+        }
+```
+
+- [ ] **Step 4: Run the tests — expect PASS**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationBindingTest`
+Expected: PASS (all loading tests and the full binding suite).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java \
+        platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+git commit -m "feat: render slot-targeted loading frame in PaginationBinding"
+```
+
+---
+
+### Task 5: Open-time overlap validation + end-to-end flows
+
+**Files:**
+- Modify: `platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java`
+- Create: `platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java`
+
+**Interfaces:**
+- Consumes: `PaginationBinding.frameSlots()` (Task 3), `PaginationBindings.of(session)` (existing), `session.components().componentAt(slot)` (existing), the whole feature from Tasks 1–4.
+- Produces: `FirstRenderPhase.validatePaginationOverlap` now also rejects frame slots that collide with a static component or another pagination.
+
+This test file is modeled on the existing `PaginationOpenWiringTest` (same `engine.open` / `sessions.find` / `CapturingHandler` patterns); a new file is used rather than editing `PaginationSampleFlowsTest` so the open-flow template is exactly the known-good one.
+
+- [ ] **Step 1: Write the failing tests (create the file)**
+
+Create `PaginationFrameSlotFlowsTest.java` with the MIT header copied from `PaginationOpenWiringTest.java`, then:
+
+```java
+package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
+import tech.guilhermekaua.spigotboot.inventoryapi.View;
+import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseReason;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.RenderContext;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.engine.phase.FirstRenderPhase;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.registry.ViewRegistry;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.render.SlotPainter;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.SessionRegistry;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.ViewSession;
+import tech.guilhermekaua.spigotboot.inventoryapi.layout.Layout;
+import tech.guilhermekaua.spigotboot.inventoryapi.pagination.Pagination;
+import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.PageResult;
+import tech.guilhermekaua.spigotboot.inventoryapi.placeholder.NoopPlaceholderApplier;
+import tech.guilhermekaua.spigotboot.inventoryapi.service.ViewArguments;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaginationFrameSlotFlowsTest {
+
+    private ServerMock server;
+    private Plugin plugin;
+    private SessionRegistry sessions;
+    private ViewRegistry views;
+    private ViewEngine engine;
+    private PlayerMock player;
+
+    private final ComponentConflictView componentConflictView = new ComponentConflictView();
+    private final TwoPaginationConflictView twoPaginationConflictView = new TwoPaginationConflictView();
+    private final EmptyStateView emptyStateView = new EmptyStateView();
+    private final AsyncEmptyStateView asyncEmptyStateView = new AsyncEmptyStateView();
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.createMockPlugin();
+        player = server.addPlayer("tester");
+        sessions = new SessionRegistry();
+        views = new ViewRegistry();
+        views.register(componentConflictView);
+        views.register(twoPaginationConflictView);
+        views.register(emptyStateView);
+        views.register(asyncEmptyStateView);
+        engine = new ViewEngine(plugin, views, sessions,
+                new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
+        }, new BukkitPlatformScheduler(plugin));
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.getScheduler().cancelTasks(plugin);
+        MockBukkit.unmock();
+    }
+
+    // ---------------------------------------------------------------- fixture views
+
+    static final class ComponentConflictView extends View {
+        CloseReason lastCloseReason;
+        final Pagination<String> pagination = this.<String>paginate(Collections.<String>emptyList())
+                .layout(Layout.ofSlots(0, 1))
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 8)
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("Conflict").rows(1);
+        }
+
+        @Override
+        protected void onFirstRender(@NotNull RenderContext context) {
+            context.slot(8, new ItemStack(Material.STONE)); // collides with the empty-state frame slot
+        }
+
+        @Override
+        protected void onClose(@NotNull CloseContext context) {
+            lastCloseReason = context.reason();
+        }
+    }
+
+    static final class TwoPaginationConflictView extends View {
+        CloseReason lastCloseReason;
+        final Pagination<String> a = this.<String>paginate(Collections.<String>emptyList())
+                .layout(Layout.ofSlots(0, 1))
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 4) // 4 is pagination b's target
+                .build();
+        final Pagination<String> b = this.<String>paginate(Collections.singletonList("x"))
+                .layout(Layout.ofSlots(3, 4))
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("TwoPag").rows(1);
+        }
+
+        @Override
+        protected void onClose(@NotNull CloseContext context) {
+            lastCloseReason = context.reason();
+        }
+    }
+
+    static final class EmptyStateView extends View {
+        final Pagination<String> pagination = this.<String>paginate(Collections.<String>emptyList())
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 4)
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("EmptyState").layout("OOOOOOOOO");
+        }
+    }
+
+    static final class AsyncEmptyStateView extends View {
+        final Map<UUID, CompletableFuture<PageResult<String>>> futures = new ConcurrentHashMap<>();
+        final Pagination<String> pagination = this.<String>paginateAsync(request -> {
+            CompletableFuture<PageResult<String>> future = new CompletableFuture<>();
+            futures.put(request.playerId(), future);
+            return future;
+        })
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD), 4)
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 4)
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("AsyncEmpty").layout("OOOOOOOOO");
+        }
+    }
+
+    // ---------------------------------------------------------------- tests
+
+    @Test
+    void emptyStateSlotOnComponent_abortsOpenFailed() {
+        Logger logger = Logger.getLogger(FirstRenderPhase.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            engine.open(player, ComponentConflictView.class, ViewArguments.empty());
+
+            assertFalse(sessions.find(player.getUniqueId()).isPresent(),
+                    "the overlap must abort the open, registering nothing");
+            assertEquals(CloseReason.OPEN_FAILED, componentConflictView.lastCloseReason);
+            assertTrue(handler.hasThrownContaining("a pagination frame item"));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void frameSlotOnAnotherPagination_abortsOpenFailed() {
+        Logger logger = Logger.getLogger(FirstRenderPhase.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            engine.open(player, TwoPaginationConflictView.class, ViewArguments.empty());
+
+            assertFalse(sessions.find(player.getUniqueId()).isPresent());
+            assertEquals(CloseReason.OPEN_FAILED, twoPaginationConflictView.lastCloseReason);
+            assertTrue(handler.hasThrownContaining("two paginations"));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void eagerEmptySource_paintsEmptyStateOnOpen() {
+        engine.open(player, EmptyStateView.class, ViewArguments.empty());
+
+        ViewSession session = sessions.find(player.getUniqueId()).orElseThrow(IllegalStateException::new);
+        Inventory inventory = session.inventory();
+        assertEquals(Material.BARRIER, inventory.getItem(4).getType());
+        assertNull(inventory.getItem(0), "the rest of the layout is empty");
+        assertNull(inventory.getItem(8));
+    }
+
+    @Test
+    void async_showsLoadingSlot_thenEmptyStateAfterSettlingEmpty() {
+        engine.open(player, AsyncEmptyStateView.class, ViewArguments.empty());
+
+        ViewSession session = sessions.find(player.getUniqueId()).orElseThrow(IllegalStateException::new);
+        Inventory inventory = session.inventory();
+        // in flight: the loading slot shows the loading item, the rest of the layout is empty
+        assertEquals(Material.EMERALD, inventory.getItem(4).getType());
+        assertNull(inventory.getItem(0));
+
+        // settle empty on the main thread: the inline settle repaints
+        asyncEmptyStateView.futures.get(player.getUniqueId())
+                .complete(PageResult.of(Collections.<String>emptyList(), 0));
+
+        assertEquals(Material.BARRIER, inventory.getItem(4).getType(),
+                "settled-empty replaces the loading frame with the empty-state frame");
+        assertNull(inventory.getItem(0));
+    }
+
+    private static final class CapturingHandler extends Handler {
+        private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+        boolean hasThrownContaining(String fragment) {
+            for (LogRecord record : records) {
+                Throwable thrown = record.getThrown();
+                if (thrown != null && thrown.getMessage() != null
+                        && thrown.getMessage().contains(fragment)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run them — expect the overlap tests to FAIL**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationFrameSlotFlowsTest`
+Expected: `eagerEmptySource_...` and `async_...` PASS (the feature works end-to-end already), but the two overlap tests FAIL — `validatePaginationOverlap` does not yet inspect frame slots, so the conflicting views open instead of aborting.
+
+- [ ] **Step 3: Extend `validatePaginationOverlap` in `FirstRenderPhase`**
+
+Add the import `import java.util.List;` to `FirstRenderPhase.java`. Replace the `validatePaginationOverlap` method (line ~142):
+
+```java
+    // overlap validation (§5.3/§6): a slot cannot be both statically bound and a pagination
+    // target; frame slots (empty-state / loading) must not collide with a component or another
+    // pagination. runs inside the try so the failure flows into the OPEN_FAILED abort path.
+    private void validatePaginationOverlap(ViewSession session) {
+        List<PaginationBinding> bindings = PaginationBindings.of(session);
+        for (PaginationBinding binding : bindings) {
+            for (int slot : binding.targetSlots()) {
+                if (session.components().componentAt(slot) != null) {
+                    throw new ViewConfigurationException(
+                            "slot " + slot + " is bound to both a component and pagination");
+                }
+            }
+            for (int slot : binding.frameSlots()) {
+                if (session.components().componentAt(slot) != null) {
+                    throw new ViewConfigurationException(
+                            "slot " + slot + " is bound to both a component and a pagination frame item");
+                }
+                for (PaginationBinding other : bindings) {
+                    if (other == binding) {
+                        continue;
+                    }
+                    if (contains(other.targetSlots(), slot) || contains(other.frameSlots(), slot)) {
+                        throw new ViewConfigurationException(
+                                "slot " + slot + " is bound to two paginations");
+                    }
+                }
+            }
+        }
+    }
+
+    private static boolean contains(int[] slots, int value) {
+        for (int slot : slots) {
+            if (slot == value) {
+                return true;
+            }
+        }
+        return false;
+    }
+```
+
+- [ ] **Step 4: Run the tests — expect PASS**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test -Danimal.sniffer.skip=true -Dtest=PaginationFrameSlotFlowsTest`
+Expected: PASS (all four tests).
+
+- [ ] **Step 5: Run the full module suite (no skip) to confirm no regressions**
+
+Run: `mvnw.cmd -q -pl platform-spigot/inventory-api/api -am test`
+Expected: BUILD SUCCESS. (On a fresh clone, if animal-sniffer fails because the 1.8 signature jar is missing, first run `mvnw.cmd -pl spigot-api-1_8-signature install`, then re-run.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java \
+        platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java
+git commit -m "feat: reject frame slots overlapping a component or another pagination at open"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+- §4.1 `emptyStateItem` API → Task 1 (interface + impl + tests). ✓
+- §4.2 `loadingItem` overload (async-only) → Task 1 (impl + async-only test). ✓
+- §5 precedence (loading-slots → empty-slots → normal; empty-state suppresses fallback fill) → Task 3 (`emptyState_pageWithItems_...`) + Task 4 (loading branch ordering). ✓
+- §5 decorative/inert frame items, no click change → relies on existing `applyToSlot` frame path (no `elementComponents` entry); no production change needed; covered implicitly by render tests. ✓
+- §5 per-slot evaluation → Task 3 (`emptyState_evaluatesItemOncePerSlot`). ✓
+- §6.1 spec carries values → Task 1. ✓
+- §6.3 `isCurrentPageEmpty()` → Task 2. ✓
+- §6.4 binding render + `ownedOutsideSlots` clear + bounds + `frameSlots()` → Tasks 3 & 4. ✓
+- §6.5 component + cross-pagination overlap → Task 5. ✓
+- §7 backward compat (`loadingItem(fn)` fill-all, `fallbackItem` intact) → Task 1 (`loadingItem_withoutSlots_resetsToFillAll`), Task 3 (`emptyState_pageWithItems_...`), Task 4 (`loading_withoutSlots_stillFillsAllLayoutSlots`). ✓
+- §8 tests (builder, binding, overlap, integration) → Tasks 1, 3, 4, 5. ✓
+
+**2. Placeholder scan** — No `TBD`/`TODO`/"handle edge cases"/"similar to Task N"; every code step shows complete code. ✓
+
+**3. Type consistency** — `emptyStateSlots`/`loadingSlots`/`emptyStateItem` names and `int[]`/`Function<ViewContext, ItemStack>` types are identical across `PaginationSpec`, `PaginationBuilderImpl`, and `PaginationBinding`. `frameSlots()`, `paintFrameMode`, `clearSlots`, `outsideLayout`, `checkFrameSlotBounds`, `validatedFrameSlots`, `isCurrentPageEmpty`, `contains` are each defined once and referenced consistently. The `PaginationSpec` constructor's three trailing params (`emptyStateItem, emptyStateSlots, loadingSlots`) match every call site (`build()`, `specOf`, `emptyStateSpec`, `loadingSlotsSpec`). ✓
+
+## Execution Handoff
+
+(Filled in by the brainstorming/writing-plans flow after the plan is saved.)

--- a/docs/superpowers/specs/2026-06-18-pagination-slot-targeted-frames-design.md
+++ b/docs/superpowers/specs/2026-06-18-pagination-slot-targeted-frames-design.md
@@ -1,0 +1,299 @@
+# Slot-targeted empty-state and loading frames for pagination — Design Spec
+
+- **Date:** 2026-06-18
+- **Module:** `platform-spigot/inventory-api/api`
+- **Status:** Approved by user (brainstorming session)
+- **Branch:** `feat/inventory-api/choose-fallback-slot`
+
+## 1. Goal
+
+Let a paginated view show a frame item in **specific slots** rather than across the whole
+pagination layout, for two render states:
+
+- **Empty state** — when the current page settled with zero items, paint an item only in
+  chosen slot(s) and leave the rest of the layout empty. Enables the common "minimalist GUI
+  that shows a single centered *no results* item" without the current
+  `slot N is bound to both a component and pagination` error.
+- **Loading state** — while an async page load is in flight, paint the loading item only in
+  chosen slot(s) (e.g. a single centered spinner) and leave the rest empty.
+
+Today both states fill **every** layout slot:
+
+```java
+paginateAsync(this::loadPage)
+    .layoutChar('O')
+    .fallbackItem(ctx -> new ItemStack(Material.BARRIER)); // shows on ALL layout slots
+```
+
+Target:
+
+```java
+paginateAsync(this::loadPage)
+    .layoutChar('O')
+    .itemRenderer(...)
+    .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 22) // only slot 22 when empty
+    .loadingItem(ctx -> new ItemStack(Material.CLOCK), 22);     // only slot 22 while loading
+```
+
+**Non-goals (YAGNI):** overriding a static component while empty/loading; relative (layout-indexed)
+coordinates; a per-slot item callback (different item per slot); any "whole pagination is empty
+across all pages" notion beyond "the current page has zero items"; changing the behavior of
+`fallbackItem(fn)` or `loadingItem(fn)` (both keep their current fill-all semantics).
+
+## 2. Language level
+
+Main sources of this module compile at **Java 8** (`platform-spigot/inventory-api/api/pom.xml`,
+`<source>1.8</source>`). No records, no `var`, no `List.of()`/`Stream.toList()`. Use `int[]`,
+`Collections.emptyList()`, `LinkedHashSet`, explicit loops. All new/changed public and protected
+APIs carry the MIT license header and complete Javadoc (`@param`/`@return`/`@throws`) per CLAUDE.md.
+
+## 3. Decisions (locked during brainstorming)
+
+1. **Empty-state trigger:** renders **only** when the current page settled with zero items, in
+   the chosen slot(s); all other layout slots are cleared. A partially-filled page shows no
+   empty-state. `fallbackItem(fn)` keeps its current "fill every empty layout slot" behavior.
+2. **Empty-state API:** a **dedicated** builder method `emptyStateItem(fn, int... slots)` — its
+   trigger differs from `fallbackItem` (only-when-empty vs. always-fill), so a distinct name is
+   clearer than overloading `fallbackItem`.
+3. **Loading API:** an **overload** `loadingItem(fn, int... slots)` — the slotted form has the
+   **same** trigger as `loadingItem(fn)` (shown while loading), it only restricts *where*, so an
+   overload is the natural fit (a second "loading item" method name would be redundant).
+4. **Coordinates:** **absolute** inventory slots (0–53), consistent with the rest of the API
+   (`Layout.ofSlots`, component slots). They **may point anywhere** in the container, not only at
+   the pagination's own layout slots.
+5. **Collision rule:** a frame slot that lands on a **static component** is **rejected at open**
+   with `ViewConfigurationException` (same posture as the existing component/pagination overlap
+   check). A frame slot that lands on a **different** pagination's target or frame slots is also
+   rejected. A frame slot **may** coincide with its own pagination's layout slots (the slot-22
+   case) — that is the normal use.
+
+## 4. Public API — `PaginationBuilder<T>`
+
+`PaginationBuilder` is `@ApiStatus.NonExtendable`; the methods are added to the interface and
+implemented in `PaginationBuilderImpl`. Both are available on every `paginate*` builder.
+`emptyStateItem` works for eager and async sources (like `fallbackItem`); `loadingItem` (both
+overloads) remains **async-only** (`build()` throws `ViewConfigurationException` on a non-async
+builder, via the existing `firstAsyncOnlyOption()` check, which already keys on `loadingItem`).
+
+### 4.1 `emptyStateItem`
+
+```java
+/**
+ * Sets an item painted into the given slots when the current page settled with no elements,
+ * leaving every other layout slot empty. Unlike {@link #fallbackItem(Function)} — which fills
+ * every uncovered slot of every page — this renders only while the current page is empty, and
+ * only in {@code slots}; when the page has any element it renders nothing. When both are set,
+ * the empty page shows the empty-state item (the fallback fill is suppressed for that paint).
+ *
+ * <p>Slots are absolute container slots and may lie outside the pagination's layout. Evaluated
+ * against the session's context once per slot at paint time. A slot bound to a static component
+ * or to another pagination fails at open with {@link ViewConfigurationException}.
+ *
+ * @param item  the empty-state item factory
+ * @param slots the absolute container slots to paint, at least one, each non-negative
+ * @return this builder
+ * @throws NullPointerException     if {@code item} or {@code slots} is null
+ * @throws IllegalArgumentException if {@code slots} is empty or contains a negative slot
+ */
+@NotNull PaginationBuilder<T> emptyStateItem(@NotNull Function<ViewContext, ItemStack> item,
+                                             int... slots);
+```
+
+### 4.2 `loadingItem` overload
+
+```java
+/**
+ * Sets the loading item painted only into the given slots while an async load is in flight,
+ * leaving every other layout slot empty. The slotted form of {@link #loadingItem(Function)};
+ * it has the same trigger (shown while loading) and only restricts where the item paints.
+ * Async-only: on a non-async builder {@link #build()} throws {@link ViewConfigurationException}.
+ *
+ * <p>Slots are absolute container slots and may lie outside the pagination's layout. Evaluated
+ * against the session's context once per slot at paint time. A slot bound to a static component
+ * or to another pagination fails at open with {@link ViewConfigurationException}.
+ *
+ * @param item  the loading item factory
+ * @param slots the absolute container slots to paint, at least one, each non-negative
+ * @return this builder
+ * @throws NullPointerException     if {@code item} or {@code slots} is null
+ * @throws IllegalArgumentException if {@code slots} is empty or contains a negative slot
+ */
+@NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item,
+                                          int... slots);
+```
+
+The existing no-slots `loadingItem(Function)` is unchanged. Java overload resolution selects the
+non-varargs method for `loadingItem(fn)` and the varargs method only when an explicit slot list is
+passed, so `loadingItem(fn)` keeps fill-all behavior. `emptyStateItem` has **no** no-slots
+overload; calling it with no slots throws `IllegalArgumentException` (there is no sensible
+"all slots" default distinct from `fallbackItem`).
+
+## 5. Semantics & precedence
+
+The empty-state / loading-slots frames are **decorative and inert**, exactly like `fallbackItem`
+today: they are painted as frame items, never registered as element components, so
+`ClickRoutingPhase` resolves no component for them (`PaginationBindings.componentAt` reads only
+`elementComponents`) and a click on them follows the view's default click policy. No click-routing
+change is required, including for frame slots outside the layout.
+
+Per repaint, the binding selects exactly one render mode and paints its owned slots
+deterministically. "Owned outside slots" = the empty-state and loading slots that are **not**
+in the pagination's own layout (`targetSlots`):
+
+| Render state | Chosen frame slots | Other layout slots | Owned outside slots |
+|---|---|---|---|
+| Loading **and** `loadingItem` has slots | loading item | cleared | loading item (if chosen) / cleared |
+| Loading, `loadingItem` has no slots / none | today's `loadingOrFallback` over **all** layout slots | — | cleared |
+| Settled empty **and** `emptyStateItem` has slots | empty-state item | cleared | empty-state item (if chosen) / cleared |
+| Settled, page has elements | elements + `fallbackItem` fill (today) | — | cleared |
+| Settled empty, no `emptyStateItem` | today's `emptyOrFallback` over **all** layout slots | — | cleared |
+
+Mode selection precedence: **loading-with-slots** → **empty-with-slots** → **normal engine fill**.
+"Loading" wins over "empty" because a page in flight is not yet known to be empty. When both
+`fallbackItem` and `emptyStateItem` are set and the page is empty, the empty-state frame takes the
+slots and the rest of the layout is cleared (the fill-all is suppressed for that paint), matching
+decision 1. The frame item function is evaluated **once per slot** so each slot receives a fresh
+`ItemStack` (avoids mutable-stack aliasing across slots).
+
+A frame slot may be shared by both features for the same pagination (e.g. `loadingItem(spinner, 22)`
+and `emptyStateItem(barrier, 22)`): the modes are mutually exclusive per paint, so slot 22 shows the
+spinner while loading, the barrier when settled empty, and an element/clear otherwise — no conflict,
+no validation error.
+
+## 6. Internal design
+
+### 6.1 `PaginationSpec<T>` (`internal.pagination`)
+Add two carried values plus accessors: `emptyStateItem` (`Function<ViewContext, ItemStack>`, nullable),
+`emptyStateSlots` (`int[]`, empty when unset), and `loadingSlots` (`int[]`, empty when unset; the
+existing `loadingItem` function is reused). Store defensive copies; arrays returned by accessors are
+clones. Constructor stays package-private; `PaginationBuilderImpl` and same-package tests construct it.
+
+### 6.2 `PaginationBuilderImpl<T>`
+- New fields `Function<ViewContext, ItemStack> emptyStateItem`, `int[] emptyStateSlots = {}`,
+  `int[] loadingSlots = {}`.
+- `emptyStateItem(fn, slots)` and `loadingItem(fn, slots)`: `Objects.requireNonNull` both args;
+  throw `IllegalArgumentException` when `slots.length == 0` or any slot `< 0`; store the fn and a
+  **de-duplicated, order-preserving** copy of `slots` (e.g. via `LinkedHashSet<Integer>`).
+- `loadingItem(fn, slots)` sets the shared `loadingItem` field (so the async-only check still
+  fires) and `loadingSlots`; the existing `loadingItem(fn)` sets `loadingItem` and resets
+  `loadingSlots = {}`.
+- `build()` passes the three new values into the `PaginationSpec` constructor. No new
+  combination validation in `validate()` — async-only is already covered by `loadingItem != null`.
+
+### 6.3 `Paginator` + `AbstractPageSourcePagination`
+Add one query so the binding can detect the empty mode without reaching into geometry state:
+
+```java
+/** @return whether the most recently settled page rendered no elements */
+boolean isCurrentPageEmpty();
+```
+
+Implemented in `AbstractPageSourcePagination` as `return this.currentItems.isEmpty();` (the field is
+already `volatile`). The three concrete paginations inherit it. `insertPageItems()` is **unchanged**
+and remains the "normal engine fill" path (rows 2 and 5 of the §5 table).
+
+### 6.4 `PaginationBinding`
+This class already owns the painter, `targetSlots`, `lastApplied`, `elementComponents`, the
+`PlainViewContextImpl`, and the `applyToSlot` frame path — so all new painting lives here.
+
+- **`initialize(...)`:** after resolving `targetSlots`, build `this.emptyStateSupplier =
+  frameSupplier(spec.emptyStateItem(), "empty-state item");` (mirrors the existing
+  `fallbackSupplier`/`loadingSupplier`). Capture `emptyStateSlots`/`loadingSlots` from the spec and
+  precompute `ownedOutsideSlots = (emptyStateSlots ∪ loadingSlots) \ targetSlots`. Bounds-check the
+  frame slots here, alongside the existing `checkBounds` for layout/pattern slots:
+  each slot `< effectiveConfig.rows() * Layout.ROW_WIDTH`, else `ViewConfigurationException`.
+- **`repaint()`:** replace the body with mode selection:
+
+  ```text
+  if (paginator == null) return;
+  inventory = session.inventory(); if (inventory == null) return;
+  applyPlaceholders = session.effectiveConfig().applyPlaceholders();
+  loading = paginator.isLoading();
+  empty   = !loading && paginator.isCurrentPageEmpty();
+
+  if (loading && loadingSlots.length > 0)
+      paintFrameMode(inventory, loadingSupplier, loadingSlots, applyPlaceholders);
+  else if (empty && emptyStateSlots.length > 0)
+      paintFrameMode(inventory, emptyStateSupplier, emptyStateSlots, applyPlaceholders);
+  else {
+      paginator.insertPageItems();                                  // paints targetSlots
+      clearSlots(inventory, ownedOutsideSlots, applyPlaceholders);  // outside slots reset
+  }
+  ```
+
+  ```text
+  paintFrameMode(inventory, supplier, frameSlots, applyPlaceholders):
+      chosen = setOf(frameSlots)
+      for slot in frameSlots:                       // per-slot eval -> fresh ItemStack
+          applyToSlot(inventory, slot, supplier.get(), applyPlaceholders)
+      for slot in targetSlots:      if !chosen.contains(slot) applyToSlot(.., clear, ..)
+      for slot in ownedOutsideSlots: if !chosen.contains(slot) applyToSlot(.., clear, ..)
+  // clear == RenderedItem.ofItem(null); applyToSlot's frame branch drops any element
+  // component and records lastApplied, so bookkeeping stays consistent.
+  ```
+
+  Clearing is idempotent (painting `null`/air into already-free, validated slots), so no
+  transition flag is needed; correctness does not depend on the previous mode.
+- **Accessors for validation:** add `frameSlots()` returning the de-duplicated union of
+  `emptyStateSlots` and `loadingSlots` (clone). Keep existing `targetSlots()`.
+
+Because every repaint path funnels through `PaginationBinding.repaint()` (the initial paint in
+`FirstRenderPhase.paintAll`, and async settles / state flushes via
+`ViewEngine.paginationSettle` → `UpdatePhase` → `repaint()`; `paginator.insertPageItems()` has no
+other caller), this single change covers first paint, navigation, async settle, and refresh.
+
+### 6.5 `FirstRenderPhase.validatePaginationOverlap`
+Extend the existing check (which runs inside the open try-block, so failures abort with
+`OPEN_FAILED`):
+
+```text
+for binding in PaginationBindings.of(session):
+    for slot in binding.targetSlots():
+        if components.componentAt(slot) != null:
+            throw "slot " + slot + " is bound to both a component and pagination"
+    for slot in binding.frameSlots():
+        if components.componentAt(slot) != null:
+            throw "slot " + slot + " is bound to both a component and a pagination frame item"
+        for other in bindings where other != binding:
+            if other.targetSlots() or other.frameSlots() contains slot:
+                throw "slot " + slot + " is bound to two paginations"
+```
+
+(The component table comparison uses `session.components().componentAt(slot)`, as today.)
+
+## 7. Backward compatibility
+
+Purely additive. No existing signature changes; `fallbackItem(fn)`, `loadingItem(fn)`, all three
+geometries (normal/scroll/pattern) and the existing render paths behave exactly as before when the
+new methods are unused (the new slot arrays are empty, so every new branch is skipped and `repaint()`
+falls through to the unchanged `insertPageItems()` with an empty `ownedOutsideSlots` clear pass).
+
+## 8. Testing
+
+JUnit 5 + Mockito + MockBukkit, beside the code under test.
+
+- **`PaginationBuilderImplTest`** — `emptyStateItem`/`loadingItem(fn, slots)` store fn + slots;
+  reject null fn (NPE), null slots (NPE), zero slots (IAE), negative slot (IAE); dedupe slots;
+  `loadingItem(fn, slots)` is async-only (`build()` throws on a non-async builder);
+  `loadingItem(fn)` still resets to fill-all.
+- **`PaginationBindingTest`** — empty page paints the empty-state item at chosen slots and clears the
+  rest of the layout; a page with elements paints no empty-state and leaves `fallbackItem` behavior
+  intact; loading with `loadingItem(fn, slots)` paints only chosen slots and clears the rest;
+  legacy `loadingItem(fn)` still fills all; an outside-layout frame slot is painted when active and
+  cleared on the transition to elements/loaded; per-slot evaluation yields a fresh `ItemStack` per
+  slot; empty-state suppresses `fallbackItem` fill on the empty page.
+- **Overlap (`FirstRenderPhase` / open path)** — a frame slot on a static component throws; a frame
+  slot out of container bounds throws; a frame slot on a different pagination throws; a frame slot on
+  the binding's own layout slot is accepted.
+- **Integration (`PaginationSampleFlowsTest`)** — eager empty source renders the empty-state frame
+  on first paint; async source shows the loading frame at chosen slots while in flight and the
+  empty-state frame after settling empty.
+
+## 9. Risk notes
+
+- `isCurrentPageEmpty()` reflects the **current page**, not the whole source. With normal
+  page-clamping an empty source means page 1 is empty, so this is the empty-state in practice; a
+  genuinely empty non-first page (should not occur under clamping) would also show the empty-state,
+  which is acceptable.
+- Owned outside slots are only ever painted by this binding's frames (validated free of components
+  and other paginations), so the idempotent clear pass can never erase another owner's content.

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
@@ -147,21 +147,28 @@ public final class FirstRenderPhase {
                     throw new ViewConfigurationException(
                             "slot " + slot + " is bound to both a component and pagination");
                 }
+                checkNotBoundToOtherPagination(slot, binding, bindings);
             }
             for (int slot : binding.frameSlots()) {
                 if (session.components().componentAt(slot) != null) {
                     throw new ViewConfigurationException(
                             "slot " + slot + " is bound to both a component and a pagination frame item");
                 }
-                for (PaginationBinding other : bindings) {
-                    if (other == binding) {
-                        continue;
-                    }
-                    if (contains(other.targetSlots(), slot) || contains(other.frameSlots(), slot)) {
-                        throw new ViewConfigurationException(
-                                "slot " + slot + " is bound to two paginations");
-                    }
-                }
+                checkNotBoundToOtherPagination(slot, binding, bindings);
+            }
+        }
+    }
+
+    // a slot must belong to at most one pagination, whether as a target or a frame slot
+    private static void checkNotBoundToOtherPagination(int slot, PaginationBinding binding,
+                                                       List<PaginationBinding> bindings) {
+        for (PaginationBinding other : bindings) {
+            if (other == binding) {
+                continue;
+            }
+            if (contains(other.targetSlots(), slot) || contains(other.frameSlots(), slot)) {
+                throw new ViewConfigurationException(
+                        "slot " + slot + " is bound to two paginations");
             }
         }
     }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/phase/FirstRenderPhase.java
@@ -44,6 +44,7 @@ import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.ViewSession;
 import tech.guilhermekaua.spigotboot.inventoryapi.state.StateToken;
 
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -136,18 +137,42 @@ public final class FirstRenderPhase {
     }
 
     // overlap validation (§5.3/§6): a slot cannot be both statically bound and a pagination
-    // target; runs inside the try so the failure flows into the OPEN_FAILED abort path.
-    // bindings have no element components yet at this point (the first fill happens in
-    // paintAll), so the check uses the binding's resolved target slots
+    // target; frame slots (empty-state / loading) must not collide with a component or another
+    // pagination. runs inside the try so the failure flows into the OPEN_FAILED abort path.
     private void validatePaginationOverlap(ViewSession session) {
-        for (PaginationBinding binding : PaginationBindings.of(session)) {
+        List<PaginationBinding> bindings = PaginationBindings.of(session);
+        for (PaginationBinding binding : bindings) {
             for (int slot : binding.targetSlots()) {
                 if (session.components().componentAt(slot) != null) {
                     throw new ViewConfigurationException(
                             "slot " + slot + " is bound to both a component and pagination");
                 }
             }
+            for (int slot : binding.frameSlots()) {
+                if (session.components().componentAt(slot) != null) {
+                    throw new ViewConfigurationException(
+                            "slot " + slot + " is bound to both a component and a pagination frame item");
+                }
+                for (PaginationBinding other : bindings) {
+                    if (other == binding) {
+                        continue;
+                    }
+                    if (contains(other.targetSlots(), slot) || contains(other.frameSlots(), slot)) {
+                        throw new ViewConfigurationException(
+                                "slot " + slot + " is bound to two paginations");
+                    }
+                }
+            }
         }
+    }
+
+    private static boolean contains(int[] slots, int value) {
+        for (int slot : slots) {
+            if (slot == value) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // unbound-layout-char warning (§5.3): chars present in the effective layout but bound by

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
@@ -272,7 +272,8 @@ public final class PaginationBinding implements PaginationHost {
     /**
      * Returns the empty-state and loading frame slots this binding paints into, de-duplicated.
      *
-     * @return a defensive copy of the frame slots; empty when no frame slots are declared
+     * @return a defensive copy of the frame slots; empty before {@link #initialize} or when no
+     *         frame slots are declared
      */
     public @NotNull int[] frameSlots() {
         LinkedHashSet<Integer> union = new LinkedHashSet<>();

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
@@ -113,6 +113,12 @@ public final class PaginationBinding implements PaginationHost {
     // against the static component table (overlap check, Task 12)
     private int[] targetSlots = new int[0];
 
+    // frame slots resolved at initialize; emptyState/loading slots may lie outside targetSlots
+    private int[] emptyStateSlots = new int[0];
+    private int[] loadingSlots = new int[0];
+    private int[] ownedOutsideSlots = new int[0];
+    private Supplier<RenderedItem> emptyStateSupplier;
+
     // current frame: the page-element component per slot, in fill order, plus what was
     // last applied per slot — lastApplied keys drive the first-paint-fallback decision
     private final Map<Integer, ComponentInstance> elementComponents = new LinkedHashMap<>();
@@ -197,11 +203,17 @@ public final class PaginationBinding implements PaginationHost {
             fillLayout = resolveFillLayout(viewLayout, effectiveConfig);
         }
         this.targetSlots = resolveTargetSlots(fillLayout, patterns);
+        this.emptyStateSlots = spec.emptyStateSlots();
+        this.loadingSlots = spec.loadingSlots();
+        checkFrameSlotBounds(this.emptyStateSlots, "empty-state", effectiveConfig);
+        checkFrameSlotBounds(this.loadingSlots, "loading", effectiveConfig);
+        this.ownedOutsideSlots = outsideLayout(this.emptyStateSlots, this.loadingSlots, this.targetSlots);
 
         this.plainContext = new PlainViewContextImpl(session, engine);
         PageSource<Object> source = spec.source().createSource(plainContext, spec, engine.scheduler());
         this.fallbackSupplier = frameSupplier(spec.fallbackItem(), "fallback item");
         this.loadingSupplier = frameSupplier(spec.loadingItem(), "loading item");
+        this.emptyStateSupplier = frameSupplier(spec.emptyStateItem(), "empty-state item");
         PageItemFactory<Object> factory = elementFactory();
 
         Paginator<Object> built;
@@ -258,6 +270,27 @@ public final class PaginationBinding implements PaginationHost {
     }
 
     /**
+     * Returns the empty-state and loading frame slots this binding paints into, de-duplicated.
+     *
+     * @return a defensive copy of the frame slots; empty when no frame slots are declared
+     */
+    public @NotNull int[] frameSlots() {
+        LinkedHashSet<Integer> union = new LinkedHashSet<>();
+        for (int slot : emptyStateSlots) {
+            union.add(slot);
+        }
+        for (int slot : loadingSlots) {
+            union.add(slot);
+        }
+        int[] result = new int[union.size()];
+        int index = 0;
+        for (int slot : union) {
+            result[index++] = slot;
+        }
+        return result;
+    }
+
+    /**
      * Returns the page-element component currently occupying a slot.
      *
      * @param slot the raw container slot
@@ -298,7 +331,49 @@ public final class PaginationBinding implements PaginationHost {
         if (paginator == null) {
             return;
         }
-        paginator.insertPageItems();
+        Inventory inventory = session.inventory();
+        if (inventory == null) {
+            return;
+        }
+        boolean applyPlaceholders = session.effectiveConfig().applyPlaceholders();
+        boolean loading = paginator.isLoading();
+        boolean empty = !loading && paginator.isCurrentPageEmpty();
+
+        if (empty && emptyStateSlots.length > 0) {
+            paintFrameMode(inventory, emptyStateSupplier, emptyStateSlots, applyPlaceholders);
+        } else {
+            paginator.insertPageItems();
+            clearSlots(inventory, ownedOutsideSlots, applyPlaceholders);
+        }
+    }
+
+    // paints the frame item at each frame slot (one supplier call per slot, so each slot gets a
+    // fresh ItemStack) and clears every other slot this binding owns (layout + owned-outside)
+    private void paintFrameMode(Inventory inventory, Supplier<RenderedItem> supplier,
+                                int[] frameSlots, boolean applyPlaceholders) {
+        Set<Integer> chosen = new LinkedHashSet<>();
+        for (int slot : frameSlots) {
+            chosen.add(slot);
+        }
+        for (int slot : frameSlots) {
+            applyToSlot(inventory, slot, supplier.get(), applyPlaceholders);
+        }
+        for (int slot : targetSlots) {
+            if (!chosen.contains(slot)) {
+                applyToSlot(inventory, slot, RenderedItem.ofItem(null), applyPlaceholders);
+            }
+        }
+        for (int slot : ownedOutsideSlots) {
+            if (!chosen.contains(slot)) {
+                applyToSlot(inventory, slot, RenderedItem.ofItem(null), applyPlaceholders);
+            }
+        }
+    }
+
+    private void clearSlots(Inventory inventory, int[] slots, boolean applyPlaceholders) {
+        for (int slot : slots) {
+            applyToSlot(inventory, slot, RenderedItem.ofItem(null), applyPlaceholders);
+        }
     }
 
     /**
@@ -461,6 +536,42 @@ public final class PaginationBinding implements PaginationHost {
                         + session.registered().type().getName());
             }
         }
+    }
+
+    private void checkFrameSlotBounds(int[] slots, String label, ViewConfig effectiveConfig) {
+        int size = effectiveConfig.rows() * Layout.ROW_WIDTH;
+        for (int slot : slots) {
+            if (slot >= size) {
+                throw new ViewConfigurationException("pagination " + label + " slot " + slot
+                        + " is out of bounds for a " + effectiveConfig.rows() + "-row view of "
+                        + session.registered().type().getName());
+            }
+        }
+    }
+
+    // the frame slots that fall outside the pagination's own layout, de-duplicated in order
+    private static int[] outsideLayout(int[] emptyStateSlots, int[] loadingSlots, int[] layout) {
+        Set<Integer> layoutSet = new LinkedHashSet<>();
+        for (int slot : layout) {
+            layoutSet.add(slot);
+        }
+        LinkedHashSet<Integer> outside = new LinkedHashSet<>();
+        for (int slot : emptyStateSlots) {
+            if (!layoutSet.contains(slot)) {
+                outside.add(slot);
+            }
+        }
+        for (int slot : loadingSlots) {
+            if (!layoutSet.contains(slot)) {
+                outside.add(slot);
+            }
+        }
+        int[] result = new int[outside.size()];
+        int index = 0;
+        for (int slot : outside) {
+            result[index++] = slot;
+        }
+        return result;
     }
 
     private PageItemFactory<Object> elementFactory() {

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
@@ -56,6 +56,7 @@ import tech.guilhermekaua.spigotboot.inventoryapi.state.StateToken;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -354,7 +355,7 @@ public final class PaginationBinding implements PaginationHost {
     // fresh ItemStack) and clears every other slot this binding owns (layout + owned-outside)
     private void paintFrameMode(Inventory inventory, Supplier<RenderedItem> supplier,
                                 int[] frameSlots, boolean applyPlaceholders) {
-        Set<Integer> chosen = new LinkedHashSet<>();
+        Set<Integer> chosen = new HashSet<>();
         for (int slot : frameSlots) {
             chosen.add(slot);
         }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBinding.java
@@ -340,7 +340,9 @@ public final class PaginationBinding implements PaginationHost {
         boolean loading = paginator.isLoading();
         boolean empty = !loading && paginator.isCurrentPageEmpty();
 
-        if (empty && emptyStateSlots.length > 0) {
+        if (loading && loadingSlots.length > 0) {
+            paintFrameMode(inventory, loadingSupplier, loadingSlots, applyPlaceholders);
+        } else if (empty && emptyStateSlots.length > 0) {
             paintFrameMode(inventory, emptyStateSupplier, emptyStateSlots, applyPlaceholders);
         } else {
             paginator.insertPageItems();

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImpl.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImpl.java
@@ -39,6 +39,7 @@ import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.PaginationEr
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
@@ -70,6 +71,9 @@ public final class PaginationBuilderImpl<T> implements PaginationBuilder<T> {
     private PaginationItemRenderer<T> renderer;
     private Function<ViewContext, ItemStack> fallbackItem;
     private Function<ViewContext, ItemStack> loadingItem;
+    private Function<ViewContext, ItemStack> emptyStateItem;
+    private int[] emptyStateSlots = new int[0];
+    private int[] loadingSlots = new int[0];
     private PaginationErrorCallback errorCallback;
     private Duration requestTimeout;
     private Duration cacheTtl;
@@ -136,7 +140,45 @@ public final class PaginationBuilderImpl<T> implements PaginationBuilder<T> {
     @Override
     public @NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item) {
         this.loadingItem = Objects.requireNonNull(item, "item");
+        this.loadingSlots = new int[0];
         return this;
+    }
+
+    @Override
+    public @NotNull PaginationBuilder<T> emptyStateItem(@NotNull Function<ViewContext, ItemStack> item,
+                                                        int... slots) {
+        this.emptyStateItem = Objects.requireNonNull(item, "item");
+        this.emptyStateSlots = validatedFrameSlots(slots, "emptyStateItem");
+        return this;
+    }
+
+    @Override
+    public @NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item,
+                                                     int... slots) {
+        this.loadingItem = Objects.requireNonNull(item, "item");
+        this.loadingSlots = validatedFrameSlots(slots, "loadingItem");
+        return this;
+    }
+
+    // validates and de-duplicates frame slots (empty-state / slotted loading), preserving order
+    private static int[] validatedFrameSlots(int[] slots, String method) {
+        Objects.requireNonNull(slots, "slots");
+        if (slots.length == 0) {
+            throw new IllegalArgumentException(method + " requires at least one slot");
+        }
+        LinkedHashSet<Integer> unique = new LinkedHashSet<>();
+        for (int slot : slots) {
+            if (slot < 0) {
+                throw new IllegalArgumentException(method + " slot must not be negative: " + slot);
+            }
+            unique.add(slot);
+        }
+        int[] result = new int[unique.size()];
+        int index = 0;
+        for (int slot : unique) {
+            result[index++] = slot;
+        }
+        return result;
     }
 
     @Override
@@ -196,7 +238,8 @@ public final class PaginationBuilderImpl<T> implements PaginationBuilder<T> {
 
         PaginationSpec<T> spec = new PaginationSpec<>(geometry, target, layoutChar, explicitLayout,
                 patterns == null ? Collections.<Layout>emptyList() : patterns, renderer, fallbackItem,
-                loadingItem, source, errorCallback, requestTimeout, cacheTtl, cacheMaxPages);
+                loadingItem, source, errorCallback, requestTimeout, cacheTtl, cacheMaxPages,
+                emptyStateItem, emptyStateSlots, loadingSlots);
         // registration happens here, AT BUILD TIME: a frozen table throws before built is set
         PaginationImpl<T> token = new PaginationImpl<>(owner, table, spec);
         built = true;

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSpec.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSpec.java
@@ -99,27 +99,36 @@ public final class PaginationSpec<T> {
     private final Duration requestTimeout;
     private final Duration cacheTtl;
     private final int cacheMaxPages;
+    private final Function<ViewContext, ItemStack> emptyStateItem;
+    private final int[] emptyStateSlots;
+    private final int[] loadingSlots;
 
     /**
      * Creates a spec. Package-private: only {@code PaginationBuilderImpl} and same-package
      * tests construct specs, after the builder validated the combination.
      *
-     * @param geometry       the page geometry
-     * @param target         the paint target
-     * @param layoutChar     the target layout character; meaningful only when {@code target}
-     *                       is {@link Target#LAYOUT_CHAR}; {@code 'O'} by default
-     * @param explicitLayout the explicit fill order; non-null only when {@code target} is
-     *                       {@link Target#EXPLICIT_LAYOUT}
-     * @param patterns       the per-page patterns, defensively copied; empty unless
-     *                       {@code target} is {@link Target#PATTERNS}
-     * @param renderer       the per-element renderer
-     * @param fallbackItem   the frame item for uncovered page slots, or null to clear them
-     * @param loadingItem    the async loading frame item, or null
-     * @param source         the source declaration
-     * @param errorCallback  the async error callback, or null
-     * @param requestTimeout the async per-request timeout, or null to disable
-     * @param cacheTtl       the async cache TTL, or null to disable caching
-     * @param cacheMaxPages  the async cache LRU bound; 128 unless overridden (the 2.x default)
+     * @param geometry        the page geometry
+     * @param target          the paint target
+     * @param layoutChar      the target layout character; meaningful only when {@code target}
+     *                        is {@link Target#LAYOUT_CHAR}; {@code 'O'} by default
+     * @param explicitLayout  the explicit fill order; non-null only when {@code target} is
+     *                        {@link Target#EXPLICIT_LAYOUT}
+     * @param patterns        the per-page patterns, defensively copied; empty unless
+     *                        {@code target} is {@link Target#PATTERNS}
+     * @param renderer        the per-element renderer
+     * @param fallbackItem    the frame item for uncovered page slots, or null to clear them
+     * @param loadingItem     the async loading frame item, or null
+     * @param source          the source declaration
+     * @param errorCallback   the async error callback, or null
+     * @param requestTimeout  the async per-request timeout, or null to disable
+     * @param cacheTtl        the async cache TTL, or null to disable caching
+     * @param cacheMaxPages   the async cache LRU bound; 128 unless overridden (the 2.x default)
+     * @param emptyStateItem  the item painted at {@code emptyStateSlots} when the current page is
+     *                        empty, or null when no empty-state is declared
+     * @param emptyStateSlots the absolute slots the empty-state item paints into; never null,
+     *                        empty when no empty-state is declared
+     * @param loadingSlots    the absolute slots the loading item paints into; never null, empty
+     *                        when the loading item fills the whole layout (the default)
      * @throws NullPointerException if {@code geometry}, {@code target}, {@code patterns},
      *                              {@code renderer} or {@code source} is null
      */
@@ -135,7 +144,10 @@ public final class PaginationSpec<T> {
                    @Nullable PaginationErrorCallback errorCallback,
                    @Nullable Duration requestTimeout,
                    @Nullable Duration cacheTtl,
-                   int cacheMaxPages) {
+                   int cacheMaxPages,
+                   @Nullable Function<ViewContext, ItemStack> emptyStateItem,
+                   int[] emptyStateSlots,
+                   int[] loadingSlots) {
         this.geometry = Objects.requireNonNull(geometry, "geometry is required.");
         this.target = Objects.requireNonNull(target, "target is required.");
         this.layoutChar = layoutChar;
@@ -150,6 +162,9 @@ public final class PaginationSpec<T> {
         this.requestTimeout = requestTimeout;
         this.cacheTtl = cacheTtl;
         this.cacheMaxPages = cacheMaxPages;
+        this.emptyStateItem = emptyStateItem;
+        this.emptyStateSlots = emptyStateSlots == null ? new int[0] : emptyStateSlots.clone();
+        this.loadingSlots = loadingSlots == null ? new int[0] : loadingSlots.clone();
     }
 
     /**
@@ -273,5 +288,33 @@ public final class PaginationSpec<T> {
      */
     public int cacheMaxPages() {
         return cacheMaxPages;
+    }
+
+    /**
+     * Returns the empty-state item painted at {@link #emptyStateSlots()} when the current page
+     * settled with no elements.
+     *
+     * @return the empty-state item factory, or null when no empty-state is declared
+     */
+    public @Nullable Function<ViewContext, ItemStack> emptyStateItem() {
+        return emptyStateItem;
+    }
+
+    /**
+     * Returns the absolute slots the empty-state item paints into.
+     *
+     * @return a defensive copy; empty when no empty-state is declared
+     */
+    public int[] emptyStateSlots() {
+        return emptyStateSlots.clone();
+    }
+
+    /**
+     * Returns the absolute slots the loading item paints into.
+     *
+     * @return a defensive copy; empty when the loading item fills the whole layout
+     */
+    public int[] loadingSlots() {
+        return loadingSlots.clone();
     }
 }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AbstractPageSourcePagination.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/AbstractPageSourcePagination.java
@@ -192,6 +192,11 @@ abstract class AbstractPageSourcePagination<T, S> implements Paginator<T> {
     }
 
     @Override
+    public boolean isCurrentPageEmpty() {
+        return this.currentItems.isEmpty();
+    }
+
+    @Override
     public void changePage(int page) {
         changePageInternal(page, false);
     }

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/Paginator.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/engine/Paginator.java
@@ -58,6 +58,14 @@ public interface Paginator<T> {
     void insertPageItems();
 
     /**
+     * Reports whether the most recently settled page rendered no elements. Used by the host to
+     * decide whether to paint the empty-state frame.
+     *
+     * @return {@code true} when the current page has no elements
+     */
+    boolean isCurrentPageEmpty();
+
+    /**
      * Navigates directly to the given 1-indexed page.
      *
      * <p>The target is clamped to at least 1, and to {@link #getTotalPages()} once the backing

--- a/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/PaginationBuilder.java
+++ b/platform-spigot/inventory-api/api/src/main/java/tech/guilhermekaua/spigotboot/inventoryapi/pagination/PaginationBuilder.java
@@ -124,6 +124,26 @@ public interface PaginationBuilder<T> {
     @NotNull PaginationBuilder<T> fallbackItem(@NotNull Function<ViewContext, ItemStack> item);
 
     /**
+     * Sets an item painted into the given slots when the current page settled with no elements,
+     * leaving every other layout slot empty. Unlike {@link #fallbackItem(Function)} — which fills
+     * every uncovered slot of every page — this renders only while the current page is empty, and
+     * only in {@code slots}; when the page has any element it renders nothing. When both are set,
+     * the empty page shows the empty-state item (the fallback fill is suppressed for that paint).
+     *
+     * <p>Slots are absolute container slots and may lie outside the pagination's layout. Evaluated
+     * against the session's context once per slot at paint time. A slot bound to a static component
+     * or to another pagination fails at open with {@link ViewConfigurationException}.
+     *
+     * @param item  the empty-state item factory
+     * @param slots the absolute container slots to paint, at least one, each non-negative
+     * @return this builder
+     * @throws NullPointerException     if {@code item} or {@code slots} is null
+     * @throws IllegalArgumentException if {@code slots} is empty or contains a negative slot
+     */
+    @NotNull PaginationBuilder<T> emptyStateItem(@NotNull Function<ViewContext, ItemStack> item,
+                                                 int... slots);
+
+    /**
      * Sets the item painted into every page slot while an async load is in flight. Async-only:
      * on a non-async builder {@link #build()} throws {@link ViewConfigurationException}.
      *
@@ -131,6 +151,25 @@ public interface PaginationBuilder<T> {
      * @return this builder
      */
     @NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item);
+
+    /**
+     * Sets the loading item painted only into the given slots while an async load is in flight,
+     * leaving every other layout slot empty. The slotted form of {@link #loadingItem(Function)};
+     * it has the same trigger (shown while loading) and only restricts where the item paints.
+     * Async-only: on a non-async builder {@link #build()} throws {@link ViewConfigurationException}.
+     *
+     * <p>Slots are absolute container slots and may lie outside the pagination's layout. Evaluated
+     * against the session's context once per slot at paint time. A slot bound to a static component
+     * or to another pagination fails at open with {@link ViewConfigurationException}.
+     *
+     * @param item  the loading item factory
+     * @param slots the absolute container slots to paint, at least one, each non-negative
+     * @return this builder
+     * @throws NullPointerException     if {@code item} or {@code slots} is null
+     * @throws IllegalArgumentException if {@code slots} is empty or contains a negative slot
+     */
+    @NotNull PaginationBuilder<T> loadingItem(@NotNull Function<ViewContext, ItemStack> item,
+                                              int... slots);
 
     /**
      * Sets the callback invoked when an async page load fails. Async-only: on a non-async

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java
@@ -77,6 +77,7 @@ class PaginationFrameSlotFlowsTest {
 
     private final ComponentConflictView componentConflictView = new ComponentConflictView();
     private final TwoPaginationConflictView twoPaginationConflictView = new TwoPaginationConflictView();
+    private final TwoPaginationTargetConflictView twoPaginationTargetConflictView = new TwoPaginationTargetConflictView();
     private final EmptyStateView emptyStateView = new EmptyStateView();
     private final AsyncEmptyStateView asyncEmptyStateView = new AsyncEmptyStateView();
 
@@ -89,6 +90,7 @@ class PaginationFrameSlotFlowsTest {
         views = new ViewRegistry();
         views.register(componentConflictView);
         views.register(twoPaginationConflictView);
+        views.register(twoPaginationTargetConflictView);
         views.register(emptyStateView);
         views.register(asyncEmptyStateView);
         engine = new ViewEngine(plugin, views, sessions,
@@ -143,6 +145,28 @@ class PaginationFrameSlotFlowsTest {
         @Override
         protected void onInit(@NotNull ViewConfigBuilder config) {
             config.title("TwoPag").rows(1);
+        }
+
+        @Override
+        protected void onClose(@NotNull CloseContext context) {
+            lastCloseReason = context.reason();
+        }
+    }
+
+    static final class TwoPaginationTargetConflictView extends View {
+        CloseReason lastCloseReason;
+        final Pagination<String> a = this.<String>paginate(Collections.singletonList("x"))
+                .layout(Layout.ofSlots(0, 1))
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .build();
+        final Pagination<String> b = this.<String>paginate(Collections.singletonList("y"))
+                .layout(Layout.ofSlots(1, 2)) // 1 is also pagination a's target
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("TwoPagTarget").rows(1);
         }
 
         @Override
@@ -210,6 +234,22 @@ class PaginationFrameSlotFlowsTest {
 
             assertFalse(sessions.find(player.getUniqueId()).isPresent());
             assertEquals(CloseReason.OPEN_FAILED, twoPaginationConflictView.lastCloseReason);
+            assertTrue(handler.hasThrownContaining("two paginations"));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void targetSlotOnAnotherPagination_abortsOpenFailed() {
+        Logger logger = Logger.getLogger(FirstRenderPhase.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            engine.open(player, TwoPaginationTargetConflictView.class, ViewArguments.empty());
+
+            assertFalse(sessions.find(player.getUniqueId()).isPresent());
+            assertEquals(CloseReason.OPEN_FAILED, twoPaginationTargetConflictView.lastCloseReason);
             assertTrue(handler.hasThrownContaining("two paginations"));
         } finally {
             logger.removeHandler(handler);

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java
@@ -58,7 +58,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Handler;
-import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/engine/PaginationFrameSlotFlowsTest.java
@@ -1,0 +1,277 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.inventoryapi.internal.engine;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import org.bukkit.Material;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.spigot.scheduler.BukkitPlatformScheduler;
+import tech.guilhermekaua.spigotboot.inventoryapi.View;
+import tech.guilhermekaua.spigotboot.inventoryapi.config.ViewConfigBuilder;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseContext;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.CloseReason;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.RenderContext;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.engine.phase.FirstRenderPhase;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.registry.ViewRegistry;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.render.SlotPainter;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.SessionRegistry;
+import tech.guilhermekaua.spigotboot.inventoryapi.internal.session.ViewSession;
+import tech.guilhermekaua.spigotboot.inventoryapi.layout.Layout;
+import tech.guilhermekaua.spigotboot.inventoryapi.pagination.Pagination;
+import tech.guilhermekaua.spigotboot.inventoryapi.pagination.source.PageResult;
+import tech.guilhermekaua.spigotboot.inventoryapi.placeholder.NoopPlaceholderApplier;
+import tech.guilhermekaua.spigotboot.inventoryapi.service.ViewArguments;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PaginationFrameSlotFlowsTest {
+
+    private ServerMock server;
+    private Plugin plugin;
+    private SessionRegistry sessions;
+    private ViewRegistry views;
+    private ViewEngine engine;
+    private PlayerMock player;
+
+    private final ComponentConflictView componentConflictView = new ComponentConflictView();
+    private final TwoPaginationConflictView twoPaginationConflictView = new TwoPaginationConflictView();
+    private final EmptyStateView emptyStateView = new EmptyStateView();
+    private final AsyncEmptyStateView asyncEmptyStateView = new AsyncEmptyStateView();
+
+    @BeforeEach
+    void setUp() {
+        server = MockBukkit.mock();
+        plugin = MockBukkit.createMockPlugin();
+        player = server.addPlayer("tester");
+        sessions = new SessionRegistry();
+        views = new ViewRegistry();
+        views.register(componentConflictView);
+        views.register(twoPaginationConflictView);
+        views.register(emptyStateView);
+        views.register(asyncEmptyStateView);
+        engine = new ViewEngine(plugin, views, sessions,
+                new SlotPainter(new NoopPlaceholderApplier()), (p, title) -> {
+        }, new BukkitPlatformScheduler(plugin));
+    }
+
+    @AfterEach
+    void tearDown() {
+        server.getScheduler().cancelTasks(plugin);
+        MockBukkit.unmock();
+    }
+
+    // ---------------------------------------------------------------- fixture views
+
+    static final class ComponentConflictView extends View {
+        CloseReason lastCloseReason;
+        final Pagination<String> pagination = this.<String>paginate(Collections.<String>emptyList())
+                .layout(Layout.ofSlots(0, 1))
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 8)
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("Conflict").rows(1);
+        }
+
+        @Override
+        protected void onFirstRender(@NotNull RenderContext context) {
+            context.slot(8, new ItemStack(Material.STONE)); // collides with the empty-state frame slot
+        }
+
+        @Override
+        protected void onClose(@NotNull CloseContext context) {
+            lastCloseReason = context.reason();
+        }
+    }
+
+    static final class TwoPaginationConflictView extends View {
+        CloseReason lastCloseReason;
+        final Pagination<String> a = this.<String>paginate(Collections.<String>emptyList())
+                .layout(Layout.ofSlots(0, 1))
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 4) // 4 is pagination b's target
+                .build();
+        final Pagination<String> b = this.<String>paginate(Collections.singletonList("x"))
+                .layout(Layout.ofSlots(3, 4))
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("TwoPag").rows(1);
+        }
+
+        @Override
+        protected void onClose(@NotNull CloseContext context) {
+            lastCloseReason = context.reason();
+        }
+    }
+
+    static final class EmptyStateView extends View {
+        final Pagination<String> pagination = this.<String>paginate(Collections.<String>emptyList())
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 4)
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("EmptyState").layout("OOOOOOOOO");
+        }
+    }
+
+    static final class AsyncEmptyStateView extends View {
+        final Map<UUID, CompletableFuture<PageResult<String>>> futures = new ConcurrentHashMap<>();
+        final Pagination<String> pagination = this.<String>paginateAsync(request -> {
+            CompletableFuture<PageResult<String>> future = new CompletableFuture<>();
+            futures.put(request.playerId(), future);
+            return future;
+        })
+                .itemRenderer((ctx, item, index, value) -> item.item(new ItemStack(Material.PAPER)))
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD), 4)
+                .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 4)
+                .build();
+
+        @Override
+        protected void onInit(@NotNull ViewConfigBuilder config) {
+            config.title("AsyncEmpty").layout("OOOOOOOOO");
+        }
+    }
+
+    // ---------------------------------------------------------------- tests
+
+    @Test
+    void emptyStateSlotOnComponent_abortsOpenFailed() {
+        Logger logger = Logger.getLogger(FirstRenderPhase.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            engine.open(player, ComponentConflictView.class, ViewArguments.empty());
+
+            assertFalse(sessions.find(player.getUniqueId()).isPresent(),
+                    "the overlap must abort the open, registering nothing");
+            assertEquals(CloseReason.OPEN_FAILED, componentConflictView.lastCloseReason);
+            assertTrue(handler.hasThrownContaining("a pagination frame item"));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void frameSlotOnAnotherPagination_abortsOpenFailed() {
+        Logger logger = Logger.getLogger(FirstRenderPhase.class.getName());
+        CapturingHandler handler = new CapturingHandler();
+        logger.addHandler(handler);
+        try {
+            engine.open(player, TwoPaginationConflictView.class, ViewArguments.empty());
+
+            assertFalse(sessions.find(player.getUniqueId()).isPresent());
+            assertEquals(CloseReason.OPEN_FAILED, twoPaginationConflictView.lastCloseReason);
+            assertTrue(handler.hasThrownContaining("two paginations"));
+        } finally {
+            logger.removeHandler(handler);
+        }
+    }
+
+    @Test
+    void eagerEmptySource_paintsEmptyStateOnOpen() {
+        engine.open(player, EmptyStateView.class, ViewArguments.empty());
+
+        ViewSession session = sessions.find(player.getUniqueId()).orElseThrow(IllegalStateException::new);
+        Inventory inventory = session.inventory();
+        assertEquals(Material.BARRIER, inventory.getItem(4).getType());
+        assertNull(inventory.getItem(0), "the rest of the layout is empty");
+        assertNull(inventory.getItem(8));
+    }
+
+    @Test
+    void async_showsLoadingSlot_thenEmptyStateAfterSettlingEmpty() {
+        engine.open(player, AsyncEmptyStateView.class, ViewArguments.empty());
+
+        ViewSession session = sessions.find(player.getUniqueId()).orElseThrow(IllegalStateException::new);
+        Inventory inventory = session.inventory();
+        // in flight: the loading slot shows the loading item, the rest of the layout is empty
+        assertEquals(Material.EMERALD, inventory.getItem(4).getType());
+        assertNull(inventory.getItem(0));
+
+        // settle empty on the main thread: the inline settle repaints
+        asyncEmptyStateView.futures.get(player.getUniqueId())
+                .complete(PageResult.of(Collections.<String>emptyList(), 0));
+
+        assertEquals(Material.BARRIER, inventory.getItem(4).getType(),
+                "settled-empty replaces the loading frame with the empty-state frame");
+        assertNull(inventory.getItem(0));
+    }
+
+    private static final class CapturingHandler extends Handler {
+        private final List<LogRecord> records = new CopyOnWriteArrayList<>();
+
+        boolean hasThrownContaining(String fragment) {
+            for (LogRecord record : records) {
+                Throwable thrown = record.getThrown();
+                if (thrown != null && thrown.getMessage() != null
+                        && thrown.getMessage().contains(fragment)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void publish(LogRecord record) {
+            records.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
@@ -206,7 +206,8 @@ class PaginationBindingTest {
                                                 Function<ViewContext, ItemStack> fallbackItem,
                                                 PaginationSourceSpec<T> source) {
         return new PaginationSpec<>(geometry, target, layoutChar, explicitLayout, patterns,
-                renderer, fallbackItem, null, source, null, null, null, 128);
+                renderer, fallbackItem, null, source, null, null, null, 128,
+                null, new int[0], new int[0]);
     }
 
     private static <T> PaginationSpec<T> layoutCharSpec(PaginationItemRenderer<T> renderer,

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
@@ -725,6 +725,112 @@ class PaginationBindingTest {
         assertTrue(error.getMessage().contains("empty-state"));
     }
 
+    /** a source that never settles and always reports loading */
+    static final class LoadingPageSource implements PageSource<Integer> {
+        @Override
+        public void request(PageRequest request, BiConsumer<PageResult<Integer>, Throwable> onSettle) {
+            // never settles: stays loading
+        }
+
+        @Override
+        public int totalElements() {
+            return 0;
+        }
+
+        @Override
+        public boolean totalsKnown() {
+            return false;
+        }
+
+        @Override
+        public boolean isLoading() {
+            return true;
+        }
+
+        @Override
+        public Throwable lastError() {
+            return null;
+        }
+
+        @Override
+        public List<Integer> elements() {
+            return Collections.emptyList();
+        }
+    }
+
+    // spec carrying a loading frame with explicit slots (LAYOUT_CHAR 'O', normal geometry)
+    private static <T> PaginationSpec<T> loadingSlotsSpec(PaginationItemRenderer<T> renderer,
+                                                          PaginationSourceSpec<T> source,
+                                                          Function<ViewContext, ItemStack> loadingItem,
+                                                          int[] loadingSlots) {
+        return new PaginationSpec<>(PaginationSpec.Geometry.NORMAL, PaginationSpec.Target.LAYOUT_CHAR,
+                'O', null, Collections.emptyList(), renderer, null, loadingItem, source,
+                null, null, null, 128, null, new int[0], loadingSlots);
+    }
+
+    @Test
+    void loading_withSlots_paintsLoadingItemAtChosenSlotsAndClearsRest() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[]{3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(Material.EMERALD, inventory.getItem(3).getType());
+        assertNull(inventory.getItem(2), "non-chosen layout slots clear while loading");
+        assertNull(inventory.getItem(4));
+    }
+
+    @Test
+    void loading_withSlots_paintsOutsideLayoutSlot() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[]{7}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        assertEquals(Material.EMERALD, session.inventory().getItem(7).getType());
+        assertNull(session.inventory().getItem(2), "layout cleared; only the chosen loading slot painted");
+    }
+
+    @Test
+    void loading_withoutSlots_stillFillsAllLayoutSlots() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[0]),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(Material.EMERALD, inventory.getItem(2).getType());
+        assertEquals(Material.EMERALD, inventory.getItem(3).getType());
+        assertEquals(Material.EMERALD, inventory.getItem(4).getType());
+    }
+
+    @Test
+    void initialize_loadingSlotOutOfBounds_throwsNamingSlotAndKind() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                loadingSlotsSpec(amountRenderer(), PaginationSourceSpec.custom(context -> new LoadingPageSource()),
+                        ctx -> new ItemStack(Material.EMERALD), new int[]{9}),
+                0, session, engine);
+
+        ViewConfigurationException error = assertThrows(ViewConfigurationException.class,
+                () -> binding.initialize(session.layout(), session.effectiveConfig()));
+        assertTrue(error.getMessage().contains("slot 9"));
+        assertTrue(error.getMessage().contains("loading"));
+    }
+
     private static final class CapturingHandler extends Handler {
         private final List<LogRecord> records = new ArrayList<>();
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
@@ -782,7 +782,7 @@ class PaginationBindingTest {
         Inventory inventory = session.inventory();
         assertEquals(Material.EMERALD, inventory.getItem(3).getType());
         assertNull(inventory.getItem(2), "non-chosen layout slots clear while loading");
-        assertNull(inventory.getItem(4));
+        assertNull(inventory.getItem(4), "non-chosen layout slots clear while loading");
     }
 
     @Test

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
@@ -67,6 +67,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
@@ -621,6 +622,107 @@ class PaginationBindingTest {
                 0, itemsSession, engine);
         withItems.initialize(itemsSession.layout(), itemsSession.effectiveConfig());
         assertFalse(withItems.paginator().isCurrentPageEmpty());
+    }
+
+    // spec carrying an empty-state frame (LAYOUT_CHAR 'O', normal geometry)
+    private static <T> PaginationSpec<T> emptyStateSpec(PaginationItemRenderer<T> renderer,
+                                                        PaginationSourceSpec<T> source,
+                                                        Function<ViewContext, ItemStack> fallbackItem,
+                                                        Function<ViewContext, ItemStack> emptyStateItem,
+                                                        int[] emptyStateSlots) {
+        return new PaginationSpec<>(PaginationSpec.Geometry.NORMAL, PaginationSpec.Target.LAYOUT_CHAR,
+                'O', null, Collections.emptyList(), renderer, fallbackItem, null, source,
+                null, null, null, 128, emptyStateItem, emptyStateSlots, new int[0]);
+    }
+
+    @Test
+    void emptyState_emptyPage_paintsItemAtChosenSlotsAndClearsRestOfLayout() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Collections.<Integer>emptyList()),
+                        null, ctx -> new ItemStack(Material.BARRIER), new int[]{3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(Material.BARRIER, inventory.getItem(3).getType());
+        assertNull(inventory.getItem(2), "non-chosen layout slots clear when the page is empty");
+        assertNull(inventory.getItem(4));
+    }
+
+    @Test
+    void emptyState_pageWithItems_paintsNoEmptyState_andKeepsFallbackFill() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Arrays.asList(1, 2)),
+                        ctx -> new ItemStack(Material.STONE),
+                        ctx -> new ItemStack(Material.BARRIER), new int[]{3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(1, inventory.getItem(2).getAmount(), "elements render normally");
+        assertEquals(2, inventory.getItem(3).getAmount(), "chosen slot shows the element, not the empty-state");
+        assertEquals(Material.STONE, inventory.getItem(4).getType(), "uncovered slot keeps the fallback fill");
+    }
+
+    @Test
+    void emptyState_evaluatesItemOncePerSlot() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        AtomicInteger counter = new AtomicInteger();
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Collections.<Integer>emptyList()),
+                        null, ctx -> new ItemStack(Material.BARRIER, counter.incrementAndGet()),
+                        new int[]{2, 3}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+
+        Inventory inventory = session.inventory();
+        assertEquals(1, inventory.getItem(2).getAmount());
+        assertEquals(2, inventory.getItem(3).getAmount(), "the factory runs once per chosen slot");
+    }
+
+    @Test
+    void emptyState_outsideLayoutSlot_paintedWhenEmpty_clearedOnTransitionToItems() {
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        AtomicReference<List<Integer>> backing = new AtomicReference<>(Collections.<Integer>emptyList());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.lazy(context -> backing.get()),
+                        null, ctx -> new ItemStack(Material.BARRIER), new int[]{7}),
+                0, session, engine);
+        binding.initialize(session.layout(), session.effectiveConfig());
+
+        binding.repaint();
+        assertEquals(Material.BARRIER, session.inventory().getItem(7).getType(),
+                "the outside empty-state slot is painted while empty");
+
+        backing.set(Arrays.asList(1, 2, 3));
+        binding.refreshLazy(new PlainViewContextImpl(session, engine));
+        binding.repaint();
+
+        assertNull(session.inventory().getItem(7), "the outside empty-state slot clears once items arrive");
+        assertEquals(1, session.inventory().getItem(2).getAmount());
+    }
+
+    @Test
+    void initialize_emptyStateSlotOutOfBounds_throwsNamingSlotAndKind() {
+        // layoutConfig is a single row (size 9): slot 9 is out of bounds
+        ViewSession session = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding binding = new PaginationBinding(
+                emptyStateSpec(amountRenderer(), PaginationSourceSpec.eager(Arrays.asList(1)),
+                        null, ctx -> new ItemStack(Material.BARRIER), new int[]{9}),
+                0, session, engine);
+
+        ViewConfigurationException error = assertThrows(ViewConfigurationException.class,
+                () -> binding.initialize(session.layout(), session.effectiveConfig()));
+        assertTrue(error.getMessage().contains("slot 9"));
+        assertTrue(error.getMessage().contains("empty-state"));
     }
 
     private static final class CapturingHandler extends Handler {

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBindingTest.java
@@ -606,6 +606,23 @@ class PaginationBindingTest {
         assertArrayEquals(new int[]{2, 3, 4, 5}, binding.targetSlots());
     }
 
+    @Test
+    void isCurrentPageEmpty_trueForEmptySource_falseWhenItemsPresent() {
+        ViewSession emptySession = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding empty = new PaginationBinding(
+                layoutCharSpec(amountRenderer(), PaginationSourceSpec.eager(Collections.<Integer>emptyList())),
+                0, emptySession, engine);
+        empty.initialize(emptySession.layout(), emptySession.effectiveConfig());
+        assertTrue(empty.paginator().isCurrentPageEmpty());
+
+        ViewSession itemsSession = sessionFor(new PagedView(), layoutConfig());
+        PaginationBinding withItems = new PaginationBinding(
+                layoutCharSpec(amountRenderer(), PaginationSourceSpec.eager(Arrays.asList(1, 2))),
+                0, itemsSession, engine);
+        withItems.initialize(itemsSession.layout(), itemsSession.effectiveConfig());
+        assertFalse(withItems.paginator().isCurrentPageEmpty());
+    }
+
     private static final class CapturingHandler extends Handler {
         private final List<LogRecord> records = new ArrayList<>();
 

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImplTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationBuilderImplTest.java
@@ -22,8 +22,11 @@
  */
 package tech.guilhermekaua.spigotboot.inventoryapi.internal.pagination;
 
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.inventoryapi.View;
+import tech.guilhermekaua.spigotboot.inventoryapi.context.ViewContext;
 import tech.guilhermekaua.spigotboot.inventoryapi.exception.ViewConfigurationException;
 import tech.guilhermekaua.spigotboot.inventoryapi.internal.state.IdentifiableToken;
 import tech.guilhermekaua.spigotboot.inventoryapi.layout.Layout;
@@ -37,7 +40,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -329,5 +334,77 @@ class PaginationBuilderImplTest {
         IllegalStateException thrown = assertThrows(IllegalStateException.class, builder::build);
         assertTrue(thrown.getMessage().contains("frozen"));
         assertEquals(0, view.tokenTable().size());
+    }
+
+    // --- emptyStateItem and slotted loadingItem ---
+
+    @Test
+    void emptyStateItem_storesFunctionAndDeduplicatedSlots() {
+        Function<ViewContext, ItemStack> fn = ctx -> new ItemStack(Material.BARRIER);
+        PaginationImpl<String> token = (PaginationImpl<String>) eagerBuilder(new TestView())
+                .itemRenderer(renderer()).emptyStateItem(fn, 22, 22, 4).build();
+
+        assertSame(fn, token.spec().emptyStateItem());
+        assertArrayEquals(new int[]{22, 4}, token.spec().emptyStateSlots());
+    }
+
+    @Test
+    void emptyStateItem_nullFunction_throwsNpe() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        assertThrows(NullPointerException.class, () -> builder.emptyStateItem(null, 1));
+    }
+
+    @Test
+    void emptyStateItem_noSlots_throwsIllegalArgument() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.emptyStateItem(ctx -> new ItemStack(Material.BARRIER)));
+    }
+
+    @Test
+    void emptyStateItem_negativeSlot_throwsIllegalArgument() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        assertThrows(IllegalArgumentException.class,
+                () -> builder.emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 0, -1));
+    }
+
+    @Test
+    void loadingItem_withSlots_storesDeduplicatedSlots_onAsyncBuilder() {
+        PaginationImpl<String> token = (PaginationImpl<String>) asyncBuilder(new TestView())
+                .itemRenderer(renderer())
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD), 4, 4)
+                .build();
+
+        assertArrayEquals(new int[]{4}, token.spec().loadingSlots());
+    }
+
+    @Test
+    void loadingItem_withSlots_onEagerSource_throwsAsyncOnly() {
+        PaginationBuilderImpl<String> builder = eagerBuilder(new TestView());
+        builder.itemRenderer(renderer()).loadingItem(ctx -> new ItemStack(Material.EMERALD), 4);
+
+        ViewConfigurationException thrown = assertThrows(ViewConfigurationException.class, builder::build);
+        assertTrue(thrown.getMessage().contains("loadingItem"));
+    }
+
+    @Test
+    void loadingItem_withoutSlots_resetsToFillAll() {
+        PaginationImpl<String> token = (PaginationImpl<String>) asyncBuilder(new TestView())
+                .itemRenderer(renderer())
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD), 4)
+                .loadingItem(ctx -> new ItemStack(Material.EMERALD))
+                .build();
+
+        assertEquals(0, token.spec().loadingSlots().length);
+    }
+
+    @Test
+    void defaults_noEmptyStateItemNorFrameSlots() {
+        PaginationSpec<String> spec = ((PaginationImpl<String>) eagerBuilder(new TestView())
+                .itemRenderer(renderer()).build()).spec();
+
+        assertNull(spec.emptyStateItem());
+        assertEquals(0, spec.emptyStateSlots().length);
+        assertEquals(0, spec.loadingSlots().length);
     }
 }

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpecTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpecTest.java
@@ -55,7 +55,8 @@ class PaginationSourceSpecTest {
 
     // pins the package-private PaginationSpec constructor order Task 8's builder must use:
     // (geometry, target, layoutChar, explicitLayout, patterns, renderer, fallbackItem,
-    //  loadingItem, source, errorCallback, requestTimeout, cacheTtl, cacheMaxPages)
+    //  loadingItem, source, errorCallback, requestTimeout, cacheTtl, cacheMaxPages,
+    //  emptyStateItem, emptyStateSlots, loadingSlots)
     private PaginationSpec<Integer> specOf(PaginationSourceSpec<Integer> source) {
         // the renderer is a no-op lambda: createSource never invokes it
         return new PaginationSpec<Integer>(PaginationSpec.Geometry.NORMAL,

--- a/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpecTest.java
+++ b/platform-spigot/inventory-api/api/src/test/java/tech/guilhermekaua/spigotboot/inventoryapi/internal/pagination/PaginationSourceSpecTest.java
@@ -60,7 +60,8 @@ class PaginationSourceSpecTest {
         // the renderer is a no-op lambda: createSource never invokes it
         return new PaginationSpec<Integer>(PaginationSpec.Geometry.NORMAL,
                 PaginationSpec.Target.LAYOUT_CHAR, 'O', null, Collections.emptyList(),
-                (ctx, item, index, value) -> { }, null, null, source, null, null, null, 128);
+                (ctx, item, index, value) -> { }, null, null, source, null, null, null, 128,
+                null, new int[0], new int[0]);
     }
 
     @Test
@@ -144,7 +145,8 @@ class PaginationSourceSpecTest {
         PaginationSpec<Integer> spec = new PaginationSpec<Integer>(PaginationSpec.Geometry.NORMAL,
                 PaginationSpec.Target.LAYOUT_CHAR, 'O', null, Collections.emptyList(),
                 (ctx, item, index, value) -> { }, null, null, sourceSpec,
-                (request, error) -> { }, Duration.ofSeconds(5), Duration.ofSeconds(30), 64);
+                (request, error) -> { }, Duration.ofSeconds(5), Duration.ofSeconds(30), 64,
+                null, new int[0], new int[0]);
 
         PageSource<Integer> first = sourceSpec.createSource(context, spec, scheduler);
         PageSource<Integer> second = sourceSpec.createSource(context, spec, scheduler);


### PR DESCRIPTION
## Summary

Lets a paginated view render its empty-state and loading frame items in **specific absolute slots** instead of across the whole pagination layout — e.g. a single centered "no results" item, or a single centered loading spinner.

```java
paginateAsync(this::loadPage)
    .layoutChar('O')
    .itemRenderer(...)
    .emptyStateItem(ctx -> new ItemStack(Material.BARRIER), 22) // only slot 22 when the page is empty
    .loadingItem(ctx -> new ItemStack(Material.CLOCK), 22);     // only slot 22 while loading
```

Previously the only frame option (`fallbackItem`) filled **every** layout slot, and putting a component on a layout slot threw `slot N is bound to both a component and pagination`.

## What changed

- **New API** (`PaginationBuilder`): `emptyStateItem(fn, int... slots)` (eager + async) and a `loadingItem(fn, int... slots)` overload (async-only). `fallbackItem(fn)` and `loadingItem(fn)` keep their fill-all behavior unchanged.
- **Semantics** (spec §5): per repaint the binding picks one mode — `loading-slots → empty-slots → normal fill`. The empty-state shows only when the current page settled with zero items, paints just the chosen slots, clears the rest; it suppresses the `fallbackItem` fill on an empty page. Frame items are decorative/inert (not registered as element components), so clicks need no special handling.
- **Coordinates**: absolute slots (0–53), may point anywhere in the container.
- **Validation**: out-of-bounds frame slots rejected at `initialize`; frame slots overlapping a static component or another pagination rejected at open (`ViewConfigurationException` → `OPEN_FAILED`).

## Affected module

`platform-spigot/inventory-api/api` only — `PaginationBuilder`, `PaginationBuilderImpl`, `PaginationSpec`, `Paginator` + `AbstractPageSourcePagination` (new `isCurrentPageEmpty()`), `PaginationBinding` (mode-based `repaint()`), `FirstRenderPhase` (overlap validation).

## Test notes

TDD throughout. New/updated coverage in `PaginationBuilderImplTest` (validation + storage), `PaginationBindingTest` (empty-state + loading render modes, bounds, per-slot evaluation, outside-layout transitions), and a new `PaginationFrameSlotFlowsTest` (end-to-end via `engine.open`: eager-empty, async loading→settle-empty, and both overlap rejections). Full `inventory-api` module suite is green (JDK 21).

## Backward compatibility

Purely additive. No signature changes to existing methods; all three geometries (normal/scroll/pattern) behave as before when the new methods are unused.

## Known semantic

A failed async **first** load currently shows the empty-state frame (the page has zero rendered items and is no longer loading). This follows the spec definition literally and is out of the spec's scope; flagging it in case error-state handling is wanted later.

## Design docs

- Spec: `docs/superpowers/specs/2026-06-18-pagination-slot-targeted-frames-design.md`
- Plan: `docs/superpowers/plans/2026-06-18-pagination-slot-targeted-frames.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)