### PR TITLE
fix(core-spigot): resolve animal-sniffer 1.8.8 getClass() false positive

### DIFF
--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilder.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilder.java
@@ -305,7 +305,7 @@ public class ItemBuilder {
         }
         return changeItemMeta(meta -> {
             try {
-                meta.getClass().getMethod("setCustomModelData", Integer.class).invoke(meta, data);
+                ItemMeta.class.getMethod("setCustomModelData", Integer.class).invoke(meta, data);
             } catch (ReflectiveOperationException ignored) {
                 // pre-1.14: no custom model data support
             }


### PR DESCRIPTION
## Summary

`ItemBuilder#setCustomModelData` resolved its reflective target via `meta.getClass()`, which invokes `java.lang.Object#getClass()` on a Bukkit interface receiver (`ItemMeta`). The animal-sniffer 1.8.8 signature carries no JDK API, and interface signatures do not inherit `Object`'s methods, so the `check-spigot-188-api` execution failed with:

```
Undefined reference: Class org.bukkit.inventory.meta.ItemMeta.getClass()
```

This is the documented limitation called out in the root `pom.xml` (*"methods inherited from JDK supertypes but invoked on a Bukkit-typed receiver … rewrite the call site"*).

## Fix

Resolve the method via the `ItemMeta.class` literal instead of `meta.getClass()`, matching the existing `ItemUtils#trySetOwningPlayer` idiom (`SkullMeta.class.getMethod(...)`). A class literal is not a method call on a Bukkit receiver, and `getMethod`/`invoke` run on `java.lang.Class`/`Method` (covered by the `java.*` ignore).

Runtime behaviour is unchanged:
- 1.14+: the public interface method resolves and is invoked.
- 1.8.8: `getMethod` throws `NoSuchMethodException` → caught → no-op, exactly as before.

## Affected module

`platform-spigot/core-spigot`

## Test notes

`mvnw -pl platform-spigot/core-spigot clean verify` now recompiles and runs the `check-spigot-188-api` execution against the installed 1.8.8 signature with `BUILD SUCCESS` (no `Undefined reference`). One-line change, no behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)