### PR TITLE
feat(core): method-level @AssertTrue and @AssertFalse

### DIFF
--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
@@ -635,7 +635,9 @@ public class DefaultValidator implements Validator {
      * contribute only default methods (invocable bodies). Bridge, synthetic,
      * and {@link Object} methods are skipped. Private methods skip signature
      * deduplication so same-named private asserts on different hierarchy levels
-     * are each retained.
+     * are each retained. Non-private methods reserve their signature before
+     * annotation filtering so an unannotated override suppresses ancestor
+     * {@link AssertTrue}/{@link AssertFalse} rules with the same signature.
      */
     private void collectAssertMethodsFrom(@NotNull Class<?> type,
                                           @NotNull List<Method> methods,
@@ -650,20 +652,27 @@ public class DefaultValidator implements Validator {
             if (type.isInterface() && !method.isDefault()) {
                 continue;
             }
-            if (method.getAnnotation(AssertTrue.class) == null
-                    && method.getAnnotation(AssertFalse.class) == null) {
-                continue;
-            }
+
+            boolean annotated = method.getAnnotation(AssertTrue.class) != null
+                    || method.getAnnotation(AssertFalse.class) != null;
+
             // Private methods cannot override; never consult or populate seenSignatures.
             if (Modifier.isPrivate(method.getModifiers())) {
-                methods.add(method);
+                if (annotated) {
+                    methods.add(method);
+                }
                 continue;
             }
+
+            // Reserve signature before annotation filtering so unannotated
+            // overrides block ancestor assert methods with the same signature.
             String signature = methodSignature(method);
             if (!seenSignatures.add(signature)) {
                 continue;
             }
-            methods.add(method);
+            if (annotated) {
+                methods.add(method);
+            }
         }
     }
 

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
@@ -30,6 +30,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.regex.Matcher;
 
@@ -577,7 +578,8 @@ public class DefaultValidator implements Validator {
     /**
      * Collects methods that may carry {@link AssertTrue}/{@link AssertFalse},
      * walking the class hierarchy subclass-first, then each class's interfaces
-     * (including superinterfaces), and skipping overridden signatures.
+     * (including superinterfaces). Overridable methods are signature-deduped;
+     * private methods are always retained (they cannot override).
      */
     private @NotNull List<Method> getAllAssertMethods(@NotNull Class<?> clazz) {
         List<Method> methods = new ArrayList<>();
@@ -614,7 +616,9 @@ public class DefaultValidator implements Validator {
     /**
      * Adds annotated assert methods declared on {@code type}. Interface types
      * contribute only default methods (invocable bodies). Bridge, synthetic,
-     * and {@link Object} methods are skipped.
+     * and {@link Object} methods are skipped. Private methods skip signature
+     * deduplication so same-named private asserts on different hierarchy levels
+     * are each retained.
      */
     private void collectAssertMethodsFrom(@NotNull Class<?> type,
                                           @NotNull List<Method> methods,
@@ -631,6 +635,11 @@ public class DefaultValidator implements Validator {
             }
             if (method.getAnnotation(AssertTrue.class) == null
                     && method.getAnnotation(AssertFalse.class) == null) {
+                continue;
+            }
+            // Private methods cannot override; never consult or populate seenSignatures.
+            if (Modifier.isPrivate(method.getModifiers())) {
+                methods.add(method);
                 continue;
             }
             String signature = methodSignature(method);

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
@@ -28,6 +28,8 @@ import tech.guilhermekaua.spigotboot.core.validation.annotation.*;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.regex.Matcher;
 
@@ -330,6 +332,74 @@ public class DefaultValidator implements Validator {
                 return NotEmpty.class;
             }
         });
+
+        factories.put(AssertTrue.class, new ConstraintFactory<AssertTrue>() {
+            @Override
+            public @NotNull Constraint<?> create(@NotNull AssertTrue annotation) {
+                return new Constraint<Object>() {
+                    @Override
+                    public boolean isValid(Object value) {
+                        if (value == null) return true;
+                        if (value instanceof Boolean) return (Boolean) value;
+                        return false;
+                    }
+
+                    @Override
+                    public @NotNull String message(Object value) {
+                        return annotation.message();
+                    }
+
+                    @Override
+                    public boolean isFailFast() {
+                        return annotation.failFast();
+                    }
+
+                    @Override
+                    public String suggestedFix(Object value) {
+                        return "Ensure the assertion evaluates to true";
+                    }
+                };
+            }
+
+            @Override
+            public @NotNull Class<AssertTrue> getAnnotationType() {
+                return AssertTrue.class;
+            }
+        });
+
+        factories.put(AssertFalse.class, new ConstraintFactory<AssertFalse>() {
+            @Override
+            public @NotNull Constraint<?> create(@NotNull AssertFalse annotation) {
+                return new Constraint<Object>() {
+                    @Override
+                    public boolean isValid(Object value) {
+                        if (value == null) return true;
+                        if (value instanceof Boolean) return !(Boolean) value;
+                        return false;
+                    }
+
+                    @Override
+                    public @NotNull String message(Object value) {
+                        return annotation.message();
+                    }
+
+                    @Override
+                    public boolean isFailFast() {
+                        return annotation.failFast();
+                    }
+
+                    @Override
+                    public String suggestedFix(Object value) {
+                        return "Ensure the assertion evaluates to false";
+                    }
+                };
+            }
+
+            @Override
+            public @NotNull Class<AssertFalse> getAnnotationType() {
+                return AssertFalse.class;
+            }
+        });
     }
 
     @Override
@@ -390,7 +460,160 @@ public class DefaultValidator implements Validator {
             }
         }
 
+        errors.addAll(validateAssertMethods(object, basePath));
+
         return ValidationResult.of(errors);
+    }
+
+    @SuppressWarnings("unchecked")
+    private @NotNull List<ValidationError> validateAssertMethods(@NotNull Object object,
+                                                                 @NotNull PropertyPath basePath) {
+        List<ValidationError> errors = new ArrayList<>();
+
+        for (Method method : getAllAssertMethods(object.getClass())) {
+            AssertTrue assertTrue = method.getAnnotation(AssertTrue.class);
+            AssertFalse assertFalse = method.getAnnotation(AssertFalse.class);
+            if (assertTrue == null && assertFalse == null) {
+                continue;
+            }
+
+            String pathAttr = assertTrue != null ? assertTrue.path() : assertFalse.path();
+            boolean failFast = assertTrue != null ? assertTrue.failFast() : assertFalse.failFast();
+            PropertyPath errorPath = resolveAssertPath(basePath, method, pathAttr);
+            String fieldName = resolveAssertFieldName(errorPath, method);
+
+            if (method.getParameterCount() != 0 || !isBooleanReturnType(method)) {
+                String message = "Assert method must return boolean/Boolean and take no parameters: "
+                        + method.getDeclaringClass().getSimpleName() + "." + method.getName();
+                errors.add(new ValidationError(
+                        errorPath,
+                        fieldName,
+                        null,
+                        message,
+                        failFast,
+                        "Change the method to a zero-arg boolean-returning method"
+                ));
+                continue;
+            }
+
+            Object returnValue;
+            try {
+                method.setAccessible(true);
+                returnValue = method.invoke(object);
+            } catch (InvocationTargetException e) {
+                Throwable cause = e.getCause() != null ? e.getCause() : e;
+                String message = "Assert method threw: " + cause.getClass().getSimpleName()
+                        + (cause.getMessage() != null ? ": " + cause.getMessage() : "");
+                errors.add(new ValidationError(
+                        errorPath,
+                        fieldName,
+                        null,
+                        message,
+                        failFast,
+                        "Fix the assert method so it does not throw"
+                ));
+                continue;
+            } catch (IllegalAccessException e) {
+                errors.add(new ValidationError(
+                        errorPath,
+                        fieldName,
+                        null,
+                        "Assert method is not accessible: " + method.getName(),
+                        failFast,
+                        "Make the assert method accessible"
+                ));
+                continue;
+            }
+
+            Annotation annotation = assertTrue != null ? assertTrue : assertFalse;
+            ConstraintFactory<?> factory = factories.get(annotation.annotationType());
+            if (factory == null) {
+                continue;
+            }
+            Constraint<Object> constraint = (Constraint<Object>) createConstraint(factory, annotation);
+            if (!constraint.isValid(returnValue)) {
+                errors.add(new ValidationError(
+                        errorPath,
+                        fieldName,
+                        returnValue,
+                        constraint.message(returnValue),
+                        constraint.isFailFast(),
+                        constraint.suggestedFix(returnValue)
+                ));
+            }
+        }
+
+        return errors;
+    }
+
+    private @NotNull PropertyPath resolveAssertPath(@NotNull PropertyPath basePath,
+                                                    @NotNull Method method,
+                                                    @NotNull String pathAttr) {
+        if (pathAttr.isEmpty()) {
+            return basePath.child(method.getName());
+        }
+        PropertyPath relative = PropertyPath.parse(pathAttr);
+        PropertyPath result = basePath;
+        for (Object element : relative.elements()) {
+            result = result.child(element);
+        }
+        return result;
+    }
+
+    private @NotNull String resolveAssertFieldName(@NotNull PropertyPath errorPath,
+                                                   @NotNull Method method) {
+        Object last = errorPath.last();
+        if (last != null) {
+            return String.valueOf(last);
+        }
+        return method.getName();
+    }
+
+    private boolean isBooleanReturnType(@NotNull Method method) {
+        Class<?> returnType = method.getReturnType();
+        return returnType == boolean.class || returnType == Boolean.class;
+    }
+
+    /**
+     * Collects methods that may carry {@link AssertTrue}/{@link AssertFalse},
+     * walking the hierarchy subclass-first and skipping overridden signatures.
+     */
+    private @NotNull List<Method> getAllAssertMethods(@NotNull Class<?> clazz) {
+        List<Method> methods = new ArrayList<>();
+        Set<String> seenSignatures = new HashSet<>();
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            for (Method method : current.getDeclaredMethods()) {
+                if (method.isBridge() || method.isSynthetic()) {
+                    continue;
+                }
+                if (method.getAnnotation(AssertTrue.class) == null
+                        && method.getAnnotation(AssertFalse.class) == null) {
+                    continue;
+                }
+                String signature = methodSignature(method);
+                if (!seenSignatures.add(signature)) {
+                    continue;
+                }
+                methods.add(method);
+            }
+            current = current.getSuperclass();
+        }
+        return methods;
+    }
+
+    private @NotNull String methodSignature(@NotNull Method method) {
+        StringBuilder sb = new StringBuilder(method.getName());
+        sb.append('(');
+        Class<?>[] params = method.getParameterTypes();
+        for (int i = 0; i < params.length; i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            sb.append(params[i].getName());
+        }
+        sb.append(')');
+        return sb.toString();
     }
 
     private @NotNull List<Field> getAllFields(@NotNull Class<?> clazz) {

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
@@ -576,30 +576,69 @@ public class DefaultValidator implements Validator {
 
     /**
      * Collects methods that may carry {@link AssertTrue}/{@link AssertFalse},
-     * walking the hierarchy subclass-first and skipping overridden signatures.
+     * walking the class hierarchy subclass-first, then each class's interfaces
+     * (including superinterfaces), and skipping overridden signatures.
      */
     private @NotNull List<Method> getAllAssertMethods(@NotNull Class<?> clazz) {
         List<Method> methods = new ArrayList<>();
         Set<String> seenSignatures = new HashSet<>();
+        Set<Class<?>> visitedInterfaces = new HashSet<>();
         Class<?> current = clazz;
         while (current != null && current != Object.class) {
-            for (Method method : current.getDeclaredMethods()) {
-                if (method.isBridge() || method.isSynthetic()) {
-                    continue;
-                }
-                if (method.getAnnotation(AssertTrue.class) == null
-                        && method.getAnnotation(AssertFalse.class) == null) {
-                    continue;
-                }
-                String signature = methodSignature(method);
-                if (!seenSignatures.add(signature)) {
-                    continue;
-                }
-                methods.add(method);
+            collectAssertMethodsFrom(current, methods, seenSignatures);
+            for (Class<?> iface : current.getInterfaces()) {
+                collectAssertMethodsFromInterfaces(iface, methods, seenSignatures, visitedInterfaces);
             }
             current = current.getSuperclass();
         }
         return methods;
+    }
+
+    /**
+     * Recursively collects annotated default methods from {@code iface} and its
+     * superinterfaces, skipping interfaces already visited.
+     */
+    private void collectAssertMethodsFromInterfaces(@NotNull Class<?> iface,
+                                                    @NotNull List<Method> methods,
+                                                    @NotNull Set<String> seenSignatures,
+                                                    @NotNull Set<Class<?>> visitedInterfaces) {
+        if (!iface.isInterface() || !visitedInterfaces.add(iface)) {
+            return;
+        }
+        collectAssertMethodsFrom(iface, methods, seenSignatures);
+        for (Class<?> parent : iface.getInterfaces()) {
+            collectAssertMethodsFromInterfaces(parent, methods, seenSignatures, visitedInterfaces);
+        }
+    }
+
+    /**
+     * Adds annotated assert methods declared on {@code type}. Interface types
+     * contribute only default methods (invocable bodies). Bridge, synthetic,
+     * and {@link Object} methods are skipped.
+     */
+    private void collectAssertMethodsFrom(@NotNull Class<?> type,
+                                          @NotNull List<Method> methods,
+                                          @NotNull Set<String> seenSignatures) {
+        for (Method method : type.getDeclaredMethods()) {
+            if (method.isBridge() || method.isSynthetic()) {
+                continue;
+            }
+            if (method.getDeclaringClass() == Object.class) {
+                continue;
+            }
+            if (type.isInterface() && !method.isDefault()) {
+                continue;
+            }
+            if (method.getAnnotation(AssertTrue.class) == null
+                    && method.getAnnotation(AssertFalse.class) == null) {
+                continue;
+            }
+            String signature = methodSignature(method);
+            if (!seenSignatures.add(signature)) {
+                continue;
+            }
+            methods.add(method);
+        }
     }
 
     private @NotNull String methodSignature(@NotNull Method method) {

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/DefaultValidator.java
@@ -32,6 +32,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 
 /**
@@ -40,6 +41,12 @@ import java.util.regex.Matcher;
 public class DefaultValidator implements Validator {
 
     private final Map<Class<? extends Annotation>, ConstraintFactory<?>> factories = new HashMap<>();
+
+    /**
+     * Per-class cache of assert methods discovered via hierarchy/interface walk.
+     * Avoids repeating reflection on every validation of the same type.
+     */
+    private final Map<Class<?>, List<Method>> assertMethodsCache = new ConcurrentHashMap<>();
 
     public DefaultValidator() {
         registerDefaultFactories();
@@ -580,8 +587,18 @@ public class DefaultValidator implements Validator {
      * walking the class hierarchy subclass-first, then each class's interfaces
      * (including superinterfaces). Overridable methods are signature-deduped;
      * private methods are always retained (they cannot override).
+     * Results are cached per class.
      */
     private @NotNull List<Method> getAllAssertMethods(@NotNull Class<?> clazz) {
+        return assertMethodsCache.computeIfAbsent(clazz, this::resolveAssertMethods);
+    }
+
+    /**
+     * Discovers assert methods for {@code clazz} without consulting the cache.
+     * Order: subclass declared methods first, then each type's interfaces
+     * (including superinterfaces), then superclasses — same as before caching.
+     */
+    private @NotNull List<Method> resolveAssertMethods(@NotNull Class<?> clazz) {
         List<Method> methods = new ArrayList<>();
         Set<String> seenSignatures = new HashSet<>();
         Set<Class<?>> visitedInterfaces = new HashSet<>();
@@ -593,7 +610,7 @@ public class DefaultValidator implements Validator {
             }
             current = current.getSuperclass();
         }
-        return methods;
+        return List.copyOf(methods);
     }
 
     /**

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/annotation/AssertFalse.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/annotation/AssertFalse.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validates that a no-arg method returns {@code false}.
+ * <p>
+ * Place on a zero-parameter method returning {@code boolean} or {@link Boolean}.
+ * The method is invoked during validation; a {@code false} return passes, a
+ * {@code true} return fails. A {@code null} {@link Boolean} return is treated
+ * as valid (pair with field constraints if absence must fail).
+ * <p>
+ * Typical use is cross-field rules:
+ * <pre>{@code
+ * @AssertFalse(message = "debug must be off in production", path = "debug")
+ * private boolean isDebugEnabledInProduction() {
+ *     return production && debug;
+ * }
+ * }</pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AssertFalse {
+
+    /**
+     * The error message.
+     *
+     * @return the message
+     */
+    String message() default "Expression must be false";
+
+    /**
+     * Relative property path for the validation error (e.g. {@code "debug"} or
+     * {@code "database.host"}). Empty uses the method name as the path segment.
+     *
+     * @return the relative path, or empty for the method name
+     */
+    String path() default "";
+
+    /**
+     * Whether validation failure should fail fast (prevent plugin enable).
+     *
+     * @return true to fail fast
+     */
+    boolean failFast() default true;
+}

--- a/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/annotation/AssertTrue.java
+++ b/core/src/main/java/tech/guilhermekaua/spigotboot/core/validation/annotation/AssertTrue.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License
+ * Copyright © 2025 Guilherme Kauã da Silva
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package tech.guilhermekaua.spigotboot.core.validation.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Validates that a no-arg method returns {@code true}.
+ * <p>
+ * Place on a zero-parameter method returning {@code boolean} or {@link Boolean}.
+ * The method is invoked during validation; a {@code true} return passes, a
+ * {@code false} return fails. A {@code null} {@link Boolean} return is treated
+ * as valid (pair with field constraints if absence must fail).
+ * <p>
+ * Typical use is cross-field rules:
+ * <pre>{@code
+ * @AssertTrue(message = "max must be >= min", path = "max")
+ * private boolean isMaxGteMin() {
+ *     return max >= min;
+ * }
+ * }</pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AssertTrue {
+
+    /**
+     * The error message.
+     *
+     * @return the message
+     */
+    String message() default "Expression must be true";
+
+    /**
+     * Relative property path for the validation error (e.g. {@code "max"} or
+     * {@code "database.host"}). Empty uses the method name as the path segment.
+     *
+     * @return the relative path, or empty for the method name
+     */
+    String path() default "";
+
+    /**
+     * Whether validation failure should fail fast (prevent plugin enable).
+     *
+     * @return true to fail fast
+     */
+    boolean failFast() default true;
+}

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
@@ -300,6 +300,41 @@ class ValidatorTest {
         }
     }
 
+    /**
+     * Superclass declares a public annotated assert; subclass overrides without
+     * re-annotating. The ancestor rule must not apply (return false would fail
+     * if the annotation were retained under virtual dispatch).
+     */
+    static class AnnotatedAssertSuperclass {
+        @AssertTrue(message = "superclass rule failed", path = "flag")
+        public boolean isFlag() {
+            return true;
+        }
+    }
+
+    static class UnannotatedOverrideOfSuperclassAssert extends AnnotatedAssertSuperclass {
+        @Override
+        public boolean isFlag() {
+            return false;
+        }
+    }
+
+    /**
+     * Interface default carries {@code @AssertTrue}; implementing class overrides
+     * without the annotation. Ancestor interface rule must not apply.
+     */
+    static class UnannotatedOverrideOfInterfaceAssert implements AssertTrueDefaultMethodIface {
+        @Override
+        public boolean interfaceEnabled() {
+            return false;
+        }
+
+        @Override
+        public boolean isInterfaceEnabled() {
+            return false;
+        }
+    }
+
     static class CoexistFieldAndMethodConfig {
         @NotNull
         String name;
@@ -823,6 +858,32 @@ class ValidatorTest {
         ValidationResult result = validator.validate(config);
 
         assertTrue(result.isValid(), "class override with matching signature must suppress interface default");
+    }
+
+    @Test
+    void testUnannotatedOverrideSuppressesSuperclassAssertTrue() {
+        UnannotatedOverrideOfSuperclassAssert config = new UnannotatedOverrideOfSuperclassAssert();
+
+        ValidationResult result = validator.validate(config);
+
+        assertTrue(result.isValid(),
+                "unannotated override must suppress superclass @AssertTrue (return false would fail if retained)");
+        assertFalse(result.errors().stream().anyMatch(error ->
+                error.getMessage().contains("superclass rule failed")
+        ));
+    }
+
+    @Test
+    void testUnannotatedOverrideSuppressesInterfaceAssertTrue() {
+        UnannotatedOverrideOfInterfaceAssert config = new UnannotatedOverrideOfInterfaceAssert();
+
+        ValidationResult result = validator.validate(config);
+
+        assertTrue(result.isValid(),
+                "unannotated class override must suppress interface default @AssertTrue");
+        assertFalse(result.errors().stream().anyMatch(error ->
+                error.getMessage().contains("interface rule failed")
+        ));
     }
 
     @Test

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
@@ -211,6 +211,28 @@ class ValidatorTest {
         String childName;
     }
 
+    /**
+     * Parent and child each declare a private assert with the same signature.
+     * Both must be collected and evaluated (private methods do not override).
+     */
+    static class PrivateAssertSameSignatureBase {
+        boolean baseOk = false;
+
+        @AssertTrue(message = "base private failed", path = "baseOk", failFast = false)
+        private boolean isValid() {
+            return baseOk;
+        }
+    }
+
+    static class PrivateAssertSameSignatureChild extends PrivateAssertSameSignatureBase {
+        boolean childOk = false;
+
+        @AssertTrue(message = "child private failed", path = "childOk", failFast = false)
+        private boolean isValid() {
+            return childOk;
+        }
+    }
+
     interface AssertTrueDefaultMethodIface {
         boolean interfaceEnabled();
 
@@ -717,6 +739,36 @@ class ValidatorTest {
                 "baseEnabled".equals(error.getFieldName())
                         && "baseEnabled".equals(error.getPath().asString())
         ));
+    }
+
+    @Test
+    void testPrivateAssertTrueSameSignatureOnHierarchyBothRetained() {
+        PrivateAssertSameSignatureChild config = new PrivateAssertSameSignatureChild();
+        config.baseOk = false;
+        config.childOk = false;
+
+        ValidationResult result = validator.validate(config);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "childOk".equals(error.getFieldName())
+                        && error.getMessage().contains("child private failed")
+        ), "child private @AssertTrue must be retained");
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "baseOk".equals(error.getFieldName())
+                        && error.getMessage().contains("base private failed")
+        ), "base private @AssertTrue with same signature must also be retained");
+    }
+
+    @Test
+    void testPrivateAssertTrueSameSignatureBothValid() {
+        PrivateAssertSameSignatureChild config = new PrivateAssertSameSignatureChild();
+        config.baseOk = true;
+        config.childOk = true;
+
+        ValidationResult result = validator.validate(config);
+
+        assertTrue(result.isValid());
     }
 
     @Test

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
@@ -883,4 +883,44 @@ class ValidatorTest {
         assertTrue(result.errors().stream().anyMatch(error -> "name".equals(error.getFieldName())));
         assertTrue(result.errors().stream().anyMatch(error -> "max".equals(error.getFieldName())));
     }
