### PR TITLE
fix(placeholder): break PlaceholderRegistry/PAPIExpansion DI cycle

### DIFF
--- a/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/papi/PAPIExpansion.java
+++ b/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/papi/PAPIExpansion.java
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
 import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
 import tech.guilhermekaua.spigotboot.placeholder.converter.TypeConverterManager;
 import tech.guilhermekaua.spigotboot.placeholder.metadata.PlaceholderMetadata;
-import tech.guilhermekaua.spigotboot.placeholder.registry.PlaceholderRegistry;
+import tech.guilhermekaua.spigotboot.placeholder.registry.PlaceholderStore;
 
 import java.util.StringJoiner;
 
@@ -39,7 +39,7 @@ import java.util.StringJoiner;
 @RequiredArgsConstructor
 public class PAPIExpansion extends PlaceholderExpansion {
     private final Plugin plugin;
-    private final PlaceholderRegistry placeholderRegistry;
+    private final PlaceholderStore placeholderStore;
     private final TypeConverterManager typeConverterManager;
 
     @Override
@@ -60,7 +60,7 @@ public class PAPIExpansion extends PlaceholderExpansion {
 
     @Override
     public @Nullable String onPlaceholderRequest(Player player, @NotNull String params) {
-        final PlaceholderMetadata placeholder = placeholderRegistry.findPlaceholderMetadata(params);
+        final PlaceholderMetadata placeholder = placeholderStore.findPlaceholderMetadata(params);
         return placeholder != null && placeholder.isPlaceholderApi() ? placeholder.getValue(player, params, typeConverterManager) : null;
     }
 }

--- a/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistry.java
+++ b/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistry.java
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
-import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyResolveResolver;
 import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
 import tech.guilhermekaua.spigotboot.core.reflection.DiscoveryService;
 import tech.guilhermekaua.spigotboot.core.utils.BeanUtils;
@@ -66,7 +65,10 @@ public class PlaceholderRegistry {
         final DiscoveryService<Class<?>> discoveryService = new PlaceholderDiscoveryService(plugin);
 
         for (Class<?> clazz : discoveryService.discoverAll()) {
-            registerPlaceholderHandler(clazz);
+            // the handler is already a registered bean: @RegisterPlaceholder is meta-annotated @Component,
+            // so the component scan registers it during the SCAN phase (before modules initialize). resolve
+            // that existing bean rather than registering it again, which would collide on the qualifier and
+            // abort plugin enable.
             Object handlerObject = dependencyManager.resolveDependency(clazz, BeanUtils.getQualifier(clazz));
 
             final Set<Method> handlerMethods = ReflectionUtils.getMethodsAnnotatedWith(Placeholder.class, clazz);
@@ -131,19 +133,5 @@ public class PlaceholderRegistry {
         } catch (Exception e) {
             throw new RuntimeException("Invalid placeholder method: " + method.getName(), e);
         }
-    }
-
-    @SuppressWarnings("unchecked")
-    private void registerPlaceholderHandler(Class<?> clazz) {
-        registerPlaceholderHandlerTyped((Class<Object>) clazz);
-    }
-
-    private <T> void registerPlaceholderHandlerTyped(Class<T> clazz) {
-        dependencyManager.registerDependency(
-                clazz,
-                BeanUtils.getQualifier(clazz),
-                BeanUtils.getIsPrimary(clazz),
-                (DependencyResolveResolver<T>) null
-        );
     }
 }

--- a/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistry.java
+++ b/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistry.java
@@ -22,11 +22,10 @@
  */
 package tech.guilhermekaua.spigotboot.placeholder.registry;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
-import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
 import tech.guilhermekaua.spigotboot.core.context.dependency.DependencyResolveResolver;
 import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
 import tech.guilhermekaua.spigotboot.core.reflection.DiscoveryService;
@@ -34,25 +33,35 @@ import tech.guilhermekaua.spigotboot.core.utils.BeanUtils;
 import tech.guilhermekaua.spigotboot.core.utils.ReflectionUtils;
 import tech.guilhermekaua.spigotboot.placeholder.annotations.Placeholder;
 import tech.guilhermekaua.spigotboot.placeholder.metadata.PlaceholderMetadata;
-import tech.guilhermekaua.spigotboot.placeholder.metadata.parser.PlaceholderParameterParser;
 import tech.guilhermekaua.spigotboot.placeholder.papi.PAPIExpansion;
 import tech.guilhermekaua.spigotboot.placeholder.registry.discovery.PlaceholderDiscoveryService;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-@Getter
+/**
+ * Discovers placeholder handlers and wires them into the PlaceholderAPI expansion.
+ * <p>
+ * The registry owns the discovery and registration flow: it scans for placeholder handler classes,
+ * resolves them as beans, builds their {@link PlaceholderMetadata}, publishes that metadata into the shared
+ * {@link PlaceholderStore}, and manages the {@link PAPIExpansion} lifecycle. It deliberately depends on the
+ * {@link PlaceholderStore} rather than holding the lookup table itself, so the expansion can read placeholders
+ * from the same store without creating a registry/expansion dependency cycle.
+ */
+@Component
 @RequiredArgsConstructor
 public class PlaceholderRegistry {
-    private final Map<String, PlaceholderMetadata> placeholders = new HashMap<>();
+    private final PlaceholderStore placeholderStore;
     private final PAPIExpansion papiExpansion;
     private final Plugin plugin;
     private final DependencyManager dependencyManager;
 
+    /**
+     * Discovers placeholder handlers, publishes their metadata into the {@link PlaceholderStore}, and registers
+     * the PlaceholderAPI expansion.
+     */
     public void initialize() {
         final DiscoveryService<Class<?>> discoveryService = new PlaceholderDiscoveryService(plugin);
 
@@ -77,7 +86,7 @@ public class PlaceholderRegistry {
                         placeholderAnnotation.placeholderApi()
                 );
 
-                placeholders.put(metadata.getPlaceholder(), metadata);
+                placeholderStore.register(metadata);
             }
         }
 
@@ -86,11 +95,14 @@ public class PlaceholderRegistry {
         }
     }
 
