### PR TITLE
fix(data-jdbc): avoid BatchUpdateException on old SQLite JDBC drivers

### DIFF
--- a/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/dialect/SQLiteDialect.java
+++ b/modules/data-jdbc/src/main/java/tech/guilhermekaua/spigotboot/data/jdbc/dialect/SQLiteDialect.java
@@ -102,7 +102,14 @@ public class SQLiteDialect implements Dialect {
     @Override
     public void configureDataSource(HikariDataSource ds) {
         ds.setMaximumPoolSize(1);
-        ds.addDataSourceProperty("journal_mode", "WAL");
+        // journal_mode must not be set as a DataSource property because
+        // SQLiteConfig.apply() runs all properties via executeBatch(),
+        // and PRAGMA journal_mode returns a result set, which old SQLite
+        // JDBC drivers (e.g. the one bundled with PaperSpigot 1.8.8) reject
+        // with "batch entry 0: query returns results".
+        // connectionInitSql runs via Statement.execute() after connection
+        // creation, which handles result-returning PRAGMAs correctly.
+        ds.setConnectionInitSql("PRAGMA journal_mode=WAL");
         ds.addDataSourceProperty("foreign_keys", "ON");
     }
 }


### PR DESCRIPTION
## Summary
- Moves `journal_mode=WAL` from `addDataSourceProperty()` to `setConnectionInitSql()` in `SQLiteDialect.configureDataSource()`
- `SQLiteConfig.apply()` runs DataSource properties via `executeBatch()`, but `PRAGMA journal_mode` returns a result set, which old SQLite JDBC drivers (e.g. the one bundled with PaperSpigot 1.8.8) reject with `BatchUpdateException: batch entry 0: query returns results`
- `connectionInitSql` runs via `Statement.execute()` after connection creation, which handles result-returning PRAGMAs correctly

## Test plan
- [x] All 83 existing data-jdbc tests pass
- [ ] Verify on PaperSpigot 1.8.8 server with a plugin using SQLite persistence (the original reproduction environment)