+
+    /**
+     * Cached assert-method discovery must keep hierarchy/interface order and results
+     * stable across repeated validations of the same class.
+     */
+    @Test
+    void testAssertMethodDiscoveryCacheIsStableAcrossRepeatedValidation() {
+        SuperinterfaceAssertTrueConfig config = new SuperinterfaceAssertTrueConfig();
+        config.childIfaceEnabled = false;
+        config.superIfaceEnabled = false;
+
+        ValidationResult first = validator.validate(config);
+        ValidationResult second = validator.validate(config);
+
+        List<String> firstPaths = first.errors().stream()
+                .map(error -> error.getPath().asString() + "|" + error.getMessage())
+                .toList();
+        List<String> secondPaths = second.errors().stream()
+                .map(error -> error.getPath().asString() + "|" + error.getMessage())
+                .toList();
+
+        assertEquals(2, firstPaths.size());
+        assertEquals(firstPaths, secondPaths);
+
+        PrivateAssertSameSignatureChild privateConfig = new PrivateAssertSameSignatureChild();
+        privateConfig.baseOk = false;
+        privateConfig.childOk = false;
+
+        ValidationResult privateFirst = validator.validate(privateConfig);
+        ValidationResult privateSecond = validator.validate(privateConfig);
+        List<String> privateFirstPaths = privateFirst.errors().stream()
+                .map(error -> error.getPath().asString() + "|" + error.getMessage())
+                .toList();
+        List<String> privateSecondPaths = privateSecond.errors().stream()
+                .map(error -> error.getPath().asString() + "|" + error.getMessage())
+                .toList();
+
+        assertEquals(2, privateFirstPaths.size());
+        assertEquals(privateFirstPaths, privateSecondPaths);
+    }
 }

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
@@ -211,6 +211,73 @@ class ValidatorTest {
         String childName;
     }
 
+    interface AssertTrueDefaultMethodIface {
+        boolean interfaceEnabled();
+
+        @AssertTrue(message = "interface rule failed", path = "interfaceEnabled")
+        default boolean isInterfaceEnabled() {
+            return interfaceEnabled();
+        }
+    }
+
+    interface AssertTrueSuperIface {
+        boolean superIfaceEnabled();
+
+        @AssertTrue(message = "superinterface rule failed", path = "superIfaceEnabled")
+        default boolean isSuperIfaceEnabled() {
+            return superIfaceEnabled();
+        }
+    }
+
+    interface AssertTrueChildIface extends AssertTrueSuperIface {
+        boolean childIfaceEnabled();
+
+        @AssertTrue(message = "child interface rule failed", path = "childIfaceEnabled")
+        default boolean isChildIfaceEnabled() {
+            return childIfaceEnabled();
+        }
+    }
+
+    static class InterfaceAssertTrueConfig implements AssertTrueDefaultMethodIface {
+        boolean interfaceEnabled = false;
+
+        @Override
+        public boolean interfaceEnabled() {
+            return interfaceEnabled;
+        }
+    }
+
+    static class SuperinterfaceAssertTrueConfig implements AssertTrueChildIface {
+        boolean childIfaceEnabled = true;
+        boolean superIfaceEnabled = false;
+
+        @Override
+        public boolean childIfaceEnabled() {
+            return childIfaceEnabled;
+        }
+
+        @Override
+        public boolean superIfaceEnabled() {
+            return superIfaceEnabled;
+        }
+    }
+
+    static class ClassOverridesInterfaceAssertConfig implements AssertTrueDefaultMethodIface {
+        boolean interfaceEnabled = false;
+        boolean overridePass = true;
+
+        @Override
+        public boolean interfaceEnabled() {
+            return interfaceEnabled;
+        }
+
+        @AssertTrue(message = "class override rule failed", path = "overridePass")
+        @Override
+        public boolean isInterfaceEnabled() {
+            return overridePass;
+        }
+    }
+
     static class CoexistFieldAndMethodConfig {
         @NotNull
         String name;
@@ -649,6 +716,78 @@ class ValidatorTest {
         assertTrue(result.errors().stream().anyMatch(error ->
                 "baseEnabled".equals(error.getFieldName())
                         && "baseEnabled".equals(error.getPath().asString())
+        ));
+    }
+
+    @Test
+    void testInterfaceDefaultAssertTrueViolation() {
+        InterfaceAssertTrueConfig config = new InterfaceAssertTrueConfig();
+        config.interfaceEnabled = false;
+
+        ValidationResult result = validator.validate(config);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "interfaceEnabled".equals(error.getFieldName())
+                        && "interfaceEnabled".equals(error.getPath().asString())
+                        && error.getMessage().contains("interface rule failed")
+        ));
+    }
+
+    @Test
+    void testInterfaceDefaultAssertTrueValid() {
+        InterfaceAssertTrueConfig config = new InterfaceAssertTrueConfig();
+        config.interfaceEnabled = true;
+
+        ValidationResult result = validator.validate(config);
+
+        assertTrue(result.isValid());
+    }
+
+    @Test
+    void testSuperinterfaceDefaultAssertTrueViolation() {
+        SuperinterfaceAssertTrueConfig config = new SuperinterfaceAssertTrueConfig();
+        config.childIfaceEnabled = true;
+        config.superIfaceEnabled = false;
+
+        ValidationResult result = validator.validate(config);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "superIfaceEnabled".equals(error.getFieldName())
+                        && error.getMessage().contains("superinterface rule failed")
+        ));
+        assertFalse(result.errors().stream().anyMatch(error ->
+                "childIfaceEnabled".equals(error.getFieldName())
+        ));
+    }
+
+    @Test
+    void testClassOverrideWinsOverInterfaceAssertTrue() {
+        ClassOverridesInterfaceAssertConfig config = new ClassOverridesInterfaceAssertConfig();
+        config.interfaceEnabled = false;
+        config.overridePass = true;
+
+        ValidationResult result = validator.validate(config);
+
+        assertTrue(result.isValid(), "class override with matching signature must suppress interface default");
+    }
+
+    @Test
+    void testClassOverrideAssertTrueViolationUsesClassAnnotation() {
+        ClassOverridesInterfaceAssertConfig config = new ClassOverridesInterfaceAssertConfig();
+        config.interfaceEnabled = true;
+        config.overridePass = false;
+
+        ValidationResult result = validator.validate(config);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "overridePass".equals(error.getFieldName())
+                        && error.getMessage().contains("class override rule failed")
+        ));
+        assertFalse(result.errors().stream().anyMatch(error ->
+                error.getMessage().contains("interface rule failed")
         ));
     }
 

--- a/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
+++ b/core/src/test/java/tech/guilhermekaua/spigotboot/core/test/validation/ValidatorTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import tech.guilhermekaua.spigotboot.core.exceptions.ValidationException;
 import tech.guilhermekaua.spigotboot.core.validation.ValidationResult;
 import tech.guilhermekaua.spigotboot.core.validation.Validator;
+import tech.guilhermekaua.spigotboot.core.validation.annotation.AssertFalse;
+import tech.guilhermekaua.spigotboot.core.validation.annotation.AssertTrue;
 import tech.guilhermekaua.spigotboot.core.validation.annotation.Min;
 import tech.guilhermekaua.spigotboot.core.validation.annotation.NotEmpty;
 import tech.guilhermekaua.spigotboot.core.validation.annotation.NotNull;
@@ -123,6 +125,103 @@ class ValidatorTest {
 
     static class InheritedNotEmptyConfig extends InheritedNotEmptyBaseConfig {
         String childName;
+    }
+
+    static class AssertTrueConfig {
+        int min;
+        int max;
+        Boolean optionalCheck;
+
+        @AssertTrue(message = "max must be >= min", path = "max")
+        private boolean isMaxGteMin() {
+            return max >= min;
+        }
+
+        @AssertTrue(failFast = false)
+        private boolean isEnabled() {
+            return true;
+        }
+
+        @AssertTrue(message = "optional check must be true", failFast = false)
+        private Boolean optionalCheckTrue() {
+            return optionalCheck;
+        }
+    }
+
+    static class AssertFalseConfig {
+        boolean production;
+        boolean debug;
+
+        @AssertFalse(message = "debug must be off in production", path = "debug")
+        private boolean isDebugInProduction() {
+            return production && debug;
+        }
+
+        @AssertFalse(failFast = false)
+        private boolean isFlagClear() {
+            return false;
+        }
+    }
+
+    static class AssertTrueDefaultPathConfig {
+        boolean ok = false;
+
+        @AssertTrue
+        private boolean isOk() {
+            return ok;
+        }
+    }
+
+    static class AssertTrueNestedPathConfig {
+        @AssertTrue(message = "nested path failed", path = "a.b")
+        private boolean nestedRule() {
+            return false;
+        }
+    }
+
+    static class AssertTrueInvalidSignatureConfig {
+        @AssertTrue
+        private boolean hasParam(int x) {
+            return true;
+        }
+
+        @AssertTrue(path = "badReturn")
+        private String notBoolean() {
+            return "nope";
+        }
+    }
+
+    static class AssertTrueThrowsConfig {
+        @AssertTrue(message = "should not throw")
+        private boolean boom() {
+            throw new IllegalStateException("kaboom");
+        }
+    }
+
+    static class InheritedAssertTrueBaseConfig {
+        boolean baseEnabled = false;
+
+        @AssertTrue(path = "baseEnabled")
+        private boolean isBaseEnabled() {
+            return baseEnabled;
+        }
+    }
+
+    static class InheritedAssertTrueConfig extends InheritedAssertTrueBaseConfig {
+        String childName;
+    }
+
+    static class CoexistFieldAndMethodConfig {
+        @NotNull
+        String name;
+
+        int min;
+        int max;
+
+        @AssertTrue(message = "max must be >= min", path = "max")
+        private boolean isMaxGteMin() {
+            return max >= min;
+        }
     }
 
     private NotEmptyConfig validNotEmptyConfig() {
@@ -403,5 +502,194 @@ class ValidatorTest {
         assertTrue(result.hasErrors());
         assertTrue(result.errors().stream().anyMatch(error -> "baseName".equals(error.getFieldName())));
         assertTrue(result.errors().stream().anyMatch(error -> "baseName".equals(error.getPath().asString())));
+    }
+
+    @Test
+    void testAssertTrueValidObject() {
+        AssertTrueConfig config = new AssertTrueConfig();
+        config.min = 1;
+        config.max = 10;
+        config.optionalCheck = true;
+
+        ValidationResult result = validator.validate(config);
+        assertTrue(result.isValid());
+        assertFalse(result.hasErrors());
+    }
+
+    @Test
+    void testAssertTrueViolationUsesPathAttribute() {
+        AssertTrueConfig config = new AssertTrueConfig();
+        config.min = 10;
+        config.max = 1; // violates isMaxGteMin with path = "max"
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "max".equals(error.getFieldName())
+                        && "max".equals(error.getPath().asString())
+                        && "max must be >= min".equals(error.getMessage())
+                        && Boolean.FALSE.equals(error.getInvalidValue())
+        ));
+    }
+
+    @Test
+    void testAssertTrueDefaultPathUsesMethodName() {
+        AssertTrueDefaultPathConfig config = new AssertTrueDefaultPathConfig();
+        config.ok = false;
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "isOk".equals(error.getFieldName())
+                        && "isOk".equals(error.getPath().asString())
+        ));
+    }
+
+    @Test
+    void testAssertTrueNestedPath() {
+        AssertTrueNestedPathConfig config = new AssertTrueNestedPathConfig();
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "b".equals(error.getFieldName())
+                        && "a.b".equals(error.getPath().asString())
+        ));
+    }
+
+    @Test
+    void testAssertTrueNullBooleanReturnIsValid() {
+        AssertTrueConfig config = new AssertTrueConfig();
+        config.min = 1;
+        config.max = 10;
+        config.optionalCheck = null; // null Boolean return is valid
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.errors().stream().anyMatch(error ->
+                error.getMessage().contains("optional check")
+        ));
+    }
+
+    @Test
+    void testAssertTrueFailFastDefaultTrue() {
+        AssertTrueConfig config = new AssertTrueConfig();
+        config.min = 10;
+        config.max = 1; // path = "max", failFast default true
+
+        ValidationResult result = validator.validate(config);
+        assertTrue(result.getFailFastErrors().stream().anyMatch(error -> "max".equals(error.getFieldName())));
+        assertThrows(ValidationException.class, () -> validator.validateOrThrow(config));
+    }
+
+    @Test
+    void testAssertTrueFailFastFalseOverride() {
+        AssertTrueConfig config = new AssertTrueConfig();
+        config.min = 1;
+        config.max = 10;
+        config.optionalCheck = false; // failFast = false on optionalCheckTrue
+
+        ValidationResult result = validator.validate(config);
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "optionalCheckTrue".equals(error.getFieldName())
+                        || error.getMessage().contains("optional check")
+        ));
+        assertFalse(result.getFailFastErrors().stream().anyMatch(error ->
+                error.getMessage().contains("optional check")
+        ));
+        assertDoesNotThrow(() -> validator.validateOrThrow(config));
+    }
+
+    @Test
+    void testAssertFalseValidObject() {
+        AssertFalseConfig config = new AssertFalseConfig();
+        config.production = true;
+        config.debug = false;
+
+        ValidationResult result = validator.validate(config);
+        assertTrue(result.isValid());
+        assertFalse(result.hasErrors());
+    }
+
+    @Test
+    void testAssertFalseViolationUsesPathAttribute() {
+        AssertFalseConfig config = new AssertFalseConfig();
+        config.production = true;
+        config.debug = true; // violates isDebugInProduction with path = "debug"
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "debug".equals(error.getFieldName())
+                        && "debug".equals(error.getPath().asString())
+                        && "debug must be off in production".equals(error.getMessage())
+                        && Boolean.TRUE.equals(error.getInvalidValue())
+        ));
+    }
+
+    @Test
+    void testAssertFalseFailFastDefaultTrue() {
+        AssertFalseConfig config = new AssertFalseConfig();
+        config.production = true;
+        config.debug = true;
+
+        ValidationResult result = validator.validate(config);
+        assertTrue(result.getFailFastErrors().stream().anyMatch(error -> "debug".equals(error.getFieldName())));
+        assertThrows(ValidationException.class, () -> validator.validateOrThrow(config));
+    }
+
+    @Test
+    void testInheritedAssertTrueViolation() {
+        InheritedAssertTrueConfig config = new InheritedAssertTrueConfig();
+        config.baseEnabled = false;
+        config.childName = "child";
+
+        ValidationResult result = validator.validate(config);
+
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "baseEnabled".equals(error.getFieldName())
+                        && "baseEnabled".equals(error.getPath().asString())
+        ));
+    }
+
+    @Test
+    void testAssertTrueInvalidSignatureFailsLoud() {
+        AssertTrueInvalidSignatureConfig config = new AssertTrueInvalidSignatureConfig();
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "hasParam".equals(error.getFieldName())
+                        && error.getMessage().contains("take no parameters")
+        ));
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "badReturn".equals(error.getFieldName())
+                        && error.getMessage().contains("boolean")
+        ));
+    }
+
+    @Test
+    void testAssertTrueInvocationExceptionFailsLoud() {
+        AssertTrueThrowsConfig config = new AssertTrueThrowsConfig();
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error ->
+                "boom".equals(error.getFieldName())
+                        && error.getMessage().contains("kaboom")
+        ));
+    }
+
+    @Test
+    void testAssertMethodCoexistsWithFieldConstraints() {
+        CoexistFieldAndMethodConfig config = new CoexistFieldAndMethodConfig();
+        config.name = null; // field violation
+        config.min = 10;
+        config.max = 1; // method violation
+
+        ValidationResult result = validator.validate(config);
+        assertFalse(result.isValid());
+        assertTrue(result.errors().stream().anyMatch(error -> "name".equals(error.getFieldName())));
+        assertTrue(result.errors().stream().anyMatch(error -> "max".equals(error.getFieldName())));
     }
 }


### PR DESCRIPTION
## Summary

- Adds method-level `@AssertTrue` / `@AssertFalse` validation annotations for cross-field rules (Spring/Jakarta style).
- Annotated no-arg boolean methods are invoked during validation; pass/fail follows the return value.
- Supports `message`, optional `path` (error attribution), and `failFast` (default true).
- Wired into `DefaultValidator` with hierarchy-aware method discovery; null `Boolean` returns are valid; bad signatures and thrown exceptions fail loud.

## Test plan

- [x] `./mvnw -pl core -am test "-Dtest=ValidatorTest" "-Dsurefire.failIfNoSpecifiedTests=false"` (JDK 21)
- [x] Cover pass/fail, path default + nested, failFast, inheritance, invalid signatures, invocation exceptions, coexistence with field constraints
