### PR TITLE
feat(core-spigot): version-proof head skins, drop NBTEditor

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,3 @@
 > Work In Progress
 
 Spigot Boot is a powerful library inspired by Spring Boot, designed specifically for Spigot plugins for Minecraft.
-
-## Credits:
-
-- NBTEditor: https://github.com/BananaPuncher714/NBTEditor

--- a/platform-spigot/core-spigot/pom.xml
+++ b/platform-spigot/core-spigot/pom.xml
@@ -55,9 +55,9 @@
                 <configuration>
                     <!-- TypeUtil#convertFromLegacy: UnsafeValues#fromLegacy (1.13+) is data-gated -
                          Material.valueOf("LEGACY_"+name) throws on 1.8.8 before the call is reached.
-                         (ItemUtils#getHeadByUuid calls the 1.12.1+ SkullMeta#setOwningPlayer
+                         (HeadUtils#getHeadByUuid calls the 1.12.1+ SkullMeta#setOwningPlayer
                          reflectively instead of ignoring the class, so the rest of the SkullMeta
-                         api stays checked - see ItemUtils#trySetOwningPlayer.)
+                         api stays checked - see HeadUtils#trySetOwningPlayer.)
                          combine.children="append" merges with the managed java.*/javax.* ignores
                          instead of replacing them -->
                     <ignores combine.children="append">
@@ -100,7 +100,7 @@
             <artifactId>MockBukkit-v1.20</artifactId>
         </dependency>
 
-        <!-- Exercises the legacy (1.8-1.17) GameProfile texture path in ItemUtils. authlib ships with
+        <!-- Exercises the legacy (1.8-1.17) GameProfile texture path in HeadUtils. authlib ships with
              the server at runtime, so this is test-scoped only. -->
         <dependency>
             <groupId>com.mojang</groupId>

--- a/platform-spigot/core-spigot/pom.xml
+++ b/platform-spigot/core-spigot/pom.xml
@@ -48,37 +48,6 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>shade-nbteditor</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <!-- nbteditor is only on the CodeMC repo, not on Maven Central, so it cannot
-                                 stay a normal transitive dependency. bundle it into this jar (and drop it
-                                 from the published pom) so consumers need no extra repository, and relocate
-                                 it so it cannot clash with other plugins that also shade NBTEditor. -->
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <artifactSet>
-                                <includes>
-                                    <include>io.github.bananapuncher714:nbteditor</include>
-                                </includes>
-                            </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>io.github.bananapuncher714.nbteditor</pattern>
-                                    <shadedPattern>tech.guilhermekaua.spigotboot.shaded.nbteditor</shadedPattern>
-                                </relocation>
-                            </relocations>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- activates the managed spigot-api 1.8.8 check (config in the root pom) -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -106,13 +75,6 @@
         </plugins>
     </build>
 
-    <repositories>
-        <repository>
-            <id>CodeMC</id>
-            <url>https://repo.codemc.org/repository/maven-public/</url>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>io.papermc.paper</groupId>
@@ -126,12 +88,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.bananapuncher714</groupId>
-            <artifactId>nbteditor</artifactId>
-            <version>7.19.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>tech.guilhermekaua.spigot-boot</groupId>
             <artifactId>spigot-boot-annotation-processor-spigot</artifactId>
             <version>${project.version}</version>
@@ -142,6 +98,15 @@
         <dependency>
             <groupId>com.github.seeseemelk</groupId>
             <artifactId>MockBukkit-v1.20</artifactId>
+        </dependency>
+
+        <!-- Exercises the legacy (1.8-1.17) GameProfile texture path in ItemUtils. authlib ships with
+             the server at runtime, so this is test-scoped only. -->
+        <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>authlib</artifactId>
+            <version>3.17.30</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/HeadUtils.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/HeadUtils.java
@@ -39,7 +39,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-public final class ItemUtils {
+public final class HeadUtils {
 
     /**
      * Lazily-resolved handles for the modern Bukkit profile API (introduced in 1.18.1 and stable
@@ -54,7 +54,7 @@ public final class ItemUtils {
      */
     private static final ConcurrentMap<Class<?>, Optional<Field>> PROFILE_FIELD_CACHE = new ConcurrentHashMap<>();
 
-    private ItemUtils() {
+    private HeadUtils() {
     }
 
     public static ItemStack getHeadByName(String name) {
@@ -251,7 +251,7 @@ public final class ItemUtils {
     }
 
     private static Field profileField(Class<?> metaClass) {
-        return PROFILE_FIELD_CACHE.computeIfAbsent(metaClass, ItemUtils::findProfileField).orElse(null);
+        return PROFILE_FIELD_CACHE.computeIfAbsent(metaClass, HeadUtils::findProfileField).orElse(null);
     }
 
     private static Optional<Field> findProfileField(Class<?> metaClass) {
@@ -273,7 +273,7 @@ public final class ItemUtils {
     private static Optional<ProfileApi> profileApi() {
         Optional<ProfileApi> resolved = profileApi;
         if (resolved == null) {
-            synchronized (ItemUtils.class) {
+            synchronized (HeadUtils.class) {
                 resolved = profileApi;
                 if (resolved == null) {
                     resolved = resolveProfileApi();

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilder.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilder.java
@@ -94,14 +94,14 @@ public class ItemBuilder {
 
     /**
      * Replaces the current item with a player head skinned from a Mojang texture URL. Works
-     * version-proof from 1.8.8 to the latest release (see {@link ItemUtils#getHeadByUrl(String)}); a
+     * version-proof from 1.8.8 to the latest release (see {@link HeadUtils#getHeadByUrl(String)}); a
      * null, blank, or malformed URL yields a bare head rather than throwing.
      *
      * @param url the Mojang texture URL (e.g. {@code http://textures.minecraft.net/texture/<hash>})
      * @return this ItemBuilder instance for chaining
      */
     public ItemBuilder headUrl(String url) {
-        this.item = ItemUtils.getHeadByUrl(url);
+        this.item = HeadUtils.getHeadByUrl(url);
         return this;
     }
 
@@ -112,7 +112,7 @@ public class ItemBuilder {
      * @return this ItemBuilder instance for chaining
      */
     public ItemBuilder headName(String name) {
-        this.item = ItemUtils.getHeadByName(name);
+        this.item = HeadUtils.getHeadByName(name);
         return this;
     }
 
@@ -123,7 +123,7 @@ public class ItemBuilder {
      * @return this ItemBuilder instance for chaining
      */
     public ItemBuilder headUUID(UUID uuid) {
-        this.item = ItemUtils.getHeadByUuid(uuid);
+        this.item = HeadUtils.getHeadByUuid(uuid);
         return this;
     }
 
@@ -143,7 +143,7 @@ public class ItemBuilder {
                 // fall through to a bare, owner-less head
             }
         }
-        this.item = ItemUtils.getHeadByUuid(parsed);
+        this.item = HeadUtils.getHeadByUuid(parsed);
         return this;
     }
 

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilder.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilder.java
@@ -22,7 +22,6 @@
  */
 package tech.guilhermekaua.spigotboot.core.spigot.utils;
 
-import io.github.bananapuncher714.nbteditor.NBTEditor;
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -35,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -74,15 +74,6 @@ public class ItemBuilder {
     }
 
     /**
-     * Creates a new ItemBuilder with a skull item from the given URL.
-     *
-     * @param url the URL to get the skull item from
-     */
-    public ItemBuilder(String url) {
-        item = NBTEditor.getHead(url);
-    }
-
-    /**
      * Creates a new ItemBuilder with a leather armor item of the given color.
      *
      * @param type  the Material type to use
@@ -98,6 +89,61 @@ public class ItemBuilder {
 
     public ItemBuilder setItem(ItemStack item) {
         this.item = item;
+        return this;
+    }
+
+    /**
+     * Replaces the current item with a player head skinned from a Mojang texture URL. Works
+     * version-proof from 1.8.8 to the latest release (see {@link ItemUtils#getHeadByUrl(String)}); a
+     * null, blank, or malformed URL yields a bare head rather than throwing.
+     *
+     * @param url the Mojang texture URL (e.g. {@code http://textures.minecraft.net/texture/<hash>})
+     * @return this ItemBuilder instance for chaining
+     */
+    public ItemBuilder headUrl(String url) {
+        this.item = ItemUtils.getHeadByUrl(url);
+        return this;
+    }
+
+    /**
+     * Replaces the current item with a player head owned by the named player.
+     *
+     * @param name the player name whose skin to use
+     * @return this ItemBuilder instance for chaining
+     */
+    public ItemBuilder headName(String name) {
+        this.item = ItemUtils.getHeadByName(name);
+        return this;
+    }
+
+    /**
+     * Replaces the current item with a player head owned by the player with the given UUID.
+     *
+     * @param uuid the player UUID whose skin to use
+     * @return this ItemBuilder instance for chaining
+     */
+    public ItemBuilder headUUID(UUID uuid) {
+        this.item = ItemUtils.getHeadByUuid(uuid);
+        return this;
+    }
+
+    /**
+     * Replaces the current item with a player head owned by the player with the given UUID string. A
+     * null or unparseable UUID yields a bare head rather than throwing.
+     *
+     * @param uuid the player UUID in canonical string form
+     * @return this ItemBuilder instance for chaining
+     */
+    public ItemBuilder headUUID(String uuid) {
+        UUID parsed = null;
+        if (uuid != null) {
+            try {
+                parsed = UUID.fromString(uuid.trim());
+            } catch (IllegalArgumentException ignored) {
+                // fall through to a bare, owner-less head
+            }
+        }
+        this.item = ItemUtils.getHeadByUuid(parsed);
         return this;
     }
 

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemUtils.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemUtils.java
@@ -28,16 +28,37 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 public final class ItemUtils {
+
+    /**
+     * Lazily-resolved handles for the modern Bukkit profile API (introduced in 1.18.1 and stable
+     * through the latest release). {@code null} until first resolved; the inner {@link Optional} is
+     * empty on servers that predate the API (1.8-1.17.x), which then use the legacy field path.
+     */
+    private static volatile Optional<ProfileApi> profileApi;
+
+    /**
+     * Per-meta-class cache of the legacy CraftBukkit {@code CraftMetaSkull#profile} field, so the
+     * reflective field lookup runs once per skull-meta implementation rather than per head.
+     */
+    private static final ConcurrentMap<Class<?>, Optional<Field>> PROFILE_FIELD_CACHE = new ConcurrentHashMap<>();
+
+    private ItemUtils() {
+    }
+
     public static ItemStack getHeadByName(String name) {
-        Material material = Material.getMaterial("SKULL_ITEM");
-        if (material == null) {
-            // Most likely 1.13 materials
-            material = Material.getMaterial("PLAYER_HEAD");
-        }
-        final ItemStack head = new ItemStack(material, 1, (short) 3);
+        final ItemStack head = createPlayerHead();
         if (name == null || name.isEmpty()) {
             return head;
         }
@@ -49,12 +70,7 @@ public final class ItemUtils {
     }
 
     public static ItemStack getHeadByUuid(UUID uuid) {
-        Material material = Material.getMaterial("SKULL_ITEM");
-        if (material == null) {
-            // Most likely 1.13 materials
-            material = Material.getMaterial("PLAYER_HEAD");
-        }
-        final ItemStack head = new ItemStack(material, 1, (short) 3);
+        final ItemStack head = createPlayerHead();
         if (uuid == null) {
             return head;
         }
@@ -75,6 +91,214 @@ public final class ItemUtils {
     }
 
     /**
+     * Builds a player head skinned from a Mojang texture URL (e.g.
+     * {@code http://textures.minecraft.net/texture/<hash>}), replacing the removed
+     * {@code NBTEditor.getHead(url)} dependency.
+     *
+     * <p>The texture is applied version-proof from 1.8.8 to the latest release via two tiers, both
+     * invoked reflectively so this stays compilable under the 1.8.8 signature check and safe at
+     * runtime on servers where a given API is absent:
+     * <ol>
+     *     <li><b>1.18.1+</b>: the public Bukkit {@code PlayerProfile} API
+     *         ({@code Bukkit.createPlayerProfile} → {@code PlayerTextures.setSkin(URL)} →
+     *         {@code SkullMeta.setOwnerProfile}). This survives the 1.20.5 internal
+     *         {@code GameProfile → ResolvableProfile} refactor because it never touches internals.</li>
+     *     <li><b>1.8-1.17.x</b>: reflection into the skull meta's private {@code profile} field with a
+     *         {@code com.mojang.authlib.GameProfile} carrying a base64 textures property.</li>
+     * </ol>
+     *
+     * <p>A null, blank, or malformed URL yields a bare (owner-less) player head rather than throwing,
+     * so a GUI never fails to render.
+     *
+     * @param url the Mojang texture URL, or null/blank for a bare head
+     * @return a player-head {@link ItemStack}
+     */
+    public static ItemStack getHeadByUrl(String url) {
+        final ItemStack head = createPlayerHead();
+        if (url == null || url.trim().isEmpty()) {
+            return head;
+        }
+        final SkullMeta headMeta = (SkullMeta) head.getItemMeta();
+        if (headMeta == null) {
+            return head;
+        }
+        applySkinUrl(headMeta, url.trim());
+        head.setItemMeta(headMeta);
+        return head;
+    }
+
+    /**
+     * Creates a bare player-head {@link ItemStack}, resolving the material by name so it works both
+     * pre-flattening ({@code SKULL_ITEM} with data {@code 3}) and post-flattening
+     * ({@code PLAYER_HEAD}, where the legacy data value is ignored).
+     */
+    private static ItemStack createPlayerHead() {
+        Material material = Material.getMaterial("SKULL_ITEM");
+        if (material == null) {
+            // Most likely 1.13 materials
+            material = Material.getMaterial("PLAYER_HEAD");
+        }
+        return new ItemStack(material, 1, (short) 3);
+    }
+
+    /**
+     * Applies a skin URL to the given skull meta, preferring the modern profile API and falling back
+     * to the legacy {@code GameProfile} field. Never throws.
+     *
+     * @return {@code true} if either tier applied the texture
+     */
+    static boolean applySkinUrl(SkullMeta meta, String url) {
+        if (applyViaProfileApi(meta, url)) {
+            return true;
+        }
+        return applyViaGameProfileField(meta, url);
+    }
+
+    /**
+     * Tier 1 (1.18.1+): applies the skin through the public Bukkit {@code PlayerProfile} API. Returns
+     * {@code false} when the API is absent or any reflective step fails, so the caller can fall back.
+     */
+    static boolean applyViaProfileApi(SkullMeta meta, String url) {
+        final ProfileApi api = profileApi().orElse(null);
+        if (api == null) {
+            return false;
+        }
+        try {
+            final URL skinUrl = new URL(url);
+            final Object profile = api.createPlayerProfile.invoke(null, UUID.randomUUID());
+            if (profile == null) {
+                return false;
+            }
+            final Object textures = api.getTextures.invoke(profile);
+            if (textures == null) {
+                return false;
+            }
+            api.setSkin.invoke(textures, skinUrl);
+            api.setOwnerProfile.invoke(meta, profile);
+            return true;
+        } catch (MalformedURLException | ReflectiveOperationException | RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Tier 2 (1.8-1.17.x): applies the skin by writing a {@code GameProfile} with a base64 textures
+     * property into the skull meta's private {@code profile} field.
+     */
+    static boolean applyViaGameProfileField(SkullMeta meta, String url) {
+        final Object gameProfile = createGameProfile(url);
+        if (gameProfile == null) {
+            return false;
+        }
+        return writeProfileField(meta, gameProfile);
+    }
+
+    /**
+     * Builds a {@code com.mojang.authlib.GameProfile} (reflectively, to avoid a compile-time authlib
+     * reference) with a random UUID and a {@code textures} property carrying the base64-encoded skin.
+     *
+     * @return the profile, or {@code null} if authlib is unavailable or construction fails
+     */
+    static Object createGameProfile(String url) {
+        try {
+            final Class<?> gameProfileClass = Class.forName("com.mojang.authlib.GameProfile");
+            final Class<?> propertyClass = Class.forName("com.mojang.authlib.properties.Property");
+
+            final Object gameProfile = gameProfileClass
+                    .getConstructor(UUID.class, String.class)
+                    .newInstance(UUID.randomUUID(), "");
+            final Object property = propertyClass
+                    .getConstructor(String.class, String.class)
+                    .newInstance("textures", encodeSkinTexture(url));
+
+            final Object properties = gameProfileClass.getMethod("getProperties").invoke(gameProfile);
+            properties.getClass()
+                    .getMethod("put", Object.class, Object.class)
+                    .invoke(properties, "textures", property);
+            return gameProfile;
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            return null;
+        }
+    }
+
+    /**
+     * Writes {@code gameProfile} into the {@code profile} field declared by {@code meta}'s class (or a
+     * superclass), caching the resolved field per meta class. Returns {@code false} when the field is
+     * absent (non-CraftBukkit meta) or the value is not assignable (e.g. a 1.20.5+ server whose field
+     * type changed, though that path is never reached because Tier 1 handles those versions).
+     */
+    static boolean writeProfileField(Object meta, Object gameProfile) {
+        final Field field = profileField(meta.getClass());
+        if (field == null) {
+            return false;
+        }
+        try {
+            field.set(meta, gameProfile);
+            return true;
+        } catch (IllegalAccessException | RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Base64-encodes the minimal Mojang skin-texture JSON for the given URL. The URL is escaped for
+     * the two JSON metacharacters it could theoretically contain, so the payload is always valid JSON.
+     */
+    static String encodeSkinTexture(String url) {
+        final String escaped = url.replace("\\", "\\\\").replace("\"", "\\\"");
+        final String json = "{\"textures\":{\"SKIN\":{\"url\":\"" + escaped + "\"}}}";
+        return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Field profileField(Class<?> metaClass) {
+        return PROFILE_FIELD_CACHE.computeIfAbsent(metaClass, ItemUtils::findProfileField).orElse(null);
+    }
+
+    private static Optional<Field> findProfileField(Class<?> metaClass) {
+        Class<?> current = metaClass;
+        while (current != null && current != Object.class) {
+            try {
+                final Field field = current.getDeclaredField("profile");
+                field.setAccessible(true);
+                return Optional.of(field);
+            } catch (NoSuchFieldException ignored) {
+                current = current.getSuperclass();
+            } catch (RuntimeException ignored) {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<ProfileApi> profileApi() {
+        Optional<ProfileApi> resolved = profileApi;
+        if (resolved == null) {
+            synchronized (ItemUtils.class) {
+                resolved = profileApi;
+                if (resolved == null) {
+                    resolved = resolveProfileApi();
+                    profileApi = resolved;
+                }
+            }
+        }
+        return resolved;
+    }
+
+    static Optional<ProfileApi> resolveProfileApi() {
+        try {
+            final Class<?> profileClass = Class.forName("org.bukkit.profile.PlayerProfile");
+            final Class<?> texturesClass = Class.forName("org.bukkit.profile.PlayerTextures");
+            final Method createPlayerProfile = Bukkit.class.getMethod("createPlayerProfile", UUID.class);
+            final Method getTextures = profileClass.getMethod("getTextures");
+            final Method setSkin = texturesClass.getMethod("setSkin", URL.class);
+            final Method setOwnerProfile = SkullMeta.class.getMethod("setOwnerProfile", profileClass);
+            return Optional.of(new ProfileApi(createPlayerProfile, getTextures, setSkin, setOwnerProfile));
+        } catch (ClassNotFoundException | NoSuchMethodException | RuntimeException ignored) {
+            return Optional.empty();
+        }
+    }
+
+    /**
      * Sets the skull owner via {@code SkullMeta#setOwningPlayer(OfflinePlayer)} (1.12.1+),
      * invoked reflectively on purpose: keeping a direct bytecode reference out of this module
      * lets the animal-sniffer 1.8.8 check keep covering the rest of the {@link SkullMeta} API
@@ -91,6 +315,21 @@ public final class ItemUtils {
             return true;
         } catch (ReflectiveOperationException e) {
             return false;
+        }
+    }
+
+    /** Cached reflective handles for the modern Bukkit profile API. */
+    static final class ProfileApi {
+        final Method createPlayerProfile;
+        final Method getTextures;
+        final Method setSkin;
+        final Method setOwnerProfile;
+
+        private ProfileApi(Method createPlayerProfile, Method getTextures, Method setSkin, Method setOwnerProfile) {
+            this.createPlayerProfile = createPlayerProfile;
+            this.getTextures = getTextures;
+            this.setSkin = setSkin;
+            this.setOwnerProfile = setOwnerProfile;
         }
     }
 }

--- a/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/Utils.java
+++ b/platform-spigot/core-spigot/src/main/java/tech/guilhermekaua/spigotboot/core/spigot/utils/Utils.java
@@ -54,7 +54,7 @@ public class Utils {
 
         if (useHead) {
             final String url = section.getString("head.url");
-            return new ItemBuilder(url).setName(name).setLore(lore).setGlow(glow).wrap();
+            return new ItemBuilder(material).headUrl(url).setName(name).setLore(lore).setGlow(glow).wrap();
         } else {
             return new ItemBuilder(material, data).setName(name).setLore(lore).setGlow(glow).wrap();
         }

--- a/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/HeadUtilsTest.java
+++ b/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/HeadUtilsTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
-class ItemUtilsTest {
+class HeadUtilsTest {
 
     private static final String SKIN_URL = "http://textures.minecraft.net/texture/deadbeefcafe";
 
@@ -41,19 +41,19 @@ class ItemUtilsTest {
 
     @Test
     void getHeadByUrl_null_returns_bare_player_head() {
-        ItemStack head = ItemUtils.getHeadByUrl(null);
+        ItemStack head = HeadUtils.getHeadByUrl(null);
         assertEquals(Material.PLAYER_HEAD, head.getType());
     }
 
     @Test
     void getHeadByUrl_blank_returns_bare_player_head() {
-        ItemStack head = ItemUtils.getHeadByUrl("   ");
+        ItemStack head = HeadUtils.getHeadByUrl("   ");
         assertEquals(Material.PLAYER_HEAD, head.getType());
     }
 
     @Test
     void getHeadByUrl_valid_url_returns_player_head() {
-        ItemStack head = ItemUtils.getHeadByUrl(SKIN_URL);
+        ItemStack head = HeadUtils.getHeadByUrl(SKIN_URL);
         assertEquals(Material.PLAYER_HEAD, head.getType());
     }
 
@@ -64,10 +64,10 @@ class ItemUtilsTest {
         // Verifies the version-specific reflection targets against the real (paper-api 1.20.1) modern
         // profile API: wrong class names, method names, or signatures would surface here. MockBukkit's
         // server does not implement createPlayerProfile, so the end-to-end apply cannot run in tests.
-        Optional<ItemUtils.ProfileApi> resolved = ItemUtils.resolveProfileApi();
+        Optional<HeadUtils.ProfileApi> resolved = HeadUtils.resolveProfileApi();
         assertTrue(resolved.isPresent(), "paper-api 1.20.1 exposes the org.bukkit.profile API");
 
-        ItemUtils.ProfileApi api = resolved.get();
+        HeadUtils.ProfileApi api = resolved.get();
         assertEquals("createPlayerProfile", api.createPlayerProfile.getName());
         assertArrayEquals(new Class<?>[]{UUID.class}, api.createPlayerProfile.getParameterTypes());
         assertEquals("getTextures", api.getTextures.getName());
@@ -80,26 +80,26 @@ class ItemUtilsTest {
     void applyViaProfileApi_malformed_url_returns_false() {
         SkullMeta meta = mock(SkullMeta.class);
 
-        assertFalse(ItemUtils.applyViaProfileApi(meta, "not a url"));
+        assertFalse(HeadUtils.applyViaProfileApi(meta, "not a url"));
     }
 
     // --- Tier 2: legacy GameProfile texture property + field write ------------------------------
 
     @Test
     void encodeSkinTexture_encodes_minimal_texture_json() {
-        String decoded = decode(ItemUtils.encodeSkinTexture(SKIN_URL));
+        String decoded = decode(HeadUtils.encodeSkinTexture(SKIN_URL));
         assertEquals("{\"textures\":{\"SKIN\":{\"url\":\"" + SKIN_URL + "\"}}}", decoded);
     }
 
     @Test
     void encodeSkinTexture_escapes_json_metacharacters() {
-        String decoded = decode(ItemUtils.encodeSkinTexture("a\"b\\c"));
+        String decoded = decode(HeadUtils.encodeSkinTexture("a\"b\\c"));
         assertEquals("{\"textures\":{\"SKIN\":{\"url\":\"a\\\"b\\\\c\"}}}", decoded);
     }
 
     @Test
     void createGameProfile_embeds_textures_property_with_the_encoded_skin() throws Exception {
-        Object profile = ItemUtils.createGameProfile(SKIN_URL);
+        Object profile = HeadUtils.createGameProfile(SKIN_URL);
         assertNotNull(profile, "authlib GameProfile must be constructible on the test classpath");
 
         Object properties = profile.getClass().getMethod("getProperties").invoke(profile);
@@ -109,7 +109,7 @@ class ItemUtilsTest {
 
         Object property = values.iterator().next();
         Object value = property.getClass().getMethod("getValue").invoke(property);
-        assertEquals(ItemUtils.encodeSkinTexture(SKIN_URL), value);
+        assertEquals(HeadUtils.encodeSkinTexture(SKIN_URL), value);
     }
 
     @Test
@@ -117,26 +117,26 @@ class ItemUtilsTest {
         FakeSkullMeta meta = new FakeSkullMeta();
         Object marker = new Object();
 
-        assertTrue(ItemUtils.writeProfileField(meta, marker));
+        assertTrue(HeadUtils.writeProfileField(meta, marker));
 
         assertSame(marker, meta.profile);
     }
 
     @Test
     void writeProfileField_returns_false_when_class_has_no_profile_field() {
-        assertFalse(ItemUtils.writeProfileField(new NoProfileField(), new Object()));
+        assertFalse(HeadUtils.writeProfileField(new NoProfileField(), new Object()));
     }
 
     @Test
     void writeProfileField_returns_false_for_object_without_field() {
-        assertFalse(ItemUtils.writeProfileField(new Object(), new Object()));
+        assertFalse(HeadUtils.writeProfileField(new Object(), new Object()));
     }
 
     // --- existing head factories still work -----------------------------------------------------
 
     @Test
     void getHeadByName_sets_owner() {
-        ItemStack head = ItemUtils.getHeadByName("Notch");
+        ItemStack head = HeadUtils.getHeadByName("Notch");
         assertEquals(Material.PLAYER_HEAD, head.getType());
         SkullMeta meta = (SkullMeta) head.getItemMeta();
         assertEquals("Notch", meta.getOwner());

--- a/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilderTest.java
+++ b/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemBuilderTest.java
@@ -5,6 +5,7 @@ import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -131,6 +133,45 @@ class ItemBuilderTest {
         assertNotNull(lore);
         assertEquals(1, lore.size());
         assertEquals("§aLine", lore.get(0));
+    }
+
+    @Test
+    void headUrl_produces_a_player_head() {
+        ItemStack head = new ItemBuilder(Material.STONE)
+                .headUrl("http://textures.minecraft.net/texture/deadbeefcafe")
+                .wrap();
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+    }
+
+    @Test
+    void headUrl_null_produces_a_bare_head_without_throwing() {
+        ItemStack head = new ItemBuilder(Material.STONE).headUrl(null).wrap();
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+    }
+
+    @Test
+    void headName_sets_the_owner() {
+        ItemStack head = new ItemBuilder(Material.STONE).headName("Notch").wrap();
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+        assertEquals("Notch", ((SkullMeta) head.getItemMeta()).getOwner());
+    }
+
+    @Test
+    void headUUID_string_produces_a_player_head() {
+        ItemStack head = new ItemBuilder(Material.STONE).headUUID(UUID.randomUUID().toString()).wrap();
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+    }
+
+    @Test
+    void headUUID_invalid_string_produces_a_bare_head_without_throwing() {
+        ItemStack head = new ItemBuilder(Material.STONE).headUUID("not-a-uuid").wrap();
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+    }
+
+    @Test
+    void headUUID_uuid_overload_produces_a_player_head() {
+        ItemStack head = new ItemBuilder(Material.STONE).headUUID(UUID.randomUUID()).wrap();
+        assertEquals(Material.PLAYER_HEAD, head.getType());
     }
 
     private interface ItemModelMeta extends ItemMeta {

--- a/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemUtilsTest.java
+++ b/platform-spigot/core-spigot/src/test/java/tech/guilhermekaua/spigotboot/core/spigot/utils/ItemUtilsTest.java
@@ -1,0 +1,156 @@
+package tech.guilhermekaua.spigotboot.core.spigot.utils;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+class ItemUtilsTest {
+
+    private static final String SKIN_URL = "http://textures.minecraft.net/texture/deadbeefcafe";
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+    }
+
+    // --- getHeadByUrl: fail-safe behavior --------------------------------------------------------
+
+    @Test
+    void getHeadByUrl_null_returns_bare_player_head() {
+        ItemStack head = ItemUtils.getHeadByUrl(null);
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+    }
+
+    @Test
+    void getHeadByUrl_blank_returns_bare_player_head() {
+        ItemStack head = ItemUtils.getHeadByUrl("   ");
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+    }
+
+    @Test
+    void getHeadByUrl_valid_url_returns_player_head() {
+        ItemStack head = ItemUtils.getHeadByUrl(SKIN_URL);
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+    }
+
+    // --- Tier 1: modern Bukkit PlayerProfile API (1.18.1+) --------------------------------------
+
+    @Test
+    void resolveProfileApi_binds_the_modern_profile_contract() {
+        // Verifies the version-specific reflection targets against the real (paper-api 1.20.1) modern
+        // profile API: wrong class names, method names, or signatures would surface here. MockBukkit's
+        // server does not implement createPlayerProfile, so the end-to-end apply cannot run in tests.
+        Optional<ItemUtils.ProfileApi> resolved = ItemUtils.resolveProfileApi();
+        assertTrue(resolved.isPresent(), "paper-api 1.20.1 exposes the org.bukkit.profile API");
+
+        ItemUtils.ProfileApi api = resolved.get();
+        assertEquals("createPlayerProfile", api.createPlayerProfile.getName());
+        assertArrayEquals(new Class<?>[]{UUID.class}, api.createPlayerProfile.getParameterTypes());
+        assertEquals("getTextures", api.getTextures.getName());
+        assertEquals("setSkin", api.setSkin.getName());
+        assertArrayEquals(new Class<?>[]{URL.class}, api.setSkin.getParameterTypes());
+        assertEquals("setOwnerProfile", api.setOwnerProfile.getName());
+    }
+
+    @Test
+    void applyViaProfileApi_malformed_url_returns_false() {
+        SkullMeta meta = mock(SkullMeta.class);
+
+        assertFalse(ItemUtils.applyViaProfileApi(meta, "not a url"));
+    }
+
+    // --- Tier 2: legacy GameProfile texture property + field write ------------------------------
+
+    @Test
+    void encodeSkinTexture_encodes_minimal_texture_json() {
+        String decoded = decode(ItemUtils.encodeSkinTexture(SKIN_URL));
+        assertEquals("{\"textures\":{\"SKIN\":{\"url\":\"" + SKIN_URL + "\"}}}", decoded);
+    }
+
+    @Test
+    void encodeSkinTexture_escapes_json_metacharacters() {
+        String decoded = decode(ItemUtils.encodeSkinTexture("a\"b\\c"));
+        assertEquals("{\"textures\":{\"SKIN\":{\"url\":\"a\\\"b\\\\c\"}}}", decoded);
+    }
+
+    @Test
+    void createGameProfile_embeds_textures_property_with_the_encoded_skin() throws Exception {
+        Object profile = ItemUtils.createGameProfile(SKIN_URL);
+        assertNotNull(profile, "authlib GameProfile must be constructible on the test classpath");
+
+        Object properties = profile.getClass().getMethod("getProperties").invoke(profile);
+        Object textures = properties.getClass().getMethod("get", Object.class).invoke(properties, "textures");
+        Collection<?> values = (Collection<?>) textures;
+        assertEquals(1, values.size());
+
+        Object property = values.iterator().next();
+        Object value = property.getClass().getMethod("getValue").invoke(property);
+        assertEquals(ItemUtils.encodeSkinTexture(SKIN_URL), value);
+    }
+
+    @Test
+    void writeProfileField_writes_into_a_profile_field() {
+        FakeSkullMeta meta = new FakeSkullMeta();
+        Object marker = new Object();
+
+        assertTrue(ItemUtils.writeProfileField(meta, marker));
+
+        assertSame(marker, meta.profile);
+    }
+
+    @Test
+    void writeProfileField_returns_false_when_class_has_no_profile_field() {
+        assertFalse(ItemUtils.writeProfileField(new NoProfileField(), new Object()));
+    }
+
+    @Test
+    void writeProfileField_returns_false_for_object_without_field() {
+        assertFalse(ItemUtils.writeProfileField(new Object(), new Object()));
+    }
+
+    // --- existing head factories still work -----------------------------------------------------
+
+    @Test
+    void getHeadByName_sets_owner() {
+        ItemStack head = ItemUtils.getHeadByName("Notch");
+        assertEquals(Material.PLAYER_HEAD, head.getType());
+        SkullMeta meta = (SkullMeta) head.getItemMeta();
+        assertEquals("Notch", meta.getOwner());
+    }
+
+    private static String decode(String base64) {
+        return new String(Base64.getDecoder().decode(base64), StandardCharsets.UTF_8);
+    }
+
+    /** Stand-in for a legacy CraftMetaSkull: exposes the private {@code profile} field the field path targets. */
+    private static final class FakeSkullMeta {
+        private Object profile;
+    }
+
+    private static final class NoProfileField {
+    }
+}


### PR DESCRIPTION
## What

Replace the `NBTEditor` dependency with a self-contained, version-proof player-head skin implementation, and move all head/profile helpers into a dedicated `HeadUtils` class.

`NBTEditor` was pulled from the CodeMC repo and shaded+relocated purely to back one call — `ItemBuilder(String url)` → `NBTEditor.getHead(url)`. This drops the dependency (and its shade step and repo) in favor of `HeadUtils.getHeadByUrl(String)`.

## How (version-proof, 1.8.8 → latest)

Two capability-detected tiers, both invoked **reflectively** so the module stays compilable under the animal-sniffer 1.8.8 signature check and safe at runtime where an API is absent:

- **1.18.1+** — public Bukkit profile API: `Bukkit.createPlayerProfile` → `PlayerTextures.setSkin(URL)` → `SkullMeta.setOwnerProfile`. Touches no internals, so it survives the 1.20.5 `GameProfile` → `ResolvableProfile` refactor.
- **1.8 – 1.17.x** — a `com.mojang.authlib.GameProfile` carrying a base64 textures property, written into the skull meta's private `profile` field.

A null / blank / malformed URL yields a bare head rather than throwing, so a GUI never fails to render.

## API changes

- **Removed** `ItemBuilder(String)` constructor.
- **Added** chainable builder methods: `headUrl(String)`, `headName(String)`, `headUUID(String)`, `headUUID(UUID)`.
- Migrated the one caller (`Utils.getItemFromConfig`).
- Moved all head/profile logic out of `ItemUtils` into a new `HeadUtils` class (`ItemUtils` held nothing else, so it is renamed — history preserved).

## Build cleanup

- Removed the `nbteditor` dependency, the `maven-shade-plugin` block (it only shaded nbteditor), and the CodeMC `<repository>`.
- Removed the README NBTEditor credit.
- Added `com.mojang:authlib` as a **test-scoped** dependency to exercise the legacy GameProfile path (authlib ships with the server at runtime).

## Tests

- `HeadUtilsTest` — both tiers (profile-API contract resolution against real paper-api, base64 texture JSON + escaping, GameProfile property embedding, field write) and graceful fallbacks.
- `ItemBuilderTest` — the four head builder methods.
- `mvnw -pl platform-spigot/core-spigot -am clean test` → **BUILD SUCCESS**, core-spigot **91 tests, 0 failures**.
- animal-sniffer 1.8.8 signature check → **BUILD SUCCESS**, zero undefined references.

> Note: the modern tier's end-to-end *apply* can't run under MockBukkit (its `ServerMock` doesn't implement `createPlayerProfile`), so it is verified by resolving the reflective contract (class/method names, signatures) against real paper-api 1.20.1 — the fragile part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