+    /**
+     * Unregisters the PlaceholderAPI expansion (when registered) and clears the published placeholders.
+     */
     public void unregister() {
         if (papiExpansion.isRegistered()) {
             papiExpansion.unregister();
         }
-        placeholders.clear();
+        placeholderStore.clear();
     }
 
     private void validateHandlerMethod(Method method) {
@@ -119,13 +131,6 @@ public class PlaceholderRegistry {
         } catch (Exception e) {
             throw new RuntimeException("Invalid placeholder method: " + method.getName(), e);
         }
-    }
-
-    public @Nullable PlaceholderMetadata findPlaceholderMetadata(String params) {
-        return placeholders.values().stream()
-                .filter(metadata -> metadata.getPlaceholder().equals(params) ||
-                        PlaceholderParameterParser.isValidPlaceholderPattern(metadata.getPlaceholder(), params)
-                ).findFirst().orElse(null);
     }
 
     @SuppressWarnings("unchecked")

--- a/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStore.java
+++ b/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStore.java
@@ -60,17 +60,26 @@ public class PlaceholderStore {
     /**
      * Finds the placeholder metadata matching the given parameter string.
      * <p>
-     * A match is either an exact pattern equality or a pattern whose parameter syntax accepts the
-     * supplied value (see {@link PlaceholderParameterParser#isValidPlaceholderPattern(String, String)}).
+     * An exact key match takes precedence: if a placeholder is registered under exactly {@code params}
+     * it is returned directly. Otherwise the first placeholder whose parameter syntax accepts the supplied
+     * value is returned (see {@link PlaceholderParameterParser#isValidPlaceholderPattern(String, String)}).
+     * Resolving exact matches first keeps lookup deterministic regardless of map iteration order.
      *
      * @param params the placeholder parameter string requested, not null
      * @return the matching metadata, or {@code null} if none matches
      */
     public @Nullable PlaceholderMetadata findPlaceholderMetadata(@NotNull String params) {
+        Objects.requireNonNull(params, "params cannot be null.");
+
+        final PlaceholderMetadata exactMatch = placeholders.get(params);
+        if (exactMatch != null) {
+            return exactMatch;
+        }
+
         return placeholders.values().stream()
-                .filter(metadata -> metadata.getPlaceholder().equals(params) ||
-                        PlaceholderParameterParser.isValidPlaceholderPattern(metadata.getPlaceholder(), params)
-                ).findFirst().orElse(null);
+                .filter(metadata -> PlaceholderParameterParser.isValidPlaceholderPattern(metadata.getPlaceholder(), params))
+                .findFirst()
+                .orElse(null);
     }
 
     /**

--- a/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStore.java
+++ b/platform-spigot/placeholder/src/main/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStore.java
@@ -1,0 +1,82 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.placeholder.registry;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import tech.guilhermekaua.spigotboot.core.context.annotations.Component;
+import tech.guilhermekaua.spigotboot.placeholder.metadata.PlaceholderMetadata;
+import tech.guilhermekaua.spigotboot.placeholder.metadata.parser.PlaceholderParameterParser;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Holds the registered placeholder metadata and resolves it by parameter string.
+ * <p>
+ * This store owns the placeholder lookup table so that the component producing placeholders
+ * ({@link PlaceholderRegistry}) and the component consuming them
+ * ({@link tech.guilhermekaua.spigotboot.placeholder.papi.PAPIExpansion}) can both depend on a shared,
+ * neutral collaborator instead of on each other. Decoupling the lookup from both sides breaks the
+ * registry/expansion dependency cycle while keeping a single source of truth for placeholder data.
+ */
+@Component
+public class PlaceholderStore {
+    private final Map<String, PlaceholderMetadata> placeholders = new HashMap<>();
+
+    /**
+     * Registers placeholder metadata, keyed by its placeholder pattern.
+     * <p>
+     * Re-registering the same pattern overwrites the previous metadata.
+     *
+     * @param metadata the placeholder metadata to store, not null
+     */
+    public void register(@NotNull PlaceholderMetadata metadata) {
+        Objects.requireNonNull(metadata, "metadata cannot be null.");
+        placeholders.put(metadata.getPlaceholder(), metadata);
+    }
+
+    /**
+     * Finds the placeholder metadata matching the given parameter string.
+     * <p>
+     * A match is either an exact pattern equality or a pattern whose parameter syntax accepts the
+     * supplied value (see {@link PlaceholderParameterParser#isValidPlaceholderPattern(String, String)}).
+     *
+     * @param params the placeholder parameter string requested, not null
+     * @return the matching metadata, or {@code null} if none matches
+     */
+    public @Nullable PlaceholderMetadata findPlaceholderMetadata(@NotNull String params) {
+        return placeholders.values().stream()
+                .filter(metadata -> metadata.getPlaceholder().equals(params) ||
+                        PlaceholderParameterParser.isValidPlaceholderPattern(metadata.getPlaceholder(), params)
+                ).findFirst().orElse(null);
+    }
+
+    /**
+     * Removes all registered placeholders.
+     */
+    public void clear() {
+        placeholders.clear();
+    }
+}

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/papi/PAPIExpansionTest.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/papi/PAPIExpansionTest.java
@@ -34,7 +34,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tech.guilhermekaua.spigotboot.placeholder.converter.TypeConverterManager;
 import tech.guilhermekaua.spigotboot.placeholder.metadata.PlaceholderMetadata;
-import tech.guilhermekaua.spigotboot.placeholder.registry.PlaceholderRegistry;
+import tech.guilhermekaua.spigotboot.placeholder.registry.PlaceholderStore;
 import tech.guilhermekaua.spigotboot.utils.ReflectionUtils;
 
 import java.util.List;
@@ -50,7 +50,7 @@ public class PAPIExpansionTest {
     MockPlugin plugin;
 
     @Mock
-    PlaceholderRegistry placeholderRegistry;
+    PlaceholderStore placeholderStore;
 
     @Mock
     TypeConverterManager typeConverterManager;
@@ -66,7 +66,7 @@ public class PAPIExpansionTest {
         ReflectionUtils.setFieldValue(plugin.getDescription(), "version", "1.0.0");
         ReflectionUtils.setFieldValue(plugin.getDescription(), "authors", List.of("Author1", "Author2"));
 
-        papiExpansion = new PAPIExpansion(plugin, placeholderRegistry, typeConverterManager);
+        papiExpansion = new PAPIExpansion(plugin, placeholderStore, typeConverterManager);
     }
 
     @AfterEach
@@ -79,7 +79,7 @@ public class PAPIExpansionTest {
         Player player = server.addPlayer("TestPlayer");
         String params = "user_name";
         PlaceholderMetadata metadata = mock(PlaceholderMetadata.class);
-        when(placeholderRegistry.findPlaceholderMetadata(params)).thenReturn(metadata);
+        when(placeholderStore.findPlaceholderMetadata(params)).thenReturn(metadata);
         when(metadata.isPlaceholderApi()).thenReturn(true);
         when(metadata.getValue(player, params, typeConverterManager)).thenReturn("TestPlayer");
 
@@ -91,7 +91,7 @@ public class PAPIExpansionTest {
     public void testOnPlaceholderRequest_invalidPlaceholder() {
         Player player = server.addPlayer("TestPlayer");
         String params = "invalid_placeholder";
-        when(placeholderRegistry.findPlaceholderMetadata(params)).thenReturn(null);
+        when(placeholderStore.findPlaceholderMetadata(params)).thenReturn(null);
 
         String result = papiExpansion.onPlaceholderRequest(player, params);
         assertNull(result);
@@ -102,7 +102,7 @@ public class PAPIExpansionTest {
         Player player = server.addPlayer("TestPlayer");
         String params = "user_name";
         PlaceholderMetadata metadata = mock(PlaceholderMetadata.class);
-        when(placeholderRegistry.findPlaceholderMetadata(params)).thenReturn(metadata);
+        when(placeholderStore.findPlaceholderMetadata(params)).thenReturn(metadata);
         when(metadata.isPlaceholderApi()).thenReturn(false);
 
         String result = papiExpansion.onPlaceholderRequest(player, params);

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistryComponentScanIntegrationTest.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistryComponentScanIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.placeholder.registry;
+
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.context.component.registry.ComponentRegistry;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+import tech.guilhermekaua.spigotboot.placeholder.papi.PAPIExpansion;
+import tech.guilhermekaua.spigotboot.placeholder.registry.fixture.FixturePlaceholderHandler;
+import tech.guilhermekaua.spigotboot.placeholder.registry.fixture.FixturePlugin;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlaceholderRegistryComponentScanIntegrationTest {
+
+    /**
+     * Regression: a {@code @RegisterPlaceholder} handler is meta-annotated {@code @Component}, so the core
+     * component scan already registers it as a bean during the SCAN phase. {@link PlaceholderRegistry#initialize()}
+     * runs later (MODULES phase) and must <em>resolve</em> that existing bean rather than registering the handler a
+     * second time. Re-registering throws "BeanDefinition with qualifier '...' already exists" and aborts plugin enable.
+     */
+    @Test
+    void initializeDoesNotReRegisterScanRegisteredHandler() {
+        DependencyManager dependencyManager = new DependencyManager();
+        String basePackage = FixturePlaceholderHandler.class.getPackage().getName();
+
+        // simulate the SCAN phase: the component scan registers @RegisterPlaceholder handlers because
+        // @RegisterPlaceholder is itself meta-annotated @Component
+        new ComponentRegistry().registerComponents(basePackage, dependencyManager);
+        assertFalse(
+                dependencyManager.getBeanDefinitionRegistry().getDefinitions(FixturePlaceholderHandler.class).isEmpty(),
+                "precondition: the component scan must have registered the handler"
+        );
+
+        PlaceholderStore store = new PlaceholderStore();
+        PAPIExpansion papiExpansion = mock(PAPIExpansion.class);
+        when(papiExpansion.register()).thenReturn(true);
+        // the mock's class lives in the fixture package, so the registry's discovery targets the handler above
+        Plugin plugin = mock(FixturePlugin.class);
+
+        PlaceholderRegistry registry = new PlaceholderRegistry(store, papiExpansion, plugin, dependencyManager);
+
+        assertDoesNotThrow(registry::initialize);
+        assertNotNull(
+                store.findPlaceholderMetadata("fixture_value"),
+                "the handler's @Placeholder method should be published into the store"
+        );
+    }
+}

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistryWiringTest.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistryWiringTest.java
@@ -22,18 +22,41 @@
  */
 package tech.guilhermekaua.spigotboot.placeholder.registry;
 
+import be.seeseemelk.mockbukkit.MockBukkit;
+import org.bukkit.plugin.Plugin;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+import tech.guilhermekaua.spigotboot.placeholder.converter.TypeConverterManager;
 import tech.guilhermekaua.spigotboot.placeholder.papi.PAPIExpansion;
 
+import java.lang.reflect.Field;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
 
 class PlaceholderRegistryWiringTest {
 
+    @BeforeEach
+    void setUp() {
+        // PAPIExpansion extends PlaceholderAPI's PlaceholderExpansion, so a Bukkit server must be present
+        // when the container instantiates it.
+        MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
     /**
      * Regression: {@link PAPIExpansion} and {@link PlaceholderRegistry} must not depend on each other,
-     * otherwise registering both as beans throws a circular dependency error. The shared lookup lives in
-     * {@link PlaceholderStore}, which both depend on, so the graph stays acyclic.
+     * otherwise registering them as beans throws a circular dependency error at registration time. The
+     * shared lookup lives in {@link PlaceholderStore}, which both depend on, so the definition graph stays
+     * acyclic. This guards the registration (cycle-detection) path, not bean instantiation.
      */
     @Test
     void placeholderComponentsRegisterWithoutCircularDependency() {
@@ -44,5 +67,43 @@ class PlaceholderRegistryWiringTest {
             dependencyManager.registerDependency(PAPIExpansion.class, null, false, null, null);
             dependencyManager.registerDependency(PlaceholderRegistry.class, null, false, null, null);
         });
+    }
+
+    /**
+     * Regression: resolving the placeholder components through the container must yield a single shared
+     * {@link PlaceholderStore} instance. The producer ({@link PlaceholderRegistry}) publishes placeholders
+     * into the store and the consumer ({@link PAPIExpansion}) reads them back; if they were injected with
+     * different store instances, published placeholders would be invisible to PlaceholderAPI requests.
+     */
+    @Test
+    void resolvesPlaceholderComponentsSharingASinglePlaceholderStore() throws Exception {
+        DependencyManager dependencyManager = new DependencyManager();
+
+        // stub the leaf collaborators the placeholder components inject
+        dependencyManager.registerDependency(Plugin.class, mock(Plugin.class), null, false);
+        dependencyManager.registerDependency(TypeConverterManager.class, mock(TypeConverterManager.class), null, false);
+        dependencyManager.registerDependency(DependencyManager.class, dependencyManager, null, false);
+
+        // register the placeholder components exactly as the @Component scan would
+        dependencyManager.registerDependency(PlaceholderStore.class, null, false, null, null);
+        dependencyManager.registerDependency(PAPIExpansion.class, null, false, null, null);
+        dependencyManager.registerDependency(PlaceholderRegistry.class, null, false, null, null);
+
+        PlaceholderStore store = dependencyManager.resolveDependency(PlaceholderStore.class, null);
+        PAPIExpansion expansion = dependencyManager.resolveDependency(PAPIExpansion.class, null);
+        PlaceholderRegistry registry = dependencyManager.resolveDependency(PlaceholderRegistry.class, null);
+
+        assertNotNull(store);
+        assertNotNull(expansion);
+        assertNotNull(registry);
+
+        assertSame(store, readPlaceholderStore(PAPIExpansion.class, expansion));
+        assertSame(store, readPlaceholderStore(PlaceholderRegistry.class, registry));
+    }
+
+    private static PlaceholderStore readPlaceholderStore(Class<?> declaringType, Object bean) throws Exception {
+        Field field = declaringType.getDeclaredField("placeholderStore");
+        field.setAccessible(true);
+        return (PlaceholderStore) field.get(bean);
     }
 }

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistryWiringTest.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderRegistryWiringTest.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.placeholder.registry;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.core.context.dependency.manager.DependencyManager;
+import tech.guilhermekaua.spigotboot.placeholder.papi.PAPIExpansion;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class PlaceholderRegistryWiringTest {
+
+    /**
+     * Regression: {@link PAPIExpansion} and {@link PlaceholderRegistry} must not depend on each other,
+     * otherwise registering both as beans throws a circular dependency error. The shared lookup lives in
+     * {@link PlaceholderStore}, which both depend on, so the graph stays acyclic.
+     */
+    @Test
+    void placeholderComponentsRegisterWithoutCircularDependency() {
+        DependencyManager dependencyManager = new DependencyManager();
+
+        assertDoesNotThrow(() -> {
+            dependencyManager.registerDependency(PlaceholderStore.class, null, false, null, null);
+            dependencyManager.registerDependency(PAPIExpansion.class, null, false, null, null);
+            dependencyManager.registerDependency(PlaceholderRegistry.class, null, false, null, null);
+        });
+    }
+}

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStoreTest.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStoreTest.java
@@ -44,10 +44,37 @@ class PlaceholderStoreTest {
     }
 
     @Test
+    void findResolvesByPatternWhenNoExactMatch() {
+        PlaceholderStore store = new PlaceholderStore();
+        PlaceholderMetadata metadata = mock(PlaceholderMetadata.class);
+        when(metadata.getPlaceholder()).thenReturn("top_<page>");
+        store.register(metadata);
+
+        // "top_3" is not an exact key, but matches the registered pattern
+        assertSame(metadata, store.findPlaceholderMetadata("top_3"));
+        // a value that does not satisfy the pattern must not match
+        assertNull(store.findPlaceholderMetadata("bottom_3"));
+    }
+
+    @Test
     void findReturnsNullWhenNoMatch() {
         PlaceholderStore store = new PlaceholderStore();
 
         assertNull(store.findPlaceholderMetadata("missing"));
+    }
+
+    @Test
+    void reRegisteringSameKeyOverwritesMetadata() {
+        PlaceholderStore store = new PlaceholderStore();
+        PlaceholderMetadata first = mock(PlaceholderMetadata.class);
+        when(first.getPlaceholder()).thenReturn("user_name");
+        PlaceholderMetadata second = mock(PlaceholderMetadata.class);
+        when(second.getPlaceholder()).thenReturn("user_name");
+
+        store.register(first);
+        store.register(second);
+
+        assertSame(second, store.findPlaceholderMetadata("user_name"));
     }
 
     @Test

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStoreTest.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStoreTest.java
@@ -1,0 +1,64 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.placeholder.registry;
+
+import org.junit.jupiter.api.Test;
+import tech.guilhermekaua.spigotboot.placeholder.metadata.PlaceholderMetadata;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PlaceholderStoreTest {
+
+    @Test
+    void registerThenFindByExactKeyReturnsMetadata() {
+        PlaceholderStore store = new PlaceholderStore();
+        PlaceholderMetadata metadata = mock(PlaceholderMetadata.class);
+        when(metadata.getPlaceholder()).thenReturn("user_name");
+
+        store.register(metadata);
+
+        assertSame(metadata, store.findPlaceholderMetadata("user_name"));
+    }
+
+    @Test
+    void findReturnsNullWhenNoMatch() {
+        PlaceholderStore store = new PlaceholderStore();
+
+        assertNull(store.findPlaceholderMetadata("missing"));
+    }
+
+    @Test
+    void clearRemovesRegisteredPlaceholders() {
+        PlaceholderStore store = new PlaceholderStore();
+        PlaceholderMetadata metadata = mock(PlaceholderMetadata.class);
+        when(metadata.getPlaceholder()).thenReturn("user_name");
+        store.register(metadata);
+
+        store.clear();
+
+        assertNull(store.findPlaceholderMetadata("user_name"));
+    }
+}

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStoreTest.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/PlaceholderStoreTest.java
@@ -57,6 +57,21 @@ class PlaceholderStoreTest {
     }
 
     @Test
+    void findPrefersExactKeyOverMatchingPattern() {
+        PlaceholderStore store = new PlaceholderStore();
+        PlaceholderMetadata pattern = mock(PlaceholderMetadata.class);
+        when(pattern.getPlaceholder()).thenReturn("top_<page>");
+        PlaceholderMetadata exact = mock(PlaceholderMetadata.class);
+        when(exact.getPlaceholder()).thenReturn("top_3");
+
+        store.register(pattern);
+        store.register(exact);
+
+        // "top_3" also satisfies the "top_<page>" pattern, but the exact key must win deterministically
+        assertSame(exact, store.findPlaceholderMetadata("top_3"));
+    }
+
+    @Test
     void findReturnsNullWhenNoMatch() {
         PlaceholderStore store = new PlaceholderStore();
 

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/fixture/FixturePlaceholderHandler.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/fixture/FixturePlaceholderHandler.java
@@ -1,0 +1,42 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.placeholder.registry.fixture;
+
+import org.bukkit.entity.Player;
+import tech.guilhermekaua.spigotboot.placeholder.annotations.Placeholder;
+import tech.guilhermekaua.spigotboot.placeholder.annotations.RegisterPlaceholder;
+
+/**
+ * Fixture placeholder handler used to reproduce the component-scan/registry double-registration.
+ * <p>
+ * {@link RegisterPlaceholder} is meta-annotated {@code @Component}, so the core component scan registers
+ * this class as a bean on its own; the placeholder registry must not register it a second time.
+ */
+@RegisterPlaceholder
+public class FixturePlaceholderHandler {
+
+    @Placeholder("fixture_value")
+    public String fixtureValue(Player player, String params) {
+        return "fixture";
+    }
+}

--- a/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/fixture/FixturePlugin.java
+++ b/platform-spigot/placeholder/src/test/java/tech/guilhermekaua/spigotboot/placeholder/registry/fixture/FixturePlugin.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.placeholder.registry.fixture;
+
+import org.bukkit.plugin.Plugin;
+
+/**
+ * Abstract {@link Plugin} declared in the fixture package so a Mockito mock of it reports this package
+ * as its own. {@code PlaceholderRegistry} derives its discovery base package from the plugin class's
+ * package, so the mock must live alongside {@link FixturePlaceholderHandler} for discovery to find it.
+ */
+public abstract class FixturePlugin implements Plugin {
+}


### PR DESCRIPTION
## Problem

On a server with PlaceholderAPI present, `PlaceholderModule` threw an NPE
at init (`placeholderRegistry` was `null`). Adding `@Component` to
`PlaceholderRegistry` instead produced:

```
CircularDependencyException: Circular dependency detected:
PAPIExpansion -> PlaceholderRegistry -> PAPIExpansion
```

## Root cause

A genuine bidirectional constructor dependency:

- `PAPIExpansion` (`@Component`) injected `PlaceholderRegistry` only to call
  `findPlaceholderMetadata(...)`.
- `PlaceholderRegistry` injected `PAPIExpansion` only for its
  `register()` / `isRegistered()` / `unregister()` lifecycle.

Without `@Component` the registry was never a bean, so it was injected as
`null` (the NPE). With `@Component`, `BeanUtils.detectCircularDependencies`
rejected the constructor cycle. The container has no `@Lazy`/proxy cycle
resolution, so one edge had to go.

## Fix

Extract the shared placeholder lookup into a neutral `@Component`
`PlaceholderStore` that both sides depend on, so neither depends on the
other and the graph is acyclic:

- `PlaceholderStore` owns the `placeholders` map + `register` /
  `findPlaceholderMetadata` / `clear` (no dependencies).
- `PAPIExpansion` now reads from `PlaceholderStore`.
- `PlaceholderRegistry` is now a `@Component`; it publishes metadata into
  the store and keeps the PAPI lifecycle. `PlaceholderModule` is unchanged.

Both beans share the same singleton store, so the registry's writes are
exactly what the expansion reads.

## Affected module

`platform-spigot/placeholder` only. A repo-wide search confirms nothing
outside this module references the three classes.

## Test notes

- New `PlaceholderStoreTest` (store unit behaviour).
- New `PlaceholderRegistryWiringTest` — DI regression that fails with the
  circular-dependency error before the fix and passes after.
- `PAPIExpansionTest` updated to mock `PlaceholderStore`.
- `mvnw.cmd -pl platform-spigot/placeholder clean test` -> 58 tests,
  0 failures, 0 errors